### PR TITLE
add loading by adventurer

### DIFF
--- a/ui/src/app/components/Actions.tsx
+++ b/ui/src/app/components/Actions.tsx
@@ -60,7 +60,8 @@ export default function Actions() {
                 "Explore",
                 tx.transaction_hash,
                 "Exploring",
-                "discoveryByTxHashQuery"
+                "discoveryByTxHashQuery",
+                adventurer?.id
               );
               addTransaction({
                 hash: tx.transaction_hash,

--- a/ui/src/app/components/Beast.tsx
+++ b/ui/src/app/components/Beast.tsx
@@ -70,6 +70,7 @@ export default function Beast() {
               tx.transaction_hash,
               "Attacking",
               "battlesByTxHashQuery",
+              adventurer?.id,
               { beastName: beastData.beast }
             );
             addTransaction({
@@ -95,6 +96,7 @@ export default function Beast() {
               tx.transaction_hash,
               "Fleeing",
               "battlesByTxHashQuery",
+              adventurer?.id,
               { beastName: beastData.beast }
             );
             addTransaction({

--- a/ui/src/app/components/CreateAdventurer.tsx
+++ b/ui/src/app/components/CreateAdventurer.tsx
@@ -108,6 +108,7 @@ export const CreateAdventurer = ({
           tx.transaction_hash,
           "Spawning Adventurer",
           "adventurersByOwnerQuery",
+          undefined,
           `You have spawned ${formData.name}!`
         );
         addTransaction({

--- a/ui/src/app/components/TransactionCart.tsx
+++ b/ui/src/app/components/TransactionCart.tsx
@@ -5,8 +5,10 @@ import { Metadata } from "../types";
 import { Button } from "./Button";
 import { MdClose } from "react-icons/md";
 import useLoadingStore from "../hooks/useLoadingStore";
+import useAdventurerStore from "../hooks/useAdventurerStore";
 
 const TransactionCart: React.FC = () => {
+  const adventurer = useAdventurerStore((state) => state.adventurer);
   const calls = useTransactionCartStore((state) => state.calls);
   const removeFromCalls = useTransactionCartStore(
     (state) => state.removeFromCalls
@@ -77,6 +79,7 @@ const TransactionCart: React.FC = () => {
                       tx?.transaction_hash,
                       "Multicalling",
                       "",
+                      adventurer?.id,
                       `Multicall complete!`
                     );
                     const marketIds = [];

--- a/ui/src/app/components/TxActivity.tsx
+++ b/ui/src/app/components/TxActivity.tsx
@@ -5,6 +5,7 @@ import { displayAddress, padAddress } from "../lib/utils";
 import { useQueriesStore } from "../hooks/useQueryStore";
 import useLoadingStore from "../hooks/useLoadingStore";
 import LootIconLoader from "./Loader";
+import useAdventurerStore from "../hooks/useAdventurerStore";
 
 export interface TxActivityProps {
   hash: string | undefined;
@@ -18,6 +19,8 @@ export const TxActivity = () => {
   const hash = useLoadingStore((state) => state.hash);
   const pendingMessage = useLoadingStore((state) => state.pendingMessage);
   const type = useLoadingStore((state) => state.type);
+  const loadingAdventurer = useLoadingStore((state) => state.adventurer);
+  const adventurer = useAdventurerStore((state) => state.adventurer);
   const {
     data: queryData,
     isDataUpdated,
@@ -50,7 +53,6 @@ export const TxActivity = () => {
 
       // Handle "Explore" type
       else if (type === "Explore") {
-        console.log("here");
         stopLoading(queryData.discoveryByTxHashQuery.discoveries[0]);
         setAccepted(false);
         resetDataUpdated(loadingQuery);
@@ -68,7 +70,7 @@ export const TxActivity = () => {
   return (
     <>
       {type != "Multicall" ? (
-        loading && hash ? (
+        loading && hash && loadingAdventurer === adventurer?.id ? (
           <div className="flex flex-row items-center gap-5">
             {data?.status == "RECEIVED" || data?.status == "PENDING" ? (
               <div className="flex w-48 loading-ellipsis ">

--- a/ui/src/app/components/Upgrade.tsx
+++ b/ui/src/app/components/Upgrade.tsx
@@ -89,6 +89,7 @@ const Upgrade = () => {
           tx?.transaction_hash,
           `Upgrading ${selected}`,
           "adventurerByIdQuery",
+          adventurer?.id,
           `You upgraded ${selected}!`
         );
         addTransaction({

--- a/ui/src/app/hooks/useLoadingStore.ts
+++ b/ui/src/app/hooks/useLoadingStore.ts
@@ -11,11 +11,13 @@ type LoadingState = {
   loadingQuery: QueryKey | null;
   showNotification: boolean;
   notificationData: any;
+  adventurer: number | undefined;
   startLoading: (
     type: string,
     hash: string,
     pendingMessage: string,
     data: any,
+    adventurer: number | undefined,
     notificationData?: any
   ) => void;
   stopLoading: (notificationData?: any) => void;
@@ -29,11 +31,13 @@ const useLoadingStore = create<LoadingState>((set, get) => ({
   loadingQuery: null,
   showNotification: false,
   notificationData: undefined,
+  adventurer: undefined,
   startLoading: (
     type,
     hash,
     pendingMessage,
     loadingQuery,
+    adventurer,
     notificationData
   ) => {
     set({
@@ -42,6 +46,7 @@ const useLoadingStore = create<LoadingState>((set, get) => ({
       hash,
       pendingMessage,
       loadingQuery,
+      adventurer,
       notificationData,
     });
   },
@@ -56,7 +61,12 @@ const useLoadingStore = create<LoadingState>((set, get) => ({
     });
     setTimeout(
       () =>
-        set({ type: "", notificationData: undefined, showNotification: false }),
+        set({
+          type: "",
+          notificationData: undefined,
+          showNotification: false,
+          adventurer: undefined,
+        }),
       5000
     );
   },

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -119,6 +119,8 @@ export default function Home() {
       : data.lastBattleQuery?.battles[0]?.beastId,
   });
 
+  console.log(data);
+
   const updatedAdventurer = data.adventurerByIdQuery
     ? data.adventurerByIdQuery.adventurers[0]
     : NullAdventurer;
@@ -129,11 +131,14 @@ export default function Home() {
 
   const hasBeast = !!adventurer?.beastId;
 
-  const playState = useMemo(() => ({
-    isInBattle: hasBeast,
-    isDead: false, // set this to true when player is dead
-    isMuted: isMuted,
-  }), [hasBeast, isMuted]);
+  const playState = useMemo(
+    () => ({
+      isInBattle: hasBeast,
+      isDead: false, // set this to true when player is dead
+      isMuted: isMuted,
+    }),
+    [hasBeast, isMuted]
+  );
 
   const { play, stop } = useMusic(playState, {
     volume: 0.5,
@@ -151,7 +156,6 @@ export default function Home() {
 
   const [selected, setSelected] = useState(menu[0].value);
 
-
   useEffect(() => {
     if (!adventurer || adventurer?.health == 0) {
       setSelected(menu[0].value);
@@ -164,10 +168,12 @@ export default function Home() {
     }
   }, [account]);
 
-  console.log(account)
+  console.log(account);
 
-  const goerli_graphql = "https://survivor-indexer.bibliothecadao.xyz:8080/goerli-graphql";
-  const devnet_graphql = "https://survivor-indexer.bibliothecadao.xyz:8080/devnet-graphql";
+  const goerli_graphql =
+    "https://survivor-indexer.bibliothecadao.xyz:8080/goerli-graphql";
+  const devnet_graphql =
+    "https://survivor-indexer.bibliothecadao.xyz:8080/devnet-graphql";
 
   useEffect(() => {
     setIndexer(


### PR DESCRIPTION
This resolves the issue descried by #28.

We are now changing loading state based on adventurer. NOTE: If on the same account, the previous transaction will still need to finish in order for the second transaction to complete loading.