### PR TITLE
dev: no u256_safe_divmod for now

### DIFF
--- a/contracts/game/Scarb.toml
+++ b/contracts/game/Scarb.toml
@@ -12,4 +12,4 @@ market = { path = "../market" }
 obstacles = { path = "../obstacles" }
 
 [[target.starknet-contract]]
-allowed-libfuncs-list = { name = "experimental" }
+allowed-libfuncs = true

--- a/contracts/pack/src/pack.cairo
+++ b/contracts/pack/src/pack.cairo
@@ -8,7 +8,11 @@ trait Packing<T> {
 
 //#[inline(always)]
 fn rshift_split(value: u256, bits: u256) -> (u256, u256) {
-    integer::U256DivRem::div_rem(value, bits.try_into().expect('0 bits'))
+    // temporary commented out until 0.12.1 when u256_safe_divmod is an allowed libfunc
+    // integer::U256DivRem::div_rem(value, bits.try_into().expect('0 bits'))
+    let value = integer::u512 { limb0: value.low, limb1: value.high, limb2: 0, limb3: 0 };
+    let (q, r) = integer::u512_safe_div_rem_by_u256(value, bits.try_into().expect('0 bits'));
+    (u256 { low: q.limb0, high: q.limb1 }, r)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`u256_safe_divmod` libfunc, which is used internally when dividing by u256 which we use when unpacking, is not allowed yet in 0.12. Hence we couldn't build the game with `allowed-libfuncs = true`.

This PR fixes it by using `u512_safe_div_rem_by_u256` libfunc which is allowed.