### PR TITLE
refactor lootstatistics

### DIFF
--- a/contracts/adventurer/src/bag.cairo
+++ b/contracts/adventurer/src/bag.cairo
@@ -5,28 +5,21 @@ use pack::pack::{Packing, rshift_split};
 use pack::constants::pow;
 
 use super::adventurer::{Adventurer, ImplAdventurer, IAdventurer};
-
-#[derive(Drop, Copy, Serde)] // 21 bits
-struct LootStatistics {
-    id: u8, // 7 bits
-    xp: u16, // 9 bits
-    // this is set as the items are found/purchased
-    metadata: u8, // 5 bits
-}
+use lootitems::loot::DynamicItem;
 
 #[derive(Drop, Copy, Serde)]
 struct Bag {
-    item_1: LootStatistics, // club
-    item_2: LootStatistics, // club
-    item_3: LootStatistics, // club
-    item_4: LootStatistics, // club
-    item_5: LootStatistics, // club
-    item_6: LootStatistics, // club
-    item_7: LootStatistics, // club
-    item_8: LootStatistics, // club
-    item_9: LootStatistics, // club
-    item_10: LootStatistics, // club
-    item_11: LootStatistics, // club
+    item_1: DynamicItem, // club
+    item_2: DynamicItem, // club
+    item_3: DynamicItem, // club
+    item_4: DynamicItem, // club
+    item_5: DynamicItem, // club
+    item_6: DynamicItem, // club
+    item_7: DynamicItem, // club
+    item_8: DynamicItem, // club
+    item_9: DynamicItem, // club
+    item_10: DynamicItem, // club
+    item_11: DynamicItem, // club
 }
 
 trait BagActions {
@@ -34,10 +27,10 @@ trait BagActions {
     // take bag and item to swap and item to equip
     // return bag with swapped items and item that was swapped for
     // we then store the item on the Adventurer
-    // fn swap_items(self: Bag, incoming: u8, outgoing: u8) -> (Bag, LootStatistics);
+    // fn swap_items(self: Bag, incoming: u8, outgoing: u8) -> (Bag, DynamicItem);
 
     // set item in first available slot
-    fn add_item(ref self: Bag, item: LootStatistics) -> Bag;
+    fn add_item(ref self: Bag, item: DynamicItem) -> Bag;
 
     // // finds open slot
     fn find_slot(self: Bag) -> u8;
@@ -45,33 +38,11 @@ trait BagActions {
     // check if bag full
     fn is_full(self: Bag) -> bool;
     // get item by id
-    fn get_item(self: Bag, item_id: u8) -> LootStatistics;
+    fn get_item(self: Bag, item_id: u8) -> DynamicItem;
     fn remove_item(ref self: Bag, item_id: u8) -> Bag;
 
     // creates new item
-    fn new_item(item_id: u8) -> LootStatistics;
-}
-
-impl LootStatisticsPacking of Packing<LootStatistics> {
-    fn pack(self: LootStatistics) -> felt252 {
-        (self.id.into()
-         + self.xp.into() * pow::TWO_POW_7
-         + self.metadata.into() * pow::TWO_POW_16
-        ).try_into().expect('pack LootStatistics')
-    }
-
-    fn unpack(packed: felt252) -> LootStatistics {
-        let packed = packed.into();
-        let (packed, id) = rshift_split(packed, pow::TWO_POW_7);
-        let (packed, xp) = rshift_split(packed, pow::TWO_POW_9);
-        let (_, metadata) = rshift_split(packed, pow::TWO_POW_5);
-
-        LootStatistics {
-            id: id.try_into().expect('unpack LootStatistics id'),
-            xp: xp.try_into().expect('unpack LootStatistics xp'),
-            metadata: metadata.try_into().expect('unpack LootStatistics metadata')
-        }
-    }
+    fn new_item(item_id: u8) -> DynamicItem;
 }
 
 impl BagPacking of Packing<Bag> {
@@ -120,7 +91,7 @@ impl BagPacking of Packing<Bag> {
     }
 }
 impl ImplBagActions of BagActions {
-    fn add_item(ref self: Bag, item: LootStatistics) -> Bag {
+    fn add_item(ref self: Bag, item: DynamicItem) -> Bag {
         assert(self.is_full() == false, 'Bag is full');
 
         let slot = self.find_slot();
@@ -194,7 +165,7 @@ impl ImplBagActions of BagActions {
             return true;
         }
     }
-    fn get_item(self: Bag, item_id: u8) -> LootStatistics {
+    fn get_item(self: Bag, item_id: u8) -> DynamicItem {
         if self.item_1.id == item_id {
             return self.item_1;
         } else if self.item_2.id == item_id {
@@ -222,42 +193,42 @@ impl ImplBagActions of BagActions {
     fn remove_item(ref self: Bag, item_id: u8) -> Bag {
         // this doesn't check if item is in the bag... It just removes by id...
         if self.item_1.id == item_id {
-            self.item_1 = LootStatistics { id: 0, xp: 0, metadata: 0 };
+            self.item_1 = DynamicItem { id: 0, xp: 0, metadata: 0 };
             return self;
         } else if self.item_2.id == item_id {
-            self.item_2 = LootStatistics { id: 0, xp: 0, metadata: 0 };
+            self.item_2 = DynamicItem { id: 0, xp: 0, metadata: 0 };
             return self;
         } else if self.item_3.id == item_id {
-            self.item_3 = LootStatistics { id: 0, xp: 0, metadata: 0 };
+            self.item_3 = DynamicItem { id: 0, xp: 0, metadata: 0 };
             return self;
         } else if self.item_4.id == item_id {
-            self.item_4 = LootStatistics { id: 0, xp: 0, metadata: 0 };
+            self.item_4 = DynamicItem { id: 0, xp: 0, metadata: 0 };
             return self;
         } else if self.item_5.id == item_id {
-            self.item_5 = LootStatistics { id: 0, xp: 0, metadata: 0 };
+            self.item_5 = DynamicItem { id: 0, xp: 0, metadata: 0 };
             return self;
         } else if self.item_6.id == item_id {
-            self.item_6 = LootStatistics { id: 0, xp: 0, metadata: 0 };
+            self.item_6 = DynamicItem { id: 0, xp: 0, metadata: 0 };
             return self;
         } else if self.item_7.id == item_id {
-            self.item_7 = LootStatistics { id: 0, xp: 0, metadata: 0 };
+            self.item_7 = DynamicItem { id: 0, xp: 0, metadata: 0 };
             return self;
         } else if self.item_8.id == item_id {
-            self.item_8 = LootStatistics { id: 0, xp: 0, metadata: 0 };
+            self.item_8 = DynamicItem { id: 0, xp: 0, metadata: 0 };
             return self;
         } else if self.item_9.id == item_id {
-            self.item_9 = LootStatistics { id: 0, xp: 0, metadata: 0 };
+            self.item_9 = DynamicItem { id: 0, xp: 0, metadata: 0 };
             return self;
         } else if self.item_10.id == item_id {
-            self.item_10 = LootStatistics { id: 0, xp: 0, metadata: 0 };
+            self.item_10 = DynamicItem { id: 0, xp: 0, metadata: 0 };
             return self;
         } else {
-            self.item_11 = LootStatistics { id: 0, xp: 0, metadata: 0 };
+            self.item_11 = DynamicItem { id: 0, xp: 0, metadata: 0 };
             return self;
         }
     }
-    fn new_item(item_id: u8) -> LootStatistics {
-        LootStatistics { id: item_id, xp: 0, metadata: 0 }
+    fn new_item(item_id: u8) -> DynamicItem {
+        DynamicItem { id: item_id, xp: 0, metadata: 0 }
     }
 }
 
@@ -265,27 +236,27 @@ impl ImplBagActions of BagActions {
 #[available_gas(5000000)]
 fn test_pack_bag() {
     let mut bag = Bag {
-        item_1: LootStatistics {
+        item_1: DynamicItem {
             id: 127, xp: 511, metadata: 31
-            }, item_2: LootStatistics {
+            }, item_2: DynamicItem {
             id: 127, xp: 511, metadata: 31
-            }, item_3: LootStatistics {
+            }, item_3: DynamicItem {
             id: 127, xp: 511, metadata: 31
-            }, item_4: LootStatistics {
+            }, item_4: DynamicItem {
             id: 127, xp: 511, metadata: 31
-            }, item_5: LootStatistics {
+            }, item_5: DynamicItem {
             id: 127, xp: 511, metadata: 31
-            }, item_6: LootStatistics {
+            }, item_6: DynamicItem {
             id: 127, xp: 511, metadata: 31
-            }, item_7: LootStatistics {
+            }, item_7: DynamicItem {
             id: 127, xp: 511, metadata: 31
-            }, item_8: LootStatistics {
+            }, item_8: DynamicItem {
             id: 127, xp: 511, metadata: 31
-            }, item_9: LootStatistics {
+            }, item_9: DynamicItem {
             id: 127, xp: 511, metadata: 31
-            }, item_10: LootStatistics {
+            }, item_10: DynamicItem {
             id: 127, xp: 511, metadata: 31
-            }, item_11: LootStatistics {
+            }, item_11: DynamicItem {
             id: 127, xp: 511, metadata: 31
             }
     };
@@ -341,32 +312,32 @@ fn test_pack_bag() {
 #[available_gas(5000000)]
 fn test_add_item() {
     let mut bag = Bag {
-        item_1: LootStatistics {
+        item_1: DynamicItem {
             id: 1, xp: 0, metadata: 0
-            }, item_2: LootStatistics {
+            }, item_2: DynamicItem {
             id: 2, xp: 0, metadata: 0
-            }, item_3: LootStatistics {
+            }, item_3: DynamicItem {
             id: 3, xp: 0, metadata: 0
-            }, item_4: LootStatistics {
+            }, item_4: DynamicItem {
             id: 4, xp: 0, metadata: 0
-            }, item_5: LootStatistics {
+            }, item_5: DynamicItem {
             id: 5, xp: 0, metadata: 0
-            }, item_6: LootStatistics {
+            }, item_6: DynamicItem {
             id: 0, xp: 0, metadata: 0
-            }, item_7: LootStatistics {
+            }, item_7: DynamicItem {
             id: 0, xp: 0, metadata: 0
-            }, item_8: LootStatistics {
+            }, item_8: DynamicItem {
             id: 0, xp: 0, metadata: 0
-            }, item_9: LootStatistics {
+            }, item_9: DynamicItem {
             id: 0, xp: 0, metadata: 0
-            }, item_10: LootStatistics {
+            }, item_10: DynamicItem {
             id: 0, xp: 0, metadata: 0
-            }, item_11: LootStatistics {
+            }, item_11: DynamicItem {
             id: 0, xp: 0, metadata: 0
             },
     };
 
-    let item = LootStatistics { id: 23, xp: 1, metadata: 5 };
+    let item = DynamicItem { id: 23, xp: 1, metadata: 5 };
 
     bag.add_item(item);
 
@@ -377,27 +348,27 @@ fn test_add_item() {
 #[available_gas(5000000)]
 fn test_is_full() {
     let mut bag = Bag {
-        item_1: LootStatistics {
+        item_1: DynamicItem {
             id: 1, xp: 0, metadata: 0
-            }, item_2: LootStatistics {
+            }, item_2: DynamicItem {
             id: 2, xp: 0, metadata: 0
-            }, item_3: LootStatistics {
+            }, item_3: DynamicItem {
             id: 3, xp: 0, metadata: 0
-            }, item_4: LootStatistics {
+            }, item_4: DynamicItem {
             id: 4, xp: 0, metadata: 0
-            }, item_5: LootStatistics {
+            }, item_5: DynamicItem {
             id: 5, xp: 0, metadata: 0
-            }, item_6: LootStatistics {
+            }, item_6: DynamicItem {
             id: 8, xp: 0, metadata: 0
-            }, item_7: LootStatistics {
+            }, item_7: DynamicItem {
             id: 9, xp: 0, metadata: 0
-            }, item_8: LootStatistics {
+            }, item_8: DynamicItem {
             id: 11, xp: 0, metadata: 0
-            }, item_9: LootStatistics {
+            }, item_9: DynamicItem {
             id: 12, xp: 0, metadata: 0
-            }, item_10: LootStatistics {
+            }, item_10: DynamicItem {
             id: 13, xp: 0, metadata: 0
-            }, item_11: LootStatistics {
+            }, item_11: DynamicItem {
             id: 14, xp: 0, metadata: 0
             },
     };
@@ -408,27 +379,27 @@ fn test_is_full() {
 #[available_gas(5000000)]
 fn remove_item() {
     let mut bag = Bag {
-        item_1: LootStatistics {
+        item_1: DynamicItem {
             id: 1, xp: 0, metadata: 0
-            }, item_2: LootStatistics {
+            }, item_2: DynamicItem {
             id: 2, xp: 0, metadata: 0
-            }, item_3: LootStatistics {
+            }, item_3: DynamicItem {
             id: 3, xp: 0, metadata: 0
-            }, item_4: LootStatistics {
+            }, item_4: DynamicItem {
             id: 4, xp: 0, metadata: 0
-            }, item_5: LootStatistics {
+            }, item_5: DynamicItem {
             id: 5, xp: 0, metadata: 0
-            }, item_6: LootStatistics {
+            }, item_6: DynamicItem {
             id: 8, xp: 0, metadata: 0
-            }, item_7: LootStatistics {
+            }, item_7: DynamicItem {
             id: 9, xp: 0, metadata: 0
-            }, item_8: LootStatistics {
+            }, item_8: DynamicItem {
             id: 11, xp: 0, metadata: 0
-            }, item_9: LootStatistics {
+            }, item_9: DynamicItem {
             id: 12, xp: 0, metadata: 0
-            }, item_10: LootStatistics {
+            }, item_10: DynamicItem {
             id: 13, xp: 0, metadata: 0
-            }, item_11: LootStatistics {
+            }, item_11: DynamicItem {
             id: 14, xp: 0, metadata: 0
             },
     };

--- a/contracts/adventurer/src/item_meta.cairo
+++ b/contracts/adventurer/src/item_meta.cairo
@@ -6,7 +6,8 @@ use pack::pack::{Packing, rshift_split};
 use pack::constants::pow;
 
 use super::adventurer::{Adventurer, IAdventurer, ImplAdventurer};
-use super::bag::{Bag, BagActions, LootStatistics};
+use super::bag::{Bag, BagActions};
+use lootitems::loot::DynamicItem;
 
 mod STORAGE {
     const INDEX_1: u8 = 1;
@@ -107,62 +108,39 @@ impl LootItemSpecialNamesStoragePacking of Packing<LootItemSpecialNamesStorage> 
             item_9: Packing::unpack(item_9.try_into().expect('unpack LISNS item_9')),
             item_10: Packing::unpack(item_10.try_into().expect('unpack LISNS item_10'))
         }
-        // LootItemSpecialNamesStorage {
-        //     item_1: LootItemSpecialNames {
-        //         name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-        //         }, item_2: LootItemSpecialNames {
-        //         name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-        //         }, item_3: LootItemSpecialNames {
-        //         name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-        //         }, item_4: LootItemSpecialNames {
-        //         name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-        //         }, item_5: LootItemSpecialNames {
-        //         name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-        //         }, item_6: LootItemSpecialNames {
-        //         name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-        //         }, item_7: LootItemSpecialNames {
-        //         name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-        //         }, item_8: LootItemSpecialNames {
-        //         name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-        //         }, item_9: LootItemSpecialNames {
-        //         name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-        //         }, item_10: LootItemSpecialNames {
-        //         name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-        //     }
-        // }
     }
 }
 
-// LootStatistics meta only is set once and is filled up as items are found
+// DynamicItem meta only is set once and is filled up as items are found
 // There is no swapping of positions
-// When an item is found we find the next available slot and set it on the LootStatistics NOT in the metadata -> this saves gas
+// When an item is found we find the next available slot and set it on the DynamicItem NOT in the metadata -> this saves gas
 // We only set the metadata when an item is upgraded
 trait ILootItemSpecialNames {
-    // takes LootStatistics and sets the metadata slot for that item
+    // takes DynamicItem and sets the metadata slot for that item
     // 1. Find highest slot from equipped and unequipped items
-    // 2. Return LootStatistics with slot which is then saved on the Adventurer/Bag
+    // 2. Return DynamicItem with slot which is then saved on the Adventurer/Bag
 
     // this could be somewhere else
     // this needs to be run when an item is found/purchased
     fn get_loot_special_names_slot(
-        adventurer: Adventurer, bag: Bag, loot_statistics: LootStatistics
-    ) -> LootStatistics;
+        adventurer: Adventurer, bag: Bag, loot_statistics: DynamicItem
+    ) -> DynamicItem;
 
     // on contract side we check if item.metadata > 10 if it is pass in second metadata storage
     fn set_loot_special_names(
         ref self: LootItemSpecialNamesStorage,
-        loot_statistics: LootStatistics,
+        loot_statistics: DynamicItem,
         loot_special_names: LootItemSpecialNames
     ) -> LootItemSpecialNamesStorage;
 
     fn get_loot_special_names(
-        self: LootItemSpecialNamesStorage, loot_statistics: LootStatistics
+        self: LootItemSpecialNamesStorage, loot_statistics: DynamicItem
     ) -> LootItemSpecialNames;
 }
 
 impl ImplLootItemSpecialNames of ILootItemSpecialNames {
     fn get_loot_special_names(
-        self: LootItemSpecialNamesStorage, loot_statistics: LootStatistics
+        self: LootItemSpecialNamesStorage, loot_statistics: DynamicItem
     ) -> LootItemSpecialNames {
         if loot_statistics.metadata == STORAGE::INDEX_1 {
             return self.item_1;
@@ -188,8 +166,8 @@ impl ImplLootItemSpecialNames of ILootItemSpecialNames {
     }
 
     fn get_loot_special_names_slot(
-        adventurer: Adventurer, bag: Bag, loot_statistics: LootStatistics
-    ) -> LootStatistics {
+        adventurer: Adventurer, bag: Bag, loot_statistics: DynamicItem
+    ) -> DynamicItem {
         // check slots
 
         let mut slot = 0;
@@ -255,14 +233,14 @@ impl ImplLootItemSpecialNames of ILootItemSpecialNames {
 
         // if no slots -> return first index which is 0
         if slot == 1 {
-            LootStatistics { id: loot_statistics.id, xp: loot_statistics.xp, metadata: 1 }
+            DynamicItem { id: loot_statistics.id, xp: loot_statistics.xp, metadata: 1 }
         } else {
-            LootStatistics { id: loot_statistics.id, xp: loot_statistics.xp, metadata: slot + 1 }
+            DynamicItem { id: loot_statistics.id, xp: loot_statistics.xp, metadata: slot + 1 }
         }
     }
     fn set_loot_special_names(
         ref self: LootItemSpecialNamesStorage,
-        loot_statistics: LootStatistics,
+        loot_statistics: DynamicItem,
         loot_special_names: LootItemSpecialNames
     ) -> LootItemSpecialNamesStorage {
         if loot_statistics.metadata == STORAGE::INDEX_1 {
@@ -376,10 +354,10 @@ fn test_get_item_metadata_slot() {
     let mut adventurer = ImplAdventurer::new(1, 1);
 
     // add test items
-    let item_pendant = LootStatistics { id: 1, xp: 1, metadata: 3 };
-    let item_silver_ring = LootStatistics { id: 4, xp: 1, metadata: 4 };
-    let item_ghost_wand = LootStatistics { id: 9, xp: 1, metadata: 5 };
-    let item_silk_robe = LootStatistics { id: 18, xp: 1, metadata: 6 };
+    let item_pendant = DynamicItem { id: 1, xp: 1, metadata: 3 };
+    let item_silver_ring = DynamicItem { id: 4, xp: 1, metadata: 4 };
+    let item_ghost_wand = DynamicItem { id: 9, xp: 1, metadata: 5 };
+    let item_silk_robe = DynamicItem { id: 18, xp: 1, metadata: 6 };
 
     adventurer.add_item(item_pendant);
     adventurer.add_item(item_silver_ring);
@@ -387,36 +365,36 @@ fn test_get_item_metadata_slot() {
     adventurer.add_item(item_silk_robe);
 
     let bag = Bag {
-        item_1: LootStatistics {
+        item_1: DynamicItem {
             id: 1, xp: 0, metadata: 4, 
-            }, item_2: LootStatistics {
+            }, item_2: DynamicItem {
             id: 2, xp: 0, metadata: 5, 
-            }, item_3: LootStatistics {
+            }, item_3: DynamicItem {
             id: 3, xp: 0, metadata: 6, 
-            }, item_4: LootStatistics {
+            }, item_4: DynamicItem {
             id: 4, xp: 0, metadata: 7, 
-            }, item_5: LootStatistics {
+            }, item_5: DynamicItem {
             id: 5, xp: 0, metadata: 8, 
-            }, item_6: LootStatistics {
+            }, item_6: DynamicItem {
             id: 6, xp: 0, metadata: 11, 
-            }, item_7: LootStatistics {
+            }, item_7: DynamicItem {
             id: 7, xp: 0, metadata: 0, 
-            }, item_8: LootStatistics {
+            }, item_8: DynamicItem {
             id: 8, xp: 0, metadata: 12, 
-            }, item_9: LootStatistics {
+            }, item_9: DynamicItem {
             id: 9, xp: 0, metadata: 0, 
-            }, item_10: LootStatistics {
+            }, item_10: DynamicItem {
             id: 10, xp: 0, metadata: 0, 
-            }, item_11: LootStatistics {
+            }, item_11: DynamicItem {
             id: 11, xp: 0, metadata: 18, 
         },
     };
 
-    let new_item = LootStatistics { id: 1, xp: 1, metadata: 0 };
+    let new_item = DynamicItem { id: 1, xp: 1, metadata: 0 };
 
     let item = ILootItemSpecialNames::get_loot_special_names_slot(adventurer, bag, new_item);
 
-    assert(item.metadata == 19, 'LootStatistics');
+    assert(item.metadata == 19, 'DynamicItem');
 }
 
 #[test]
@@ -446,7 +424,7 @@ fn test_set_item_metadata_slot() {
         }
     };
 
-    let loot_statistics_1 = LootStatistics { id: 102, xp: 0, metadata: 1 };
+    let loot_statistics_1 = DynamicItem { id: 102, xp: 0, metadata: 1 };
 
     let loot_special_names_2 = LootItemSpecialNames {
         name_prefix: 12, name_suffix: 11, item_suffix: 13
@@ -458,7 +436,7 @@ fn test_set_item_metadata_slot() {
     assert(item_meta_storage.item_1.name_suffix == 11, 'should be 11');
     assert(item_meta_storage.item_1.item_suffix == 13, 'should be 13');
 
-    let loot_statistics_2 = LootStatistics { id: 102, xp: 0, metadata: 2 };
+    let loot_statistics_2 = DynamicItem { id: 102, xp: 0, metadata: 2 };
 
     let loot_special_names_2 = LootItemSpecialNames {
         name_prefix: 12, name_suffix: 11, item_suffix: 13
@@ -473,16 +451,16 @@ fn test_set_item_metadata_slot() {
 #[test]
 #[available_gas(5000000)]
 fn test_get_item_metadata() {
-    let item_pendant = LootStatistics { id: 1, xp: 1, metadata: 1 };
-    let item_silver_ring = LootStatistics { id: 2, xp: 1, metadata: 2 };
-    let item_silk_robe = LootStatistics { id: 3, xp: 1, metadata: 3 };
-    let item_iron_sword = LootStatistics { id: 4, xp: 1, metadata: 4 };
-    let item_katana = LootStatistics { id: 5, xp: 1, metadata: 5 };
-    let item_falchion = LootStatistics { id: 6, xp: 1, metadata: 6 };
-    let item_leather_gloves = LootStatistics { id: 7, xp: 1, metadata: 7 };
-    let item_silk_gloves = LootStatistics { id: 8, xp: 1, metadata: 8 };
-    let item_linen_gloves = LootStatistics { id: 9, xp: 1, metadata: 9 };
-    let item_crown = LootStatistics { id: 10, xp: 1, metadata: 10 };
+    let item_pendant = DynamicItem { id: 1, xp: 1, metadata: 1 };
+    let item_silver_ring = DynamicItem { id: 2, xp: 1, metadata: 2 };
+    let item_silk_robe = DynamicItem { id: 3, xp: 1, metadata: 3 };
+    let item_iron_sword = DynamicItem { id: 4, xp: 1, metadata: 4 };
+    let item_katana = DynamicItem { id: 5, xp: 1, metadata: 5 };
+    let item_falchion = DynamicItem { id: 6, xp: 1, metadata: 6 };
+    let item_leather_gloves = DynamicItem { id: 7, xp: 1, metadata: 7 };
+    let item_silk_gloves = DynamicItem { id: 8, xp: 1, metadata: 8 };
+    let item_linen_gloves = DynamicItem { id: 9, xp: 1, metadata: 9 };
+    let item_crown = DynamicItem { id: 10, xp: 1, metadata: 10 };
 
     let mut item_meta_storage = LootItemSpecialNamesStorage {
         item_1: LootItemSpecialNames {

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -26,13 +26,13 @@ mod Game {
 
     use game::game::messages::messages;
     use lootitems::{
-        loot::{Loot, ImplLoot}, statistics::constants::{NamePrefixLength, NameSuffixLength}
+        loot::{ILoot, Loot, ImplLoot, DynamicItem}, statistics::constants::{NamePrefixLength, NameSuffixLength}
     };
     use pack::pack::Packing;
 
     use survivor::{
         adventurer::{Adventurer, ImplAdventurer, IAdventurer, Stats},
-        bag::{Bag, BagActions, ImplBagActions, LootStatistics}, adventurer_meta::AdventurerMetadata,
+        bag::{Bag, BagActions, ImplBagActions}, adventurer_meta::AdventurerMetadata,
         exploration::ExploreUtils,
         constants::{
             discovery_constants::DiscoveryEnums::{ExploreResult, TreasureDiscovery},
@@ -512,28 +512,28 @@ mod Game {
             _unpack_adventurer(self, adventurer_id).last_action
         }
         fn get_weapon_greatness(self: @ContractState, adventurer_id: u256) -> u8 {
-            ImplLoot::get_greatness_level(_unpack_adventurer(self, adventurer_id).weapon.xp)
+            _unpack_adventurer(self, adventurer_id).weapon.get_greatness()
         }
         fn get_chest_armor_greatness(self: @ContractState, adventurer_id: u256) -> u8 {
-            ImplLoot::get_greatness_level(_unpack_adventurer(self, adventurer_id).chest.xp)
+            _unpack_adventurer(self, adventurer_id).chest.get_greatness()
         }
         fn get_head_armor_greatness(self: @ContractState, adventurer_id: u256) -> u8 {
-            ImplLoot::get_greatness_level(_unpack_adventurer(self, adventurer_id).head.xp)
+            _unpack_adventurer(self, adventurer_id).head.get_greatness()
         }
         fn get_waist_armor_greatness(self: @ContractState, adventurer_id: u256) -> u8 {
-            ImplLoot::get_greatness_level(_unpack_adventurer(self, adventurer_id).waist.xp)
+            _unpack_adventurer(self, adventurer_id).waist.get_greatness()
         }
         fn get_foot_armor_greatness(self: @ContractState, adventurer_id: u256) -> u8 {
-            ImplLoot::get_greatness_level(_unpack_adventurer(self, adventurer_id).foot.xp)
+            _unpack_adventurer(self, adventurer_id).foot.get_greatness()
         }
         fn get_hand_armor_greatness(self: @ContractState, adventurer_id: u256) -> u8 {
-            ImplLoot::get_greatness_level(_unpack_adventurer(self, adventurer_id).hand.xp)
+            _unpack_adventurer(self, adventurer_id).hand.get_greatness()
         }
         fn get_necklace_greatness(self: @ContractState, adventurer_id: u256) -> u8 {
-            ImplLoot::get_greatness_level(_unpack_adventurer(self, adventurer_id).neck.xp)
+            _unpack_adventurer(self, adventurer_id).neck.get_greatness()
         }
         fn get_ring_greatness(self: @ContractState, adventurer_id: u256) -> u8 {
-            ImplLoot::get_greatness_level(_unpack_adventurer(self, adventurer_id).ring.xp)
+            _unpack_adventurer(self, adventurer_id).ring.get_greatness()
         }
         fn get_base_stats(self: @ContractState, adventurer_id: u256) -> Stats {
             _unpack_adventurer(self, adventurer_id).stats
@@ -1156,7 +1156,7 @@ mod Game {
     // @param self A reference to the ContractState. This function requires mutable access to the ContractState to update the specified item's XP.
     // @param adventurer_id The unique identifier for the adventurer who owns the item.
     // @param adventurer A reference to the Adventurer object. This object represents the adventurer who owns the item.
-    // @param item A reference to the LootStatistics object. This object represents the item to which XP will be granted.
+    // @param item A reference to the DynamicItem object. This object represents the item to which XP will be granted.
     // @param amount The amount of experience points to be added to the item before applying the item XP multiplier.
     // @param name_storage1 A reference to the LootItemSpecialNamesStorage object. This object stores the special names for items that an adventurer may possess.
     // @param name_storage2 A reference to the LootItemSpecialNamesStorage object. This object stores the special names for items that an adventurer may possess.
@@ -1170,7 +1170,7 @@ mod Game {
         ref self: ContractState,
         adventurer_id: u256,
         ref adventurer: Adventurer,
-        ref item: LootStatistics,
+        ref item: DynamicItem,
         xp_increase: u16,
         ref name_storage1: LootItemSpecialNamesStorage,
         ref name_storage2: LootItemSpecialNamesStorage,
@@ -1496,7 +1496,7 @@ mod Game {
 
         // check what item type exists on adventurer
         // if some exists pluck from adventurer and add to bag
-        let mut unequipping_item = LootStatistics { id: 0, xp: 0, metadata: 0 };
+        let mut unequipping_item = DynamicItem { id: 0, xp: 0, metadata: 0 };
         if adventurer.is_slot_free(equipping_item) == false {
             let unequipping_item = adventurer
                 .get_item_at_slot(ImplLoot::get_slot(equipping_item.id));
@@ -1818,7 +1818,7 @@ mod Game {
         Packing::unpack(self._loot_special_names.read((adventurer_id, storage_index)))
     }
 
-    fn _get_special_names(self: @ContractState, adventurer_id: u256, item: LootStatistics) -> LootItemSpecialNames {
+    fn _get_special_names(self: @ContractState, adventurer_id: u256, item: DynamicItem) -> LootItemSpecialNames {
         ImplLootItemSpecialNames::get_loot_special_names(
             _loot_special_names_storage_unpacked(
                 self, adventurer_id, _get_storage_index(self, item.metadata)
@@ -1965,17 +1965,17 @@ mod Game {
     // _get_combat_spec returns the combat spec of an item
     // as part of this we get the item details from the loot description
     fn _get_combat_spec(
-        self: @ContractState, adventurer_id: u256, item: LootStatistics
+        self: @ContractState, adventurer_id: u256, item: DynamicItem
     ) -> CombatSpec {
         // get the greatness of the item
-        let item_greatness = ImplLoot::get_greatness_level(item.xp);
+        let item_greatness = item.get_greatness();
 
         // if it's less than 15, no need to fetch the special names it doesn't have them
         if (item_greatness < 15) {
             return CombatSpec {
                 tier: ImplLoot::get_tier(item.id),
                 item_type: ImplLoot::get_type(item.id),
-                level: U8IntoU16::into(ImplLoot::get_greatness_level(item.xp)),
+                level: U8IntoU16::into(item.get_greatness()),
                 special_powers: SpecialPowers {
                     prefix1: 0, prefix2: 0, suffix: 0
                 }
@@ -1992,7 +1992,7 @@ mod Game {
             return CombatSpec {
                 tier: ImplLoot::get_tier(item.id),
                 item_type: ImplLoot::get_type(item.id),
-                level: U8IntoU16::into(ImplLoot::get_greatness_level(item.xp)),
+                level: U8IntoU16::into(item.get_greatness()),
                 special_powers: SpecialPowers {
                     prefix1: item_details.name_prefix,
                     prefix2: item_details.name_suffix,

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -687,7 +687,7 @@ mod tests {
         let mut game = new_adventurer();
         let adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(
-            ImplLoot::get_greatness_level(adventurer.weapon.xp) == game
+            adventurer.weapon.get_greatness() == game
                 .get_weapon_greatness(ADVENTURER_ID),
             'wrong weapon greatness'
         );
@@ -698,7 +698,7 @@ mod tests {
         let mut game = new_adventurer();
         let adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(
-            ImplLoot::get_greatness_level(adventurer.chest.xp) == game
+            adventurer.chest.get_greatness() == game
                 .get_chest_armor_greatness(ADVENTURER_ID),
             'wrong chest greatness'
         );
@@ -709,7 +709,7 @@ mod tests {
         let mut game = new_adventurer();
         let adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(
-            ImplLoot::get_greatness_level(adventurer.head.xp) == game
+            adventurer.head.get_greatness() == game
                 .get_head_armor_greatness(ADVENTURER_ID),
             'wrong head greatness'
         );
@@ -720,7 +720,7 @@ mod tests {
         let mut game = new_adventurer();
         let adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(
-            ImplLoot::get_greatness_level(adventurer.waist.xp) == game
+            adventurer.waist.get_greatness() == game
                 .get_waist_armor_greatness(ADVENTURER_ID),
             'wrong waist greatness'
         );
@@ -731,7 +731,7 @@ mod tests {
         let mut game = new_adventurer();
         let adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(
-            ImplLoot::get_greatness_level(adventurer.foot.xp) == game
+            adventurer.foot.get_greatness() == game
                 .get_foot_armor_greatness(ADVENTURER_ID),
             'wrong foot greatness'
         );
@@ -742,7 +742,7 @@ mod tests {
         let mut game = new_adventurer();
         let adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(
-            ImplLoot::get_greatness_level(adventurer.hand.xp) == game
+            adventurer.hand.get_greatness() == game
                 .get_hand_armor_greatness(ADVENTURER_ID),
             'wrong hand greatness'
         );
@@ -753,7 +753,7 @@ mod tests {
         let mut game = new_adventurer();
         let adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(
-            ImplLoot::get_greatness_level(adventurer.neck.xp) == game
+            adventurer.neck.get_greatness() == game
                 .get_necklace_greatness(ADVENTURER_ID),
             'wrong neck greatness'
         );
@@ -764,7 +764,7 @@ mod tests {
         let mut game = new_adventurer();
         let adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(
-            ImplLoot::get_greatness_level(adventurer.ring.xp) == game
+            adventurer.ring.get_greatness() == game
                 .get_ring_greatness(ADVENTURER_ID),
             'wrong ring greatness'
         );

--- a/contracts/loot/src/loot.cairo
+++ b/contracts/loot/src/loot.cairo
@@ -21,6 +21,36 @@ use super::{
 use combat::{combat::ImplCombat, constants::CombatEnums::{Type, Tier, Slot}};
 use pack::{pack::{Packing, rshift_split}, constants::pow};
 
+#[derive(Drop, Copy, Serde)] // 21 bits
+struct DynamicItem {
+    id: u8, // 7 bits
+    xp: u16, // 9 bits
+    // this is set as the items are found/purchased
+    metadata: u8, // 5 bits
+}
+
+impl DynamicItemPacking of Packing<DynamicItem> {
+    fn pack(self: DynamicItem) -> felt252 {
+        (self.id.into()
+         + self.xp.into() * pow::TWO_POW_7
+         + self.metadata.into() * pow::TWO_POW_16
+        ).try_into().expect('pack DynamicItem')
+    }
+
+    fn unpack(packed: felt252) -> DynamicItem {
+        let packed = packed.into();
+        let (packed, id) = rshift_split(packed, pow::TWO_POW_7);
+        let (packed, xp) = rshift_split(packed, pow::TWO_POW_9);
+        let (_, metadata) = rshift_split(packed, pow::TWO_POW_5);
+
+        DynamicItem {
+            id: id.try_into().expect('unpack DynamicItem id'),
+            xp: xp.try_into().expect('unpack DynamicItem xp'),
+            metadata: metadata.try_into().expect('unpack DynamicItem metadata')
+        }
+    }
+}
+
 #[derive(Copy, Drop, Clone, Serde)]
 struct Loot {
     id: u8,
@@ -122,22 +152,22 @@ impl ImplLoot of ILoot {
         }
     }
 
-    // get_greatness_level returns the greatness level of an item based on xp
+    // get_greatness returns the greatness level of an item based on xp
     // @param xp The xp of the item.
     // @return The greatness level of the item.
-    fn get_greatness_level(xp: u16) -> u8 {
+    fn get_greatness(self: DynamicItem) -> u8 {
         // use combat lib to determine the level but give items a bonus based
         // on the item level multiplier setting (currently 4) which means
         // items will level up 4x faster than entities without a multplier
         // such as adventurers
-        let level = ImplCombat::get_level_from_xp(xp);
+        let level = ImplCombat::get_level_from_xp(self.xp);
 
         // if level exceeds max greatness
         if level > ITEM_MAX_GREATNESS {
             // return max greatness
-            return ITEM_MAX_GREATNESS;
+            ITEM_MAX_GREATNESS
         } else {
-            return level;
+            level
         }
     }
 }

--- a/contracts/loot/src/statistics/constants.cairo
+++ b/contracts/loot/src/statistics/constants.cairo
@@ -109,7 +109,7 @@ mod ItemId {
     const HeavyGloves: u8 = 101;
 }
 
-// LootStatistics Slot Length
+// DynamicItem Slot Length
 mod ItemSlotLength {
     const SlotItemsLengthWeapon: u8 = 18;
     const SlotItemsLengthChest: u8 = 15;


### PR DESCRIPTION
- rename to DynamicItem to be more descriptive
- rename get_greatness_level() to get_greatness()
- modify get_greatness() to use self for cleaner client code