### PR TITLE
during multi-level, rotate market after each stat upgrade

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -154,7 +154,7 @@ impl AdventurerPacking of Packing<Adventurer> {
 impl ImplAdventurer of IAdventurer {
     fn get_market_entropy(self: Adventurer, adventurer_id: u256) -> u64 {
         // TODO: check potential overflow
-        ((self.xp.into() + 1) * pow::TWO_POW_9 * adventurer_id)
+        ((self.xp.into() + 1 + self.stat_points_available.into()) * pow::TWO_POW_9 * adventurer_id)
             .try_into()
             .expect('get_market_entropy')
     }

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -69,12 +69,6 @@ mod tests {
         game
     }
 
-    fn adventurer_market_items() -> Array<LootWithPrice> {
-        let mut game = new_adventurer();
-
-        game.get_items_on_market(ADVENTURER_ID)
-    }
-
     fn lvl_2_adventurer() -> IGameDispatcher {
         let mut game = new_adventurer();
 
@@ -332,7 +326,7 @@ mod tests {
     #[available_gas(65000000)]
     fn test_buy_and_bag_item() {
         let mut game = lvl_2_adventurer();
-        let market_items = @adventurer_market_items();
+        let market_items = @game.get_items_on_market(ADVENTURER_ID);
 
         game.buy_item(ADVENTURER_ID, *market_items.at(0).item.id, false);
 
@@ -345,7 +339,7 @@ mod tests {
     #[available_gas(4000000000)]
     fn test_equip_item_from_bag() {
         let mut game = lvl_2_adventurer();
-        let market_items = @adventurer_market_items();
+        let market_items = @game.get_items_on_market(ADVENTURER_ID);
 
         market_items.at(0).item.id;
 


### PR DESCRIPTION
Currently if you multi-level and have multiple stat points available, the market will stay fixed after spending a stat.

To fix this, we add adventurers available stat upgrades to the entropy