### PR TITLE
refactor: packing

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -67,7 +67,7 @@ impl StatsPacking of Packing<Stats> {
          + self.intelligence.into() * pow::TWO_POW_15
          + self.wisdom.into() * pow::TWO_POW_20
          + self.charisma.into() * pow::TWO_POW_25
-        ).try_into().unwrap()
+        ).try_into().expect('pack Stats')
     }
 
     fn unpack(packed: felt252) -> Stats {
@@ -80,12 +80,12 @@ impl StatsPacking of Packing<Stats> {
         let (_, charisma) = rshift_split(packed, pow::TWO_POW_5);
 
         Stats {
-            strength: strength.try_into().unwrap(),
-            dexterity: dexterity.try_into().unwrap(),
-            vitality: vitality.try_into().unwrap(),
-            intelligence: intelligence.try_into().unwrap(),
-            wisdom: wisdom.try_into().unwrap(),
-            charisma: charisma.try_into().unwrap()
+            strength: strength.try_into().expect('unpack Stats strength'),
+            dexterity: dexterity.try_into().expect('unpack Stats dexterity'),
+            vitality: vitality.try_into().expect('unpack Stats vitality'),
+            intelligence: intelligence.try_into().expect('unpack Stats intelligence'),
+            wisdom: wisdom.try_into().expect('unpack Stats wisdom'),
+            charisma: charisma.try_into().expect('unpack Stats charisma')
         }
     }
 }
@@ -107,7 +107,7 @@ impl AdventurerPacking of Packing<Adventurer> {
          + self.ring.pack().into() * pow::TWO_POW_217
          + self.beast_health.into() * pow::TWO_POW_238
          + self.stat_upgrade_available.into() * pow::TWO_POW_247
-        ).try_into().unwrap()
+        ).try_into().expect('pack Adventurer')
     }
 
     fn unpack(packed: felt252) -> Adventurer {
@@ -129,21 +129,21 @@ impl AdventurerPacking of Packing<Adventurer> {
         let (_, stat_upgrade_available) = rshift_split(packed, pow::TWO_POW_3);
 
         Adventurer {
-            last_action: last_action.try_into().unwrap(),
-            health: health.try_into().unwrap(),
-            xp: xp.try_into().unwrap(),
-            stats: Packing::unpack(stats.try_into().unwrap()),
-            gold: gold.try_into().unwrap(),
-            weapon: Packing::unpack(weapon.try_into().unwrap()),
-            chest: Packing::unpack(chest.try_into().unwrap()),
-            head: Packing::unpack(head.try_into().unwrap()),
-            waist: Packing::unpack(waist.try_into().unwrap()),
-            foot: Packing::unpack(foot.try_into().unwrap()),
-            hand: Packing::unpack(hand.try_into().unwrap()),
-            neck: Packing::unpack(neck.try_into().unwrap()),
-            ring: Packing::unpack(ring.try_into().unwrap()),
-            beast_health: beast_health.try_into().unwrap(),
-            stat_upgrade_available: stat_upgrade_available.try_into().unwrap()
+            last_action: last_action.try_into().expect('unpack Adventurer last_action'),
+            health: health.try_into().expect('unpack Adventurer health'),
+            xp: xp.try_into().expect('unpack Adventurer xp'),
+            stats: Packing::unpack(stats.try_into().expect('unpack Adventurer stats')),
+            gold: gold.try_into().expect('unpack Adventurer gold'),
+            weapon: Packing::unpack(weapon.try_into().expect('unpack Adventurer weapon')),
+            chest: Packing::unpack(chest.try_into().expect('unpack Adventurer chest')),
+            head: Packing::unpack(head.try_into().expect('unpack Adventurer head')),
+            waist: Packing::unpack(waist.try_into().expect('unpack Adventurer waist')),
+            foot: Packing::unpack(foot.try_into().expect('unpack Adventurer foot')),
+            hand: Packing::unpack(hand.try_into().expect('unpack Adventurer hand')),
+            neck: Packing::unpack(neck.try_into().expect('unpack Adventurer neck')),
+            ring: Packing::unpack(ring.try_into().expect('unpack Adventurer ring')),
+            beast_health: beast_health.try_into().expect('unpack Adventurer beast_health'),
+            stat_upgrade_available: stat_upgrade_available.try_into().expect('unpack Adventurer stat_upgrade')
         }
     }
 }

--- a/contracts/adventurer/src/adventurer_meta.cairo
+++ b/contracts/adventurer/src/adventurer_meta.cairo
@@ -20,7 +20,7 @@ impl PackingAdventurerMetadata of Packing<AdventurerMetadata> {
          + self.race.into() * pow::TWO_POW_40
          + self.order.into() * pow::TWO_POW_48
          + self.entropy.into() * pow::TWO_POW_56
-        ).try_into().unwrap()
+        ).try_into().expect('pack AdventurerMetadata')
     }
     fn unpack(packed: felt252) -> AdventurerMetadata {
         let packed = packed.into();
@@ -31,11 +31,11 @@ impl PackingAdventurerMetadata of Packing<AdventurerMetadata> {
         let (_, entropy) = rshift_split(packed, pow::TWO_POW_64);
 
         AdventurerMetadata {
-            name: name.try_into().unwrap(),
-            home_realm: home_realm.try_into().unwrap(),
-            race: race.try_into().unwrap(),
-            order: order.try_into().unwrap(),
-            entropy: entropy.try_into().unwrap()
+            name: name.try_into().expect('unpack AdvMetadata name'),
+            home_realm: home_realm.try_into().expect('unpack AdvMetadata home_realm'),
+            race: race.try_into().expect('unpack AdvMetadata race'),
+            order: order.try_into().expect('unpack AdvMetadata order'),
+            entropy: entropy.try_into().expect('unpack AdvMetadata entropy')
         }
     }
 }

--- a/contracts/adventurer/src/adventurer_meta.cairo
+++ b/contracts/adventurer/src/adventurer_meta.cairo
@@ -26,32 +26,29 @@ trait IAdventurerMetadata {
 
 impl ImplAdventurerMetadata of IAdventurerMetadata {
     fn pack(self: AdventurerMetadata) -> felt252 {
-        let mut packed = 0;
-        packed = packed | pack_value(self.name.into(), pow::TWO_POW_219);
-        packed = packed | pack_value(self.home_realm.into(), pow::TWO_POW_212);
-        packed = packed | pack_value(self.race.into(), pow::TWO_POW_204);
-        packed = packed | pack_value(self.order.into(), pow::TWO_POW_196);
-
-        packed = packed | pack_value(self.entropy.into(), pow::TWO_POW_132);
-
-        packed.try_into().unwrap()
+        (pack_value(self.name.into(), pow::TWO_POW_218) +
+         pack_value(self.home_realm.into(), pow::TWO_POW_210) +
+         pack_value(self.race.into(), pow::TWO_POW_202) +
+         pack_value(self.order.into(), pow::TWO_POW_194) +
+         pack_value(self.entropy.into(), pow::TWO_POW_130)).try_into().unwrap()
     }
     fn unpack(packed: felt252) -> AdventurerMetadata {
         let packed = packed.into();
         AdventurerMetadata {
-            name: U256TryIntoU32::try_into(unpack_value(packed, pow::TWO_POW_219, mask::MASK_32))
+            name: U256TryIntoU32::try_into(unpack_value(packed, pow::TWO_POW_218, mask::MASK_32))
                 .unwrap(),
             home_realm: U256TryIntoU8::try_into(
-                unpack_value(packed, pow::TWO_POW_212, mask::MASK_8)
+                unpack_value(packed, pow::TWO_POW_210, mask::MASK_8)
             )
                 .unwrap(),
-            race: U256TryIntoU8::try_into(unpack_value(packed, pow::TWO_POW_204, mask::MASK_8))
+            race: U256TryIntoU8::try_into(unpack_value(packed, pow::TWO_POW_202, mask::MASK_8))
                 .unwrap(),
-            order: U256TryIntoU8::try_into(unpack_value(packed, pow::TWO_POW_196, mask::MASK_8))
+            order: U256TryIntoU8::try_into(unpack_value(packed, pow::TWO_POW_194, mask::MASK_8))
                 .unwrap(),
-            entropy: U256TryIntoU64::try_into(unpack_value(packed, pow::TWO_POW_132, mask::MASK_64))
+            entropy: U256TryIntoU64::try_into(unpack_value(packed, pow::TWO_POW_130, mask::MASK_64))
                 .unwrap()
         }
+
     }
 }
 
@@ -59,7 +56,7 @@ impl ImplAdventurerMetadata of IAdventurerMetadata {
 #[available_gas(50000000)]
 fn test_meta() {
     let mut meta = AdventurerMetadata {
-        name: 4294967295, home_realm: 255, race: 255, order: 15, entropy: 4294967295
+        name: 4294962295, home_realm: 45, race: 28, order: 6, entropy: 4294937295
     };
 
     let packed = meta.pack();
@@ -70,4 +67,3 @@ fn test_meta() {
     assert(@meta.order == @unpacked.order, 'order');
     assert(@meta.entropy == @unpacked.entropy, 'entropy');
 }
-

--- a/contracts/adventurer/src/bag.cairo
+++ b/contracts/adventurer/src/bag.cairo
@@ -27,7 +27,6 @@ struct Bag {
     item_9: LootStatistics, // club
     item_10: LootStatistics, // club
     item_11: LootStatistics, // club
-    item_12: LootStatistics, // club
 }
 
 trait BagActions {
@@ -88,7 +87,6 @@ impl BagPacking of Packing<Bag> {
          + self.item_9.pack().into() * pow::TWO_POW_168
          + self.item_10.pack().into() * pow::TWO_POW_189
          + self.item_11.pack().into() * pow::TWO_POW_210
-         + self.item_12.pack().into() * pow::TWO_POW_231
         ).try_into().expect('pack Bag')
     }
 
@@ -104,8 +102,7 @@ impl BagPacking of Packing<Bag> {
         let (packed, item_8) = rshift_split(packed, pow::TWO_POW_21);
         let (packed, item_9) = rshift_split(packed, pow::TWO_POW_21);
         let (packed, item_10) = rshift_split(packed, pow::TWO_POW_21);
-        let (packed, item_11) = rshift_split(packed, pow::TWO_POW_21);
-        let (_, item_12) = rshift_split(packed, pow::TWO_POW_21);
+        let (_, item_11) = rshift_split(packed, pow::TWO_POW_21);
 
         Bag {
             item_1: Packing::unpack(item_1.try_into().expect('unpack Bag item_1')),
@@ -119,7 +116,6 @@ impl BagPacking of Packing<Bag> {
             item_9: Packing::unpack(item_9.try_into().expect('unpack Bag item_9')),
             item_10: Packing::unpack(item_10.try_into().expect('unpack Bag item_10')),
             item_11: Packing::unpack(item_11.try_into().expect('unpack Bag item_11')),
-            item_12: Packing::unpack(item_12.try_into().expect('unpack Bag item_12'))
         }
     }
 }
@@ -162,9 +158,6 @@ impl ImplBagActions of BagActions {
         } else if slot == 10 {
             self.item_11 = item;
             return self;
-        } else if slot == 11 {
-            self.item_12 = item;
-            return self;
         } else {
             return self;
         }
@@ -190,14 +183,12 @@ impl ImplBagActions of BagActions {
             return 8;
         } else if self.item_10.id == 0 {
             return 9;
-        } else if self.item_11.id == 0 {
-            return 10;
         } else {
-            return 11;
+            return 10;
         }
     }
     fn is_full(self: Bag) -> bool {
-        if self.item_12.id == 0 {
+        if self.item_11.id == 0 {
             return false;
         } else {
             return true;
@@ -224,10 +215,8 @@ impl ImplBagActions of BagActions {
             return self.item_9;
         } else if self.item_10.id == item_id {
             return self.item_10;
-        } else if self.item_11.id == item_id {
-            return self.item_11;
         } else {
-            return self.item_12;
+            return self.item_11;
         }
     }
     fn remove_item(ref self: Bag, item_id: u8) -> Bag {
@@ -262,11 +251,8 @@ impl ImplBagActions of BagActions {
         } else if self.item_10.id == item_id {
             self.item_10 = LootStatistics { id: 0, xp: 0, metadata: 0 };
             return self;
-        } else if self.item_11.id == item_id {
-            self.item_11 = LootStatistics { id: 0, xp: 0, metadata: 0 };
-            return self;
         } else {
-            self.item_12 = LootStatistics { id: 0, xp: 0, metadata: 0 };
+            self.item_11 = LootStatistics { id: 0, xp: 0, metadata: 0 };
             return self;
         }
     }
@@ -274,6 +260,7 @@ impl ImplBagActions of BagActions {
         LootStatistics { id: item_id, xp: 0, metadata: 0 }
     }
 }
+
 #[test]
 #[available_gas(5000000)]
 fn test_pack_bag() {
@@ -300,9 +287,7 @@ fn test_pack_bag() {
             id: 127, xp: 511, metadata: 31
             }, item_11: LootStatistics {
             id: 127, xp: 511, metadata: 31
-            }, item_12: LootStatistics {
-            id: 127, xp: 511, metadata: 31
-        },
+            }
     };
 
     let packed_bag: Bag = Packing::unpack(bag.pack());
@@ -350,10 +335,6 @@ fn test_pack_bag() {
     assert(packed_bag.item_11.id == 127, 'Loot 11 ID is not 127');
     assert(packed_bag.item_11.xp == 511, 'Loot 11 XP is not 511');
     assert(packed_bag.item_11.metadata == 31, ' 11 metadata is not 31');
-
-    assert(packed_bag.item_12.id == 127, 'Loot 12 ID is not 127');
-    assert(packed_bag.item_12.xp == 511, 'Loot 12 XP is not 511');
-    assert(packed_bag.item_12.metadata == 31, ' 12 metadata is not 31');
 }
 
 #[test]
@@ -382,9 +363,7 @@ fn test_add_item() {
             id: 0, xp: 0, metadata: 0
             }, item_11: LootStatistics {
             id: 0, xp: 0, metadata: 0
-            }, item_12: LootStatistics {
-            id: 0, xp: 0, metadata: 0
-        },
+            },
     };
 
     let item = LootStatistics { id: 23, xp: 1, metadata: 5 };
@@ -420,9 +399,7 @@ fn test_is_full() {
             id: 13, xp: 0, metadata: 0
             }, item_11: LootStatistics {
             id: 14, xp: 0, metadata: 0
-            }, item_12: LootStatistics {
-            id: 15, xp: 0, metadata: 0
-        },
+            },
     };
 
     assert(bag.is_full() == true, 'Bag should be full');
@@ -453,9 +430,7 @@ fn remove_item() {
             id: 13, xp: 0, metadata: 0
             }, item_11: LootStatistics {
             id: 14, xp: 0, metadata: 0
-            }, item_12: LootStatistics {
-            id: 15, xp: 0, metadata: 0
-        },
+            },
     };
 
     bag.remove_item(8);

--- a/contracts/adventurer/src/bag.cairo
+++ b/contracts/adventurer/src/bag.cairo
@@ -58,7 +58,7 @@ impl LootStatisticsPacking of Packing<LootStatistics> {
         (self.id.into()
          + self.xp.into() * pow::TWO_POW_7
          + self.metadata.into() * pow::TWO_POW_16
-        ).try_into().unwrap()
+        ).try_into().expect('pack LootStatistics')
     }
 
     fn unpack(packed: felt252) -> LootStatistics {
@@ -68,9 +68,9 @@ impl LootStatisticsPacking of Packing<LootStatistics> {
         let (_, metadata) = rshift_split(packed, pow::TWO_POW_5);
 
         LootStatistics {
-            id: id.try_into().unwrap(),
-            xp: xp.try_into().unwrap(),
-            metadata: metadata.try_into().unwrap()
+            id: id.try_into().expect('unpack LootStatistics id'),
+            xp: xp.try_into().expect('unpack LootStatistics xp'),
+            metadata: metadata.try_into().expect('unpack LootStatistics metadata')
         }
     }
 }
@@ -89,7 +89,7 @@ impl BagPacking of Packing<Bag> {
          + self.item_10.pack().into() * pow::TWO_POW_189
          + self.item_11.pack().into() * pow::TWO_POW_210
          + self.item_12.pack().into() * pow::TWO_POW_231
-        ).try_into().unwrap()
+        ).try_into().expect('pack Bag')
     }
 
     fn unpack(packed: felt252) -> Bag {
@@ -108,18 +108,18 @@ impl BagPacking of Packing<Bag> {
         let (_, item_12) = rshift_split(packed, pow::TWO_POW_21);
 
         Bag {
-            item_1: Packing::unpack(item_1.try_into().unwrap()),
-            item_2: Packing::unpack(item_2.try_into().unwrap()),
-            item_3: Packing::unpack(item_3.try_into().unwrap()),
-            item_4: Packing::unpack(item_4.try_into().unwrap()),
-            item_5: Packing::unpack(item_5.try_into().unwrap()),
-            item_6: Packing::unpack(item_6.try_into().unwrap()),
-            item_7: Packing::unpack(item_7.try_into().unwrap()),
-            item_8: Packing::unpack(item_8.try_into().unwrap()),
-            item_9: Packing::unpack(item_9.try_into().unwrap()),
-            item_10: Packing::unpack(item_10.try_into().unwrap()),
-            item_11: Packing::unpack(item_11.try_into().unwrap()),
-            item_12: Packing::unpack(item_12.try_into().unwrap())
+            item_1: Packing::unpack(item_1.try_into().expect('unpack Bag item_1')),
+            item_2: Packing::unpack(item_2.try_into().expect('unpack Bag item_2')),
+            item_3: Packing::unpack(item_3.try_into().expect('unpack Bag item_3')),
+            item_4: Packing::unpack(item_4.try_into().expect('unpack Bag item_4')),
+            item_5: Packing::unpack(item_5.try_into().expect('unpack Bag item_5')),
+            item_6: Packing::unpack(item_6.try_into().expect('unpack Bag item_6')),
+            item_7: Packing::unpack(item_7.try_into().expect('unpack Bag item_7')),
+            item_8: Packing::unpack(item_8.try_into().expect('unpack Bag item_8')),
+            item_9: Packing::unpack(item_9.try_into().expect('unpack Bag item_9')),
+            item_10: Packing::unpack(item_10.try_into().expect('unpack Bag item_10')),
+            item_11: Packing::unpack(item_11.try_into().expect('unpack Bag item_11')),
+            item_12: Packing::unpack(item_12.try_into().expect('unpack Bag item_12'))
         }
     }
 }

--- a/contracts/adventurer/src/item_meta.cairo
+++ b/contracts/adventurer/src/item_meta.cairo
@@ -50,7 +50,7 @@ impl LootItemSpecialNamesPacking of Packing<LootItemSpecialNames> {
         (self.name_prefix.into()
          + self.name_suffix.into() * pow::TWO_POW_7
          + self.item_suffix.into() * pow::TWO_POW_12
-        ).try_into().unwrap()
+        ).try_into().expect('pack LootItemSpecialNames')
     }
 
     fn unpack(packed: felt252) -> LootItemSpecialNames {
@@ -60,9 +60,9 @@ impl LootItemSpecialNamesPacking of Packing<LootItemSpecialNames> {
         let (_, item_suffix) = rshift_split(packed, pow::TWO_POW_4);
 
         LootItemSpecialNames {
-            name_prefix: name_prefix.try_into().unwrap(),
-            name_suffix: name_suffix.try_into().unwrap(),
-            item_suffix: item_suffix.try_into().unwrap()
+            name_prefix: name_prefix.try_into().expect('unpack LISN name_prefix'),
+            name_suffix: name_suffix.try_into().expect('unpack LISN name_suffix'),
+            item_suffix: item_suffix.try_into().expect('unpack LISN item_suffix')
         }
     }
 }
@@ -79,7 +79,7 @@ impl LootItemSpecialNamesStoragePacking of Packing<LootItemSpecialNamesStorage> 
          + self.item_8.pack().into() * pow::TWO_POW_112
          + self.item_9.pack().into() * pow::TWO_POW_128
          + self.item_10.pack().into() * pow::TWO_POW_144
-        ).try_into().unwrap()
+        ).try_into().expect('pack LISNS')
     }
 
     fn unpack(packed: felt252) -> LootItemSpecialNamesStorage {
@@ -96,16 +96,16 @@ impl LootItemSpecialNamesStoragePacking of Packing<LootItemSpecialNamesStorage> 
         let (_, item_10) = rshift_split(packed, pow::TWO_POW_16);
 
         LootItemSpecialNamesStorage {
-            item_1: Packing::unpack(item_1.try_into().unwrap()),
-            item_2: Packing::unpack(item_2.try_into().unwrap()),
-            item_3: Packing::unpack(item_3.try_into().unwrap()),
-            item_4: Packing::unpack(item_4.try_into().unwrap()),
-            item_5: Packing::unpack(item_5.try_into().unwrap()),
-            item_6: Packing::unpack(item_6.try_into().unwrap()),
-            item_7: Packing::unpack(item_7.try_into().unwrap()),
-            item_8: Packing::unpack(item_8.try_into().unwrap()),
-            item_9: Packing::unpack(item_9.try_into().unwrap()),
-            item_10: Packing::unpack(item_10.try_into().unwrap())
+            item_1: Packing::unpack(item_1.try_into().expect('unpack LISNS item_1')),
+            item_2: Packing::unpack(item_2.try_into().expect('unpack LISNS item_2')),
+            item_3: Packing::unpack(item_3.try_into().expect('unpack LISNS item_3')),
+            item_4: Packing::unpack(item_4.try_into().expect('unpack LISNS item_4')),
+            item_5: Packing::unpack(item_5.try_into().expect('unpack LISNS item_5')),
+            item_6: Packing::unpack(item_6.try_into().expect('unpack LISNS item_6')),
+            item_7: Packing::unpack(item_7.try_into().expect('unpack LISNS item_7')),
+            item_8: Packing::unpack(item_8.try_into().expect('unpack LISNS item_8')),
+            item_9: Packing::unpack(item_9.try_into().expect('unpack LISNS item_9')),
+            item_10: Packing::unpack(item_10.try_into().expect('unpack LISNS item_10'))
         }
     }
 }

--- a/contracts/adventurer/src/item_meta.cairo
+++ b/contracts/adventurer/src/item_meta.cairo
@@ -229,9 +229,6 @@ impl ImplLootItemSpecialNames of ILootItemSpecialNames {
         if bag.item_11.metadata >= slot {
             slot = bag.item_11.metadata;
         }
-        if bag.item_12.metadata >= slot {
-            slot = bag.item_12.metadata;
-        }
 
         // if no slots -> return first index which is 0
         if slot == 1 {
@@ -389,9 +386,7 @@ fn test_get_item_metadata_slot() {
             id: 10, xp: 0, metadata: 0,
             }, item_11: LootStatistics {
             id: 11, xp: 0, metadata: 18,
-            }, item_12: LootStatistics {
-            id: 12, xp: 0, metadata: 0,
-        },
+            },
     };
 
     let new_item = LootStatistics { id: 1, xp: 1, metadata: 0 };

--- a/contracts/adventurer/src/item_meta.cairo
+++ b/contracts/adventurer/src/item_meta.cairo
@@ -4,8 +4,8 @@ use option::OptionTrait;
 use integer::{
     U256TryIntoU32, U256TryIntoU16, U256TryIntoU8
 };
-use pack::pack::{pack_value, unpack_value};
-use pack::constants::{pow, mask};
+use pack::pack::{Packing, rshift_split};
+use pack::constants::pow;
 
 use super::adventurer::{Adventurer, IAdventurer, ImplAdventurer};
 use super::bag::{Bag, BagActions, LootStatistics};
@@ -45,14 +45,76 @@ struct LootItemSpecialNamesStorage {
     item_10: LootItemSpecialNames,
 }
 
+impl LootItemSpecialNamesPacking of Packing<LootItemSpecialNames> {
+    fn pack(self: LootItemSpecialNames) -> felt252 {
+        (self.name_prefix.into()
+         + self.name_suffix.into() * pow::TWO_POW_7
+         + self.item_suffix.into() * pow::TWO_POW_12
+        ).try_into().unwrap()
+    }
+
+    fn unpack(packed: felt252) -> LootItemSpecialNames {
+        let packed = packed.into();
+        let (packed, name_prefix) = rshift_split(packed, pow::TWO_POW_7);
+        let (packed, name_suffix) = rshift_split(packed, pow::TWO_POW_5);
+        let (_, item_suffix) = rshift_split(packed, pow::TWO_POW_4);
+
+        LootItemSpecialNames {
+            name_prefix: name_prefix.try_into().unwrap(),
+            name_suffix: name_suffix.try_into().unwrap(),
+            item_suffix: item_suffix.try_into().unwrap()
+        }
+    }
+}
+
+impl LootItemSpecialNamesStoragePacking of Packing<LootItemSpecialNamesStorage> {
+    fn pack(self: LootItemSpecialNamesStorage) -> felt252 {
+        (self.item_1.pack().into()
+         + self.item_2.pack().into() * pow::TWO_POW_16
+         + self.item_3.pack().into() * pow::TWO_POW_32
+         + self.item_4.pack().into() * pow::TWO_POW_48
+         + self.item_5.pack().into() * pow::TWO_POW_64
+         + self.item_6.pack().into() * pow::TWO_POW_80
+         + self.item_7.pack().into() * pow::TWO_POW_96
+         + self.item_8.pack().into() * pow::TWO_POW_112
+         + self.item_9.pack().into() * pow::TWO_POW_128
+         + self.item_10.pack().into() * pow::TWO_POW_144
+        ).try_into().unwrap()
+    }
+
+    fn unpack(packed: felt252) -> LootItemSpecialNamesStorage {
+        let packed = packed.into();
+        let (packed, item_1) = rshift_split(packed, pow::TWO_POW_16);
+        let (packed, item_2) = rshift_split(packed, pow::TWO_POW_16);
+        let (packed, item_3) = rshift_split(packed, pow::TWO_POW_16);
+        let (packed, item_4) = rshift_split(packed, pow::TWO_POW_16);
+        let (packed, item_5) = rshift_split(packed, pow::TWO_POW_16);
+        let (packed, item_6) = rshift_split(packed, pow::TWO_POW_16);
+        let (packed, item_7) = rshift_split(packed, pow::TWO_POW_16);
+        let (packed, item_8) = rshift_split(packed, pow::TWO_POW_16);
+        let (packed, item_9) = rshift_split(packed, pow::TWO_POW_16);
+        let (_, item_10) = rshift_split(packed, pow::TWO_POW_16);
+
+        LootItemSpecialNamesStorage {
+            item_1: Packing::unpack(item_1.try_into().unwrap()),
+            item_2: Packing::unpack(item_2.try_into().unwrap()),
+            item_3: Packing::unpack(item_3.try_into().unwrap()),
+            item_4: Packing::unpack(item_4.try_into().unwrap()),
+            item_5: Packing::unpack(item_5.try_into().unwrap()),
+            item_6: Packing::unpack(item_6.try_into().unwrap()),
+            item_7: Packing::unpack(item_7.try_into().unwrap()),
+            item_8: Packing::unpack(item_8.try_into().unwrap()),
+            item_9: Packing::unpack(item_9.try_into().unwrap()),
+            item_10: Packing::unpack(item_10.try_into().unwrap())
+        }
+    }
+}
+
 // LootStatistics meta only is set once and is filled up as items are found
 // There is no swapping of positions
 // When an item is found we find the next available slot and set it on the LootStatistics NOT in the metadata -> this saves gas
 // We only set the metadata when an item is upgraded
 trait ILootItemSpecialNames {
-    fn pack(self: LootItemSpecialNamesStorage) -> felt252;
-    fn unpack(packed: felt252) -> LootItemSpecialNamesStorage;
-
     // takes LootStatistics and sets the metadata slot for that item
     // 1. Find highest slot from equipped and unequipped items
     // 2. Return LootStatistics with slot which is then saved on the Adventurer/Bag
@@ -102,189 +164,6 @@ impl ImplLootItemSpecialNames of ILootItemSpecialNames {
         }
     }
 
-    fn pack(self: LootItemSpecialNamesStorage) -> felt252 {
-        let mut packed = 0;
-        packed = packed | pack_value(self.item_1.name_prefix.into(), pow::TWO_POW_244);
-        packed = packed | pack_value(self.item_1.name_suffix.into(), pow::TWO_POW_240);
-        packed = packed | pack_value(self.item_1.item_suffix.into(), pow::TWO_POW_236);
-
-        packed = packed | pack_value(self.item_2.name_prefix.into(), pow::TWO_POW_229);
-        packed = packed | pack_value(self.item_2.name_suffix.into(), pow::TWO_POW_224);
-        packed = packed | pack_value(self.item_2.item_suffix.into(), pow::TWO_POW_220);
-
-        packed = packed | pack_value(self.item_3.name_prefix.into(), pow::TWO_POW_213);
-        packed = packed | pack_value(self.item_3.name_suffix.into(), pow::TWO_POW_208);
-        packed = packed | pack_value(self.item_3.item_suffix.into(), pow::TWO_POW_204);
-
-        packed = packed | pack_value(self.item_4.name_prefix.into(), pow::TWO_POW_197);
-        packed = packed | pack_value(self.item_4.name_suffix.into(), pow::TWO_POW_192);
-        packed = packed | pack_value(self.item_4.item_suffix.into(), pow::TWO_POW_188);
-
-        packed = packed | pack_value(self.item_5.name_prefix.into(), pow::TWO_POW_181);
-        packed = packed | pack_value(self.item_5.name_suffix.into(), pow::TWO_POW_176);
-        packed = packed | pack_value(self.item_5.item_suffix.into(), pow::TWO_POW_172);
-
-        packed = packed | pack_value(self.item_6.name_prefix.into(), pow::TWO_POW_165);
-        packed = packed | pack_value(self.item_6.name_suffix.into(), pow::TWO_POW_160);
-        packed = packed | pack_value(self.item_6.item_suffix.into(), pow::TWO_POW_156);
-
-        packed = packed | pack_value(self.item_7.name_prefix.into(), pow::TWO_POW_149);
-        packed = packed | pack_value(self.item_7.name_suffix.into(), pow::TWO_POW_144);
-        packed = packed | pack_value(self.item_7.item_suffix.into(), pow::TWO_POW_140);
-
-        packed = packed | pack_value(self.item_8.name_prefix.into(), pow::TWO_POW_133);
-        packed = packed | pack_value(self.item_8.name_suffix.into(), pow::TWO_POW_128);
-        packed = packed | pack_value(self.item_8.item_suffix.into(), pow::TWO_POW_124);
-
-        packed = packed | pack_value(self.item_9.name_prefix.into(), pow::TWO_POW_117);
-        packed = packed | pack_value(self.item_9.name_suffix.into(), pow::TWO_POW_112);
-        packed = packed | pack_value(self.item_9.item_suffix.into(), pow::TWO_POW_108);
-
-        packed = packed | pack_value(self.item_10.name_prefix.into(), pow::TWO_POW_101);
-        packed = packed | pack_value(self.item_10.name_suffix.into(), pow::TWO_POW_96);
-        packed = packed | pack_value(self.item_10.item_suffix.into(), pow::TWO_POW_92);
-
-        packed.try_into().unwrap()
-    }
-
-    fn unpack(packed: felt252) -> LootItemSpecialNamesStorage {
-        internal::revoke_ap_tracking();
-        let packed = packed.into();
-
-        LootItemSpecialNamesStorage {
-            item_1: LootItemSpecialNames {
-                name_prefix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_244, mask::MASK_7)
-                )
-                    .unwrap(),
-                name_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_240, mask::MASK_5)
-                )
-                    .unwrap(),
-                item_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_236, mask::MASK_4)
-                )
-                    .unwrap(),
-                }, item_2: LootItemSpecialNames {
-                name_prefix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_229, mask::MASK_7)
-                )
-                    .unwrap(),
-                name_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_224, mask::MASK_5)
-                )
-                    .unwrap(),
-                item_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_220, mask::MASK_4)
-                )
-                    .unwrap(),
-                }, item_3: LootItemSpecialNames {
-                name_prefix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_213, mask::MASK_7)
-                )
-                    .unwrap(),
-                name_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_208, mask::MASK_5)
-                )
-                    .unwrap(),
-                item_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_204, mask::MASK_4)
-                )
-                    .unwrap(),
-                }, item_4: LootItemSpecialNames {
-                name_prefix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_197, mask::MASK_7)
-                )
-                    .unwrap(),
-                name_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_192, mask::MASK_5)
-                )
-                    .unwrap(),
-                item_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_188, mask::MASK_4)
-                )
-                    .unwrap(),
-                }, item_5: LootItemSpecialNames {
-                name_prefix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_181, mask::MASK_7)
-                )
-                    .unwrap(),
-                name_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_176, mask::MASK_5)
-                )
-                    .unwrap(),
-                item_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_172, mask::MASK_4)
-                )
-                    .unwrap(),
-                }, item_6: LootItemSpecialNames {
-                name_prefix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_165, mask::MASK_7)
-                )
-                    .unwrap(),
-                name_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_160, mask::MASK_5)
-                )
-                    .unwrap(),
-                item_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_156, mask::MASK_4)
-                )
-                    .unwrap(),
-                }, item_7: LootItemSpecialNames {
-                name_prefix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_149, mask::MASK_7)
-                )
-                    .unwrap(),
-                name_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_144, mask::MASK_5)
-                )
-                    .unwrap(),
-                item_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_140, mask::MASK_4)
-                )
-                    .unwrap(),
-                }, item_8: LootItemSpecialNames {
-                name_prefix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_133, mask::MASK_7)
-                )
-                    .unwrap(),
-                name_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_128, mask::MASK_5)
-                )
-                    .unwrap(),
-                item_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_124, mask::MASK_4)
-                )
-                    .unwrap(),
-                }, item_9: LootItemSpecialNames {
-                name_prefix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_117, mask::MASK_7)
-                )
-                    .unwrap(),
-                name_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_112, mask::MASK_5)
-                )
-                    .unwrap(),
-                item_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_108, mask::MASK_4)
-                )
-                    .unwrap(),
-                }, item_10: LootItemSpecialNames {
-                name_prefix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_101, mask::MASK_7)
-                )
-                    .unwrap(),
-                name_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_96, mask::MASK_5)
-                )
-                    .unwrap(),
-                item_suffix: U256TryIntoU8::try_into(
-                    unpack_value(packed, pow::TWO_POW_92, mask::MASK_4)
-                )
-                    .unwrap(),
-            }
-        }
-    }
     fn get_loot_special_names_slot(
         adventurer: Adventurer, bag: Bag, loot_statistics: LootStatistics
     ) -> LootStatistics {
@@ -404,71 +283,71 @@ impl ImplLootItemSpecialNames of ILootItemSpecialNames {
 #[test]
 #[available_gas(5000000)]
 fn test_item_meta_packing() {
-    let mut item_meta_storage = LootItemSpecialNamesStorage {
+    let storage = LootItemSpecialNamesStorage {
         item_1: LootItemSpecialNames {
-            name_prefix: 127, name_suffix: 31, item_suffix: 15, 
+            name_prefix: 11, name_suffix: 1, item_suffix: 15,
             }, item_2: LootItemSpecialNames {
-            name_prefix: 127, name_suffix: 31, item_suffix: 15, 
+            name_prefix: 22, name_suffix: 2, item_suffix: 14,
             }, item_3: LootItemSpecialNames {
-            name_prefix: 127, name_suffix: 31, item_suffix: 15, 
+            name_prefix: 33, name_suffix: 3, item_suffix: 13,
             }, item_4: LootItemSpecialNames {
-            name_prefix: 127, name_suffix: 31, item_suffix: 15, 
+            name_prefix: 44, name_suffix: 4, item_suffix: 12,
             }, item_5: LootItemSpecialNames {
-            name_prefix: 127, name_suffix: 31, item_suffix: 15, 
+            name_prefix: 55, name_suffix: 5, item_suffix: 11,
             }, item_6: LootItemSpecialNames {
-            name_prefix: 127, name_suffix: 31, item_suffix: 15, 
+            name_prefix: 66, name_suffix: 6, item_suffix: 10,
             }, item_7: LootItemSpecialNames {
-            name_prefix: 127, name_suffix: 31, item_suffix: 15, 
+            name_prefix: 77, name_suffix: 7, item_suffix: 9,
             }, item_8: LootItemSpecialNames {
-            name_prefix: 127, name_suffix: 31, item_suffix: 15, 
+            name_prefix: 88, name_suffix: 8, item_suffix: 8,
             }, item_9: LootItemSpecialNames {
-            name_prefix: 127, name_suffix: 31, item_suffix: 15, 
+            name_prefix: 99, name_suffix: 9, item_suffix: 7,
             }, item_10: LootItemSpecialNames {
-            name_prefix: 127, name_suffix: 31, item_suffix: 15, 
+            name_prefix: 111, name_suffix: 10, item_suffix: 6,
         }
     };
 
-    let unpacked = ImplLootItemSpecialNames::unpack(item_meta_storage.pack());
+    let unpacked: LootItemSpecialNamesStorage = Packing::unpack(storage.pack());
 
-    assert(unpacked.item_1.name_prefix == 127, 'item_1 name_prefix  127');
-    assert(unpacked.item_1.name_suffix == 31, 'item_1 name_suffix  31');
-    assert(unpacked.item_1.item_suffix == 15, 'item_1 item_suffix 15');
+    assert(unpacked.item_1.name_prefix == storage.item_1.name_prefix, 'item_1 name_prefix');
+    assert(unpacked.item_1.name_suffix == storage.item_1.name_suffix, 'item_1 name_suffix');
+    assert(unpacked.item_1.item_suffix == storage.item_1.item_suffix, 'item_1 item_suffix');
 
-    assert(unpacked.item_2.name_prefix == 127, 'item_2 name_prefix  127');
-    assert(unpacked.item_2.name_suffix == 31, 'item_2 name_suffix  31');
-    assert(unpacked.item_2.item_suffix == 15, 'item_2 item_suffix 15');
+    assert(unpacked.item_2.name_prefix == storage.item_2.name_prefix, 'item_2 name_prefix');
+    assert(unpacked.item_2.name_suffix == storage.item_2.name_suffix, 'item_2 name_suffix');
+    assert(unpacked.item_2.item_suffix == storage.item_2.item_suffix, 'item_2 item_suffix');
 
-    assert(unpacked.item_3.name_prefix == 127, 'item_3 name_prefix  127');
-    assert(unpacked.item_3.name_suffix == 31, 'item_3 name_suffix  31');
-    assert(unpacked.item_3.item_suffix == 15, 'item_3 item_suffix 15');
+    assert(unpacked.item_3.name_prefix == storage.item_3.name_prefix, 'item_3 name_prefix');
+    assert(unpacked.item_3.name_suffix == storage.item_3.name_suffix, 'item_3 name_suffix');
+    assert(unpacked.item_3.item_suffix == storage.item_3.item_suffix, 'item_3 item_suffix');
 
-    assert(unpacked.item_4.name_prefix == 127, 'item_4 name_prefix  127');
-    assert(unpacked.item_4.name_suffix == 31, 'item_4 name_suffix  31');
-    assert(unpacked.item_4.item_suffix == 15, 'item_4 item_suffix 15');
+    assert(unpacked.item_4.name_prefix == storage.item_4.name_prefix, 'item_4 name_prefix');
+    assert(unpacked.item_4.name_suffix == storage.item_4.name_suffix, 'item_4 name_suffix');
+    assert(unpacked.item_4.item_suffix == storage.item_4.item_suffix, 'item_4 item_suffix');
 
-    assert(unpacked.item_5.name_prefix == 127, 'item_5 name_prefix  127');
-    assert(unpacked.item_5.name_suffix == 31, 'item_5 name_suffix  31');
-    assert(unpacked.item_5.item_suffix == 15, 'item_5 item_suffix 15');
+    assert(unpacked.item_5.name_prefix == storage.item_5.name_prefix, 'item_5 name_prefix');
+    assert(unpacked.item_5.name_suffix == storage.item_5.name_suffix, 'item_5 name_suffix');
+    assert(unpacked.item_5.item_suffix == storage.item_5.item_suffix, 'item_5 item_suffix');
 
-    assert(unpacked.item_6.name_prefix == 127, 'item_6 name_prefix  127');
-    assert(unpacked.item_6.name_suffix == 31, 'item_6 name_suffix  31');
-    assert(unpacked.item_6.item_suffix == 15, 'item_6 item_suffix 15');
+    assert(unpacked.item_6.name_prefix == storage.item_6.name_prefix, 'item_6 name_prefix');
+    assert(unpacked.item_6.name_suffix == storage.item_6.name_suffix, 'item_6 name_suffix');
+    assert(unpacked.item_6.item_suffix == storage.item_6.item_suffix, 'item_6 item_suffix');
 
-    assert(unpacked.item_7.name_prefix == 127, 'item_7 name_prefix  127');
-    assert(unpacked.item_7.name_suffix == 31, 'item_7 name_suffix  31');
-    assert(unpacked.item_7.item_suffix == 15, 'item_7 item_suffix 15');
+    assert(unpacked.item_7.name_prefix == storage.item_7.name_prefix, 'item_7 name_prefix');
+    assert(unpacked.item_7.name_suffix == storage.item_7.name_suffix, 'item_7 name_suffix');
+    assert(unpacked.item_7.item_suffix == storage.item_7.item_suffix, 'item_7 item_suffix');
 
-    assert(unpacked.item_8.name_prefix == 127, 'item_8 name_prefix  127');
-    assert(unpacked.item_8.name_suffix == 31, 'item_8 name_suffix  31');
-    assert(unpacked.item_8.item_suffix == 15, 'item_8 item_suffix 15');
+    assert(unpacked.item_8.name_prefix == storage.item_8.name_prefix, 'item_8 name_prefix');
+    assert(unpacked.item_8.name_suffix == storage.item_8.name_suffix, 'item_8 name_suffix');
+    assert(unpacked.item_8.item_suffix == storage.item_8.item_suffix, 'item_8 item_suffix');
 
-    assert(unpacked.item_9.name_prefix == 127, 'item_9 name_prefix  127');
-    assert(unpacked.item_9.name_suffix == 31, 'item_9 name_suffix  31');
-    assert(unpacked.item_9.item_suffix == 15, 'item_9 item_suffix 15');
+    assert(unpacked.item_9.name_prefix == storage.item_9.name_prefix, 'item_9 name_prefix');
+    assert(unpacked.item_9.name_suffix == storage.item_9.name_suffix, 'item_9 name_suffix');
+    assert(unpacked.item_9.item_suffix == storage.item_9.item_suffix, 'item_9 item_suffix');
 
-    assert(unpacked.item_10.name_prefix == 127, 'item_10 name_prefix  127');
-    assert(unpacked.item_10.name_suffix == 31, 'item_10 name_suffix  31');
-    assert(unpacked.item_10.item_suffix == 15, 'item_10 item_suffix 15');
+    assert(unpacked.item_10.name_prefix == storage.item_10.name_prefix, 'item_10 name_prefix');
+    assert(unpacked.item_10.name_suffix == storage.item_10.name_suffix, 'item_10 name_suffix');
+    assert(unpacked.item_10.item_suffix == storage.item_10.item_suffix, 'item_10 item_suffix');
 }
 
 #[test]
@@ -489,29 +368,29 @@ fn test_get_item_metadata_slot() {
 
     let bag = Bag {
         item_1: LootStatistics {
-            id: 1, xp: 0, metadata: 4, 
+            id: 1, xp: 0, metadata: 4,
             }, item_2: LootStatistics {
-            id: 2, xp: 0, metadata: 5, 
+            id: 2, xp: 0, metadata: 5,
             }, item_3: LootStatistics {
-            id: 3, xp: 0, metadata: 6, 
+            id: 3, xp: 0, metadata: 6,
             }, item_4: LootStatistics {
-            id: 4, xp: 0, metadata: 7, 
+            id: 4, xp: 0, metadata: 7,
             }, item_5: LootStatistics {
-            id: 5, xp: 0, metadata: 8, 
+            id: 5, xp: 0, metadata: 8,
             }, item_6: LootStatistics {
-            id: 6, xp: 0, metadata: 11, 
+            id: 6, xp: 0, metadata: 11,
             }, item_7: LootStatistics {
-            id: 7, xp: 0, metadata: 0, 
+            id: 7, xp: 0, metadata: 0,
             }, item_8: LootStatistics {
-            id: 8, xp: 0, metadata: 12, 
+            id: 8, xp: 0, metadata: 12,
             }, item_9: LootStatistics {
-            id: 9, xp: 0, metadata: 0, 
+            id: 9, xp: 0, metadata: 0,
             }, item_10: LootStatistics {
-            id: 10, xp: 0, metadata: 0, 
+            id: 10, xp: 0, metadata: 0,
             }, item_11: LootStatistics {
-            id: 11, xp: 0, metadata: 18, 
+            id: 11, xp: 0, metadata: 18,
             }, item_12: LootStatistics {
-            id: 12, xp: 0, metadata: 0, 
+            id: 12, xp: 0, metadata: 0,
         },
     };
 
@@ -527,25 +406,25 @@ fn test_get_item_metadata_slot() {
 fn test_set_item_metadata_slot() {
     let mut item_meta_storage = LootItemSpecialNamesStorage {
         item_1: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
+            name_prefix: 0, name_suffix: 0, item_suffix: 0,
             }, item_2: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
+            name_prefix: 0, name_suffix: 0, item_suffix: 0,
             }, item_3: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
+            name_prefix: 0, name_suffix: 0, item_suffix: 0,
             }, item_4: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
+            name_prefix: 0, name_suffix: 0, item_suffix: 0,
             }, item_5: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
+            name_prefix: 0, name_suffix: 0, item_suffix: 0,
             }, item_6: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
+            name_prefix: 0, name_suffix: 0, item_suffix: 0,
             }, item_7: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
+            name_prefix: 0, name_suffix: 0, item_suffix: 0,
             }, item_8: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
+            name_prefix: 0, name_suffix: 0, item_suffix: 0,
             }, item_9: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
+            name_prefix: 0, name_suffix: 0, item_suffix: 0,
             }, item_10: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
+            name_prefix: 0, name_suffix: 0, item_suffix: 0,
         }
     };
 
@@ -589,25 +468,25 @@ fn test_get_item_metadata() {
 
     let mut item_meta_storage = LootItemSpecialNamesStorage {
         item_1: LootItemSpecialNames {
-            name_prefix: 2, name_suffix: 2, item_suffix: 10, 
+            name_prefix: 2, name_suffix: 2, item_suffix: 10,
             }, item_2: LootItemSpecialNames {
-            name_prefix: 4, name_suffix: 3, item_suffix: 11, 
+            name_prefix: 4, name_suffix: 3, item_suffix: 11,
             }, item_3: LootItemSpecialNames {
-            name_prefix: 5, name_suffix: 4, item_suffix: 11, 
+            name_prefix: 5, name_suffix: 4, item_suffix: 11,
             }, item_4: LootItemSpecialNames {
-            name_prefix: 6, name_suffix: 5, item_suffix: 3, 
+            name_prefix: 6, name_suffix: 5, item_suffix: 3,
             }, item_5: LootItemSpecialNames {
-            name_prefix: 8, name_suffix: 6, item_suffix: 2, 
+            name_prefix: 8, name_suffix: 6, item_suffix: 2,
             }, item_6: LootItemSpecialNames {
-            name_prefix: 9, name_suffix: 7, item_suffix: 1, 
+            name_prefix: 9, name_suffix: 7, item_suffix: 1,
             }, item_7: LootItemSpecialNames {
-            name_prefix: 11, name_suffix: 8, item_suffix: 5, 
+            name_prefix: 11, name_suffix: 8, item_suffix: 5,
             }, item_8: LootItemSpecialNames {
-            name_prefix: 2, name_suffix: 9, item_suffix: 6, 
+            name_prefix: 2, name_suffix: 9, item_suffix: 6,
             }, item_9: LootItemSpecialNames {
-            name_prefix: 3, name_suffix: 0, item_suffix: 7, 
+            name_prefix: 3, name_suffix: 0, item_suffix: 7,
             }, item_10: LootItemSpecialNames {
-            name_prefix: 11, name_suffix: 8, item_suffix: 5, 
+            name_prefix: 11, name_suffix: 8, item_suffix: 5,
         }
     };
 

--- a/contracts/game/src/game/game.cairo
+++ b/contracts/game/src/game/game.cairo
@@ -442,6 +442,8 @@ mod Game {
     // ------------------------------------------ //
 
     fn _start(ref self: ContractState, starting_weapon: u8, adventurer_meta: AdventurerMetadata) {
+        // https://github.com/starkware-libs/cairo/issues/2942
+        internal::revoke_ap_tracking();
         // get caller address
         let caller = get_caller_address();
 
@@ -501,6 +503,8 @@ mod Game {
         ref name_storage1: LootItemSpecialNamesStorage,
         ref name_storage2: LootItemSpecialNamesStorage
     ) {
+        // https://github.com/starkware-libs/cairo/issues/2942
+        internal::revoke_ap_tracking();
         // get adventurer entropy from storage
         let adventurer_entropy = _adventurer_meta_unpacked(@self, adventurer_id).entropy;
 
@@ -621,7 +625,7 @@ mod Game {
         }
     }
 
-    fn _beast_discovery(ref self: ContractState, adventurer_id: u256) {}
+    //fn _beast_discovery(ref self: ContractState, adventurer_id: u256) {}
 
     fn _obstacle_encounter(
         ref self: ContractState,
@@ -631,6 +635,8 @@ mod Game {
         ref name_storage2: LootItemSpecialNamesStorage,
         entropy: u128
     ) -> Adventurer {
+        // https://github.com/starkware-libs/cairo/issues/2942
+        internal::revoke_ap_tracking();
         // delegate obstacle encounter to obstacle library
         let (obstacle, dodged) = ImplObstacle::obstacle_encounter(
             adventurer.get_level(), adventurer.stats.intelligence, entropy
@@ -739,6 +745,8 @@ mod Game {
         prefixes_assigned: bool,
         special_names: LootItemSpecialNames
     ) {
+        // https://github.com/starkware-libs/cairo/issues/2942
+        internal::revoke_ap_tracking();
         // if the new level is higher than the previous level
         if (new_level > previous_level) {
             // generate greatness increased event
@@ -806,6 +814,8 @@ mod Game {
         value: u16,
         entropy: u128
     ) {
+        // https://github.com/starkware-libs/cairo/issues/2942
+        internal::revoke_ap_tracking();
         let xp_increase = value * ITEM_XP_MULTIPLIER;
 
         // if weapon is equipped
@@ -992,6 +1002,8 @@ mod Game {
         ref name_storage1: LootItemSpecialNamesStorage,
         ref name_storage2: LootItemSpecialNamesStorage
     ) {
+        // https://github.com/starkware-libs/cairo/issues/2942
+        internal::revoke_ap_tracking();
         // get adventurer entropy from storage
         let adventurer_entropy = _adventurer_meta_unpacked(@self, adventurer_id).entropy;
 
@@ -1090,7 +1102,6 @@ mod Game {
                     gold_earned: gold_reward
                 }
             );
-            return;
         } else {
             // beast has more health than was dealt so subtract damage dealt
             adventurer.beast_health = adventurer.beast_health - damage_dealt;
@@ -1143,7 +1154,6 @@ mod Game {
                     damage_location: ImplCombat::slot_to_u8(attack_location),
                 }
             );
-            return;
         }
     }
 
@@ -1155,6 +1165,8 @@ mod Game {
         beast: Beast,
         entropy: u128
     ) -> u16 {
+        // https://github.com/starkware-libs/cairo/issues/2942
+        internal::revoke_ap_tracking();
         // generate a random attack slot for the beast and get the armor the adventurer has at that slot
         let armor = adventurer.get_item_at_slot(attack_location);
 
@@ -1184,6 +1196,8 @@ mod Game {
     fn _flee(
         ref self: ContractState, ref adventurer: Adventurer, adventurer_id: u256
     ) -> Adventurer {
+        // https://github.com/starkware-libs/cairo/issues/2942
+        internal::revoke_ap_tracking();
         // get adventurer entropy from storage
         let adventurer_entropy = _adventurer_meta_unpacked(@self, adventurer_id).entropy;
 
@@ -1254,6 +1268,8 @@ mod Game {
         item_id: u8,
         ref bag: Bag
     ) {
+        // https://github.com/starkware-libs/cairo/issues/2942
+        internal::revoke_ap_tracking();
         // get item the adventurer is equipping
         let equipping_item = bag.get_item(item_id);
 
@@ -1316,6 +1332,8 @@ mod Game {
         item_id: u8,
         equip: bool
     ) {
+        // https://github.com/starkware-libs/cairo/issues/2942
+        internal::revoke_ap_tracking();
         // TODO: Remove after testing
         // assert(adventurer.stat_upgrade_available == 1, 'Not available');
 
@@ -1377,6 +1395,8 @@ mod Game {
     fn _upgrade_stat(
         ref self: ContractState, adventurer_id: u256, ref adventurer: Adventurer, stat_id: u8
     ) {
+        // https://github.com/starkware-libs/cairo/issues/2942
+        internal::revoke_ap_tracking();
         _assert_ownership(@self, adventurer_id);
 
         // add stat to adventuer

--- a/contracts/game/src/game/game.cairo
+++ b/contracts/game/src/game/game.cairo
@@ -24,7 +24,7 @@ mod Game {
     use lootitems::{
         loot::{Loot, ImplLoot}, statistics::constants::{NamePrefixLength, NameSuffixLength}
     };
-    use pack::pack::{pack_value, unpack_value};
+
     use survivor::{
         adventurer::{Adventurer, ImplAdventurer, IAdventurer},
         bag::{Bag, BagActions, ImplBagActions, LootStatistics},
@@ -500,7 +500,7 @@ mod Game {
         ref name_storage1: LootItemSpecialNamesStorage,
         ref name_storage2: LootItemSpecialNamesStorage
     ) {
-        // get adventurer entropy from storage  
+        // get adventurer entropy from storage
         let adventurer_entropy = _adventurer_meta_unpacked(@self, adventurer_id).entropy;
 
         // get global game entropy
@@ -527,7 +527,7 @@ mod Game {
                     exploration_entropy
                 );
 
-                // initialize the beast health. This is the only timeD beast.starting_health should be 
+                // initialize the beast health. This is the only timeD beast.starting_health should be
                 // used. In subsequent calls to attack the beast, adventurer.beast_health should be used as the persistent
                 // storage of the beast health
                 adventurer.beast_health = beast.starting_health;
@@ -572,7 +572,7 @@ mod Game {
                     // emit adventurer died
                     // note we technically could do this inside of _beast_counter_attack but
                     // doing so would result in AdventurerDied being emitted before
-                    // the DiscoverBeast for the beast that killed them. 
+                    // the DiscoverBeast for the beast that killed them.
                     __event_AdventurerDied(
                         ref self,
                         AdventurerState {
@@ -794,8 +794,8 @@ mod Game {
     /// @param entropy An unsigned integer used for entropy generation. This is often derived from a source of randomness.
     ///
     /// The function first retrieves the names of the special items an adventurer may possess. It then calculates the XP increase by applying a multiplier to the provided 'value'.
-    /// The function then checks each item slot (weapon, chest, head, waist, foot, hand, neck, ring) of the adventurer to see if an item is equipped (item ID > 0). 
-    /// If an item is equipped, it calls `_grant_xp_to_item_and_emit_event` to apply the XP increase to the item and handle any resulting events. 
+    /// The function then checks each item slot (weapon, chest, head, waist, foot, hand, neck, ring) of the adventurer to see if an item is equipped (item ID > 0).
+    /// If an item is equipped, it calls `_grant_xp_to_item_and_emit_event` to apply the XP increase to the item and handle any resulting events.
     fn _grant_xp_to_equipped_items(
         ref self: ContractState,
         adventurer_id: u256,
@@ -991,13 +991,13 @@ mod Game {
         ref name_storage1: LootItemSpecialNamesStorage,
         ref name_storage2: LootItemSpecialNamesStorage
     ) {
-        // get adventurer entropy from storage  
+        // get adventurer entropy from storage
         let adventurer_entropy = _adventurer_meta_unpacked(@self, adventurer_id).entropy;
 
         // generate battle fixed entropy by combining adventurer xp and adventurer entropy
         let battle_fixed_entropy: u128 = adventurer.get_battle_fixed_entropy(adventurer_entropy);
 
-        // generate special names for beast using Loot name schema. 
+        // generate special names for beast using Loot name schema.
         // We use Loot names because the combat system will deal bonus damage for matching names (these are the items super powers)
         // We do this here instead of in beast to prevent beast from depending on Loot
         let beast_prefix1 = U128TryIntoU8::try_into(
@@ -1109,7 +1109,7 @@ mod Game {
                 // emit adventurer died
                 // note we technically could do this inside of _beast_counter_attack but
                 // doing so would result in AdventurerDied being emitted before
-                // the DiscoverBeast for the beast that killed them. 
+                // the DiscoverBeast for the beast that killed them.
                 __event_AdventurerDied(
                     ref self,
                     AdventurerState {
@@ -1183,7 +1183,7 @@ mod Game {
     fn _flee(
         ref self: ContractState, ref adventurer: Adventurer, adventurer_id: u256
     ) -> Adventurer {
-        // get adventurer entropy from storage  
+        // get adventurer entropy from storage
         let adventurer_entropy = _adventurer_meta_unpacked(@self, adventurer_id).entropy;
 
         // get game entropy from storage

--- a/contracts/game/src/game/game.cairo
+++ b/contracts/game/src/game/game.cairo
@@ -24,11 +24,12 @@ mod Game {
     use lootitems::{
         loot::{Loot, ImplLoot}, statistics::constants::{NamePrefixLength, NameSuffixLength}
     };
+    use pack::pack::Packing;
 
     use survivor::{
         adventurer::{Adventurer, ImplAdventurer, IAdventurer},
         bag::{Bag, BagActions, ImplBagActions, LootStatistics},
-        adventurer_meta::{AdventurerMetadata, ImplAdventurerMetadata, IAdventurerMetadata},
+        adventurer_meta::AdventurerMetadata,
         exploration::ExploreUtils,
         constants::{
             discovery_constants::DiscoveryEnums::{ExploreResult, TreasureDiscovery},
@@ -1445,7 +1446,7 @@ mod Game {
         name_storage2: LootItemSpecialNamesStorage
     ) -> Adventurer {
         // unpack adventurer
-        let mut adventurer = ImplAdventurer::unpack(self._adventurer.read(adventurer_id));
+        let mut adventurer: Adventurer = Packing::unpack(self._adventurer.read(adventurer_id));
         // apply stat boosts
         _apply_stat_boots(self, adventurer_id, ref adventurer, name_storage1, name_storage2)
     }
@@ -1494,7 +1495,7 @@ mod Game {
 
     fn _unpack_adventurer(self: @ContractState, adventurer_id: u256) -> Adventurer {
         // unpack adventurer
-        ImplAdventurer::unpack(self._adventurer.read(adventurer_id))
+        Packing::unpack(self._adventurer.read(adventurer_id))
     }
 
     fn _pack_adventurer(ref self: ContractState, adventurer_id: u256, adventurer: Adventurer) {
@@ -1502,7 +1503,7 @@ mod Game {
     }
 
     fn _bag_unpacked(self: @ContractState, adventurer_id: u256) -> Bag {
-        ImplBagActions::unpack(self._bag.read(adventurer_id))
+        Packing::unpack(self._bag.read(adventurer_id))
     }
 
     fn _pack_bag(ref self: ContractState, adventurer_id: u256, bag: Bag) {
@@ -1510,7 +1511,7 @@ mod Game {
     }
 
     fn _adventurer_meta_unpacked(self: @ContractState, adventurer_id: u256) -> AdventurerMetadata {
-        ImplAdventurerMetadata::unpack(self._adventurer_meta.read(adventurer_id))
+        Packing::unpack(self._adventurer_meta.read(adventurer_id))
     }
 
     fn _pack_adventurer_meta(
@@ -1534,7 +1535,7 @@ mod Game {
     fn _loot_special_names_storage_unpacked(
         self: @ContractState, adventurer_id: u256, storage_index: u256
     ) -> LootItemSpecialNamesStorage {
-        ImplLootItemSpecialNames::unpack(
+        Packing::unpack(
             self._loot_special_names.read((adventurer_id, storage_index))
         )
     }

--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -1,35 +1,35 @@
-use starknet::{ContractAddress};
+use starknet::ContractAddress;
 
-use survivor::adventurer::{Adventurer, ImplAdventurer, IAdventurer};
-use survivor::adventurer_meta::{AdventurerMetadata, ImplAdventurerMetadata};
-use survivor::bag::{Bag, BagActions, ImplBagActions, LootStatistics};
-use lootitems::loot::{Loot, ImplLoot};
+use survivor::adventurer::Adventurer;
+use survivor::adventurer_meta::AdventurerMetadata;
+use survivor::bag::Bag;
+use lootitems::loot::Loot;
 
 #[starknet::interface]
-trait IGame<T> {
+trait IGame<TContractState> {
     // actions ---------------------------------------------------
-    fn start(ref self: T, starting_weapon: u8, adventurer_meta: AdventurerMetadata);
-    fn explore(ref self: T, adventurer_id: u256);
-    fn attack(ref self: T, adventurer_id: u256);
-    fn flee(ref self: T, adventurer_id: u256);
-    fn equip(ref self: T, adventurer_id: u256, item_id: u8);
-    fn buy_item(ref self: T, adventurer_id: u256, item_id: u8, equip: bool);
-    fn buy_health(ref self: T, adventurer_id: u256);
-    fn upgrade_stat(ref self: T, adventurer_id: u256, stat: u8);
-    fn slay_idle_adventurer(ref self: T, adventurer_id: u256);
+    fn start(ref self: TContractState, starting_weapon: u8, adventurer_meta: AdventurerMetadata);
+    fn explore(ref self: TContractState, adventurer_id: u256);
+    fn attack(ref self: TContractState, adventurer_id: u256);
+    fn flee(ref self: TContractState, adventurer_id: u256);
+    fn equip(ref self: TContractState, adventurer_id: u256, item_id: u8);
+    fn buy_item(ref self: TContractState, adventurer_id: u256, item_id: u8, equip: bool);
+    fn buy_health(ref self: TContractState, adventurer_id: u256);
+    fn upgrade_stat(ref self: TContractState, adventurer_id: u256, stat: u8);
+    fn slay_idle_adventurer(ref self: TContractState, adventurer_id: u256);
 
     // view ------------------------------------------------------
-    fn get_adventurer(self: @T, adventurer_id: u256) -> Adventurer;
-    fn get_adventurer_meta(self: @T, adventurer_id: u256) -> AdventurerMetadata;
-    fn get_bag(self: @T, adventurer_id: u256) -> Bag;
-    fn get_items_on_market(self: @T, adventurer_id: u256) -> Array<Loot>;
-    fn get_dao_address(self: @T) -> ContractAddress;
-    fn get_lords_address(self: @T) -> ContractAddress;
-    fn get_entropy(self: @T) -> u256;
+    fn get_adventurer(self: @TContractState, adventurer_id: u256) -> Adventurer;
+    fn get_adventurer_meta(self: @TContractState, adventurer_id: u256) -> AdventurerMetadata;
+    fn get_bag(self: @TContractState, adventurer_id: u256) -> Bag;
+    fn get_items_on_market(self: @TContractState, adventurer_id: u256) -> Array<Loot>;
+    fn get_dao_address(self: @TContractState) -> ContractAddress;
+    fn get_lords_address(self: @TContractState) -> ContractAddress;
+    fn get_entropy(self: @TContractState) -> u256;
 
     // setters ---------------------------------------------------
-    fn set_entropy(ref self: T, entropy: felt252);
+    fn set_entropy(ref self: TContractState, entropy: felt252);
 
     // checks
-    fn owner_of(self: @T, adventurer_id: u256) -> ContractAddress;
+    fn owner_of(self: @TContractState, adventurer_id: u256) -> ContractAddress;
 }

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -16,9 +16,7 @@ mod tests {
 
     use game::game::interfaces::{IGameDispatcherTrait, IGameDispatcher};
     use game::game::game::{Game};
-    use survivor::adventurer_meta::{
-        AdventurerMetadata, ImplAdventurerMetadata, IAdventurerMetadata,
-    };
+    use survivor::adventurer_meta::AdventurerMetadata;
 
     use survivor::constants::adventurer_constants::{
         STARTING_GOLD, POTION_HEALTH_AMOUNT, POTION_PRICE, STARTING_HEALTH
@@ -136,7 +134,7 @@ mod tests {
             // result in a panic. This test is annotated to expect a panic
             // so if it doesn't, this test will fail
             game.attack(0);
-        } // if the beast was not killed in one hit 
+        } // if the beast was not killed in one hit
         else {
             assert(updated_adventurer.xp == adventurer_start.xp, 'should have same xp');
             assert(updated_adventurer.gold == adventurer_start.gold, 'should have same gold');

--- a/contracts/loot/src/loot.cairo
+++ b/contracts/loot/src/loot.cairo
@@ -19,7 +19,7 @@ use super::{
 };
 
 use combat::{combat::ImplCombat, constants::CombatEnums::{Type, Tier, Slot}};
-use pack::{pack::{pack_value, unpack_value}, constants::{pow, mask}};
+use pack::{pack::{Packing, pack_value, unpack_value}, constants::{pow, mask}};
 
 #[derive(Copy, Drop, Clone, Serde)]
 struct Loot {
@@ -134,28 +134,28 @@ impl ImplLoot of ILoot {
 
         // if level exceeds max greatness
         if level > ITEM_MAX_GREATNESS {
-            // return max greatness 
+            // return max greatness
             return ITEM_MAX_GREATNESS;
         } else {
             return level;
         }
     }
+}
 
+impl PackingLoot of Packing<Loot> {
     // pack an item for storage
     // @param item The item to pack.
     // @return The packed item in a felt252
     fn pack(self: Loot) -> felt252 {
-        let mut packed = 0;
         let item_tier = ImplCombat::tier_to_u8(self.tier);
         let item_type = ImplCombat::type_to_u8(self.item_type);
         let item_slot = ImplCombat::slot_to_u8(self.slot);
 
-        packed = packed | pack_value(self.id.into(), pow::TWO_POW_236);
-        packed = packed | pack_value(item_tier.into(), pow::TWO_POW_220);
-        packed = packed | pack_value(item_type.into(), pow::TWO_POW_204);
-        packed = packed | pack_value(item_slot.into(), pow::TWO_POW_118);
-
-        packed.try_into().unwrap()
+        (pack_value(self.id.into(), pow::TWO_POW_236)
+         + pack_value(item_tier.into(), pow::TWO_POW_220)
+         + pack_value(item_type.into(), pow::TWO_POW_204)
+         + pack_value(item_slot.into(), pow::TWO_POW_118)
+        ).try_into().unwrap()
     }
 
     // unpack an item from storage
@@ -163,25 +163,13 @@ impl ImplLoot of ILoot {
     // @return The unpacked item
     fn unpack(packed: felt252) -> Loot {
         let packed = packed.into();
-        let item_tier_u8 = U256TryIntoU8::try_into(
-            unpack_value(packed, pow::TWO_POW_220, mask::MASK_16)
-        )
-            .unwrap();
-        let item_type_u8 = U256TryIntoU8::try_into(
-            unpack_value(packed, pow::TWO_POW_204, mask::MASK_16)
-        )
-            .unwrap();
-
-        let item_slot_u8 = U256TryIntoU8::try_into(
-            unpack_value(packed, pow::TWO_POW_118, mask::MASK_16)
-        )
-            .unwrap();
-
-        let item_id = U256TryIntoU8::try_into(unpack_value(packed, pow::TWO_POW_236, mask::MASK_16))
-            .unwrap();
-        let item_tier = ImplCombat::u8_to_tier(item_tier_u8);
-        let item_type = ImplCombat::u8_to_type(item_type_u8);
-        let item_slot = ImplCombat::u8_to_slot(item_slot_u8);
+        let item_tier: u8 = unpack_value(packed, pow::TWO_POW_220, mask::MASK_16).try_into().unwrap();
+        let item_type: u8 = unpack_value(packed, pow::TWO_POW_204, mask::MASK_16).try_into().unwrap();
+        let item_slot: u8 = unpack_value(packed, pow::TWO_POW_118, mask::MASK_16).try_into().unwrap();
+        let item_id = unpack_value(packed, pow::TWO_POW_236, mask::MASK_16).try_into().unwrap();
+        let item_tier = ImplCombat::u8_to_tier(item_tier);
+        let item_type = ImplCombat::u8_to_type(item_type);
+        let item_slot = ImplCombat::u8_to_slot(item_slot);
 
         Loot { id: item_id, tier: item_tier, item_type: item_type, slot: item_slot }
     }
@@ -428,9 +416,9 @@ fn test_item_name_suffix() {
         );
 
         //
-        // Rings 
+        // Rings
         //
-        // Can have any name so no need to test. Note while the contract doesn't generate any Rings with 
+        // Can have any name so no need to test. Note while the contract doesn't generate any Rings with
         // name prefix set 1  such as "X Bane" Gold Ring of Power, this is because those ring variants
         // haven't yet reached G19 to receive their name. This is simlar to us
         // knowing that all Warhammers will eventually be "X Bane" even though none have reached G19
@@ -481,9 +469,7 @@ fn test_pack_and_unpack() {
         id: 1, tier: Tier::T1(()), item_type: Type::Bludgeon_or_Metal(()), slot: Slot::Waist(())
     };
 
-    let unpacked = ImplLoot::unpack(loot.pack());
-
-    let unpacked = ImplLoot::unpack(loot.pack());
+    let unpacked: Loot = Packing::unpack(loot.pack());
     assert(loot.id == unpacked.id, 'id');
     assert(loot.tier == unpacked.tier, 'tier');
     assert(loot.item_type == unpacked.item_type, 'item_type');

--- a/contracts/loot/src/loot.cairo
+++ b/contracts/loot/src/loot.cairo
@@ -155,7 +155,7 @@ impl PackingLoot of Packing<Loot> {
          + item_tier.into() * pow::TWO_POW_8
          + item_type.into() * pow::TWO_POW_16
          + item_slot.into() * pow::TWO_POW_24
-        ).try_into().unwrap()
+        ).try_into().expect('pack Loot')
     }
 
     // unpack an item from storage
@@ -169,10 +169,10 @@ impl PackingLoot of Packing<Loot> {
         let (_, item_slot) = rshift_split(packed, pow::TWO_POW_8);
 
         Loot {
-            id: item_id.try_into().unwrap(),
-            tier: ImplCombat::u8_to_tier(item_tier.try_into().unwrap()),
-            item_type: ImplCombat::u8_to_type(item_type.try_into().unwrap()),
-            slot: ImplCombat::u8_to_slot(item_slot.try_into().unwrap())
+            id: item_id.try_into().expect('unpack Loot id'),
+            tier: ImplCombat::u8_to_tier(item_tier.try_into().expect('unpack Loot tier')),
+            item_type: ImplCombat::u8_to_type(item_type.try_into().expect('unpack Loot item type')),
+            slot: ImplCombat::u8_to_slot(item_slot.try_into().expect('unpack Loot slot'))
         }
     }
 }

--- a/contracts/pack/src/pack.cairo
+++ b/contracts/pack/src/pack.cairo
@@ -1,11 +1,13 @@
-use integer::{u256_from_felt252};
-use traits::{TryInto, Into};
-use option::OptionTrait;
-use debug::PrintTrait;
+use traits::Into;
+
+trait Packing<T> {
+    fn pack(self: T) -> felt252;
+    fn unpack(packed: felt252) -> T;
+}
 
 #[inline(always)]
 fn pack_value(value: felt252, pow: u256) -> u256 {
-    u256_from_felt252(value) * pow
+    value.into() * pow
 }
 
 #[inline(always)]

--- a/contracts/pack/src/pack.cairo
+++ b/contracts/pack/src/pack.cairo
@@ -1,4 +1,5 @@
-use traits::Into;
+use option::OptionTrait;
+use traits::{Into, TryInto};
 
 trait Packing<T> {
     fn pack(self: T) -> felt252;
@@ -13,4 +14,48 @@ fn pack_value(value: felt252, pow: u256) -> u256 {
 #[inline(always)]
 fn unpack_value(value: u256, pow: u256, mask: u256) -> u256 {
     (value / pow) & mask
+}
+
+#[inline(always)]
+fn rshift_split(value: u256, bits: u256) -> (u256, u256) {
+    integer::U256DivRem::div_rem(value, bits.try_into().expect('0 bits'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rshift_split;
+    use pack::constants::pow;
+
+    #[test]
+    #[available_gas(10000000)]
+    fn test_rshift_split_pass() {
+        let v = 0b11010101;
+
+        let (q, r) = rshift_split(v, pow::TWO_POW_1);
+        assert(q == 0b1101010, 'q 1 bit');
+        assert(r == 0b1, 'r 1 bit');
+
+        let (q, r) = rshift_split(v, pow::TWO_POW_2);
+        assert(q == 0b110101, 'q 2 bits');
+        assert(r == 0b01, 'r 2 bits');
+
+        let (q, r) = rshift_split(v, pow::TWO_POW_3);
+        assert(q == 0b11010, 'q 3 bits');
+        assert(r == 0b101, 'r 3 bits');
+
+        let (q, r) = rshift_split(v, pow::TWO_POW_4);
+        assert(q == 0b1101, 'q 4 bits');
+        assert(r == 0b0101, 'r 4 bits');
+
+        let (q, r) = rshift_split(v, pow::TWO_POW_8);
+        assert(q == 0, 'q 8 bits');
+        assert(r == v, 'r 8 bits');
+    }
+
+    #[test]
+    #[available_gas(10000000)]
+    #[should_panic]
+    fn test_rshift_split_0() {
+        rshift_split(0b1101, 0);
+    }
 }

--- a/contracts/pack/src/pack.cairo
+++ b/contracts/pack/src/pack.cairo
@@ -3,10 +3,12 @@ use traits::{TryInto, Into};
 use option::OptionTrait;
 use debug::PrintTrait;
 
+#[inline(always)]
 fn pack_value(value: felt252, pow: u256) -> u256 {
     u256_from_felt252(value) * pow
 }
 
+#[inline(always)]
 fn unpack_value(value: u256, pow: u256, mask: u256) -> u256 {
     (value / pow) & mask
 }

--- a/contracts/pack/src/pack.cairo
+++ b/contracts/pack/src/pack.cairo
@@ -6,7 +6,7 @@ trait Packing<T> {
     fn unpack(packed: felt252) -> T;
 }
 
-#[inline(always)]
+//#[inline(always)]
 fn rshift_split(value: u256, bits: u256) -> (u256, u256) {
     integer::U256DivRem::div_rem(value, bits.try_into().expect('0 bits'))
 }

--- a/contracts/pack/src/pack.cairo
+++ b/contracts/pack/src/pack.cairo
@@ -7,16 +7,6 @@ trait Packing<T> {
 }
 
 #[inline(always)]
-fn pack_value(value: felt252, pow: u256) -> u256 {
-    value.into() * pow
-}
-
-#[inline(always)]
-fn unpack_value(value: u256, pow: u256, mask: u256) -> u256 {
-    (value / pow) & mask
-}
-
-#[inline(always)]
 fn rshift_split(value: u256, bits: u256) -> (u256, u256) {
     integer::U256DivRem::div_rem(value, bits.try_into().expect('0 bits'))
 }


### PR DESCRIPTION
Better bit packing.

There's a bunch of improvements:

 * no use of bitwise builtin, all done via arithmetic
 * generic `Packing` trait
 * previous implementation was buggy and the bugs were "hidden" because of wrong unit tests
 * some packing-unrelated cleanup of imports

The refactor revealed another issue in the game - to pack a `Bag`, we need `12 * 21 = 252` bits, but a `felt252`, despite the name, cannot hold the full value of `252` bits. In other words, a `Bag` with 12 items cannot be packed into a single felt. How to deal with this?
