### PR TITLE
reduce item & advntr leveling speed and general cleanup

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -2,7 +2,6 @@ use core::result::ResultTrait;
 use integer::{u8_overflowing_add, u16_overflowing_add, u16_overflowing_sub};
 use traits::{TryInto, Into};
 use option::OptionTrait;
-use debug::PrintTrait;
 use poseidon::poseidon_hash_span;
 use array::ArrayTrait;
 

--- a/contracts/adventurer/src/constants/adventurer_constants.cairo
+++ b/contracts/adventurer/src/constants/adventurer_constants.cairo
@@ -20,7 +20,7 @@ const MAX_XP: u16 = 8191; // 2^13 - 1
 const MAX_ADVENTURER_BLOCKS: u16 = 512; // 2^9
 
 // controls how much faster items level up compared to the player
-const ITEM_XP_MULTIPLIER: u16 = 4;
+const ITEM_XP_MULTIPLIER: u16 = 3;
 const ITEM_MAX_GREATNESS: u8 = 20;
 
 mod StatisticIndex {

--- a/contracts/adventurer/src/exploration.cairo
+++ b/contracts/adventurer/src/exploration.cairo
@@ -1,19 +1,15 @@
 use core::option::OptionTrait;
 use core::traits::Into;
-use survivor::adventurer::{Adventurer, ImplAdventurer};
-use survivor::constants::discovery_constants::{
-    DiscoveryEnums::TreasureDiscovery, DiscoveryEnums::ExploreResult
+use integer::{U8IntoU128, U128TryIntoU16};
+
+use survivor::{
+    adventurer::{Adventurer, ImplAdventurer},
+    constants::discovery_constants::{
+        DiscoveryEnums::TreasureDiscovery, DiscoveryEnums::ExploreResult
+    }
 };
-use integer::{U8IntoU64, U64TryIntoU16, U8IntoU128, U128TryIntoU16};
 
-trait Explore {
-    fn get_random_treasury_discovery(adventurer: Adventurer, entropy: u128) -> TreasureDiscovery;
-    fn get_level_adjusted_discovery_amount(adventurer: Adventurer, entropy: u128) -> u16;
-    fn get_gold_discovery(adventurer: Adventurer, entropy: u128) -> u16;
-    fn get_health_discovery(adventurer: Adventurer, entropy: u128) -> u16;
-    fn get_xp_discovery(adventurer: Adventurer, entropy: u128) -> u16;
-}
-
+#[generate_trait]
 impl ExploreUtils of Explore {
     // get_random_treasury_discovery returns a random number between 0 and 3 based on provided entropy
     // @param adventurer: Adventurer

--- a/contracts/adventurer/src/item_meta.cairo
+++ b/contracts/adventurer/src/item_meta.cairo
@@ -1,5 +1,4 @@
 use core::serde::Serde;
-use debug::PrintTrait;
 use traits::{TryInto, Into};
 use option::OptionTrait;
 use integer::{U256TryIntoU32, U256TryIntoU16, U256TryIntoU8};
@@ -111,33 +110,7 @@ impl LootItemSpecialNamesStoragePacking of Packing<LootItemSpecialNamesStorage> 
     }
 }
 
-// ItemPrimitive meta only is set once and is filled up as items are found
-// There is no swapping of positions
-// When an item is found we find the next available slot and set it on the ItemPrimitive NOT in the metadata -> this saves gas
-// We only set the metadata when an item is upgraded
-trait ILootItemSpecialNames {
-    // takes ItemPrimitive and sets the metadata slot for that item
-    // 1. Find highest slot from equipped and unequipped items
-    // 2. Return ItemPrimitive with slot which is then saved on the Adventurer/Bag
-
-    // this could be somewhere else
-    // this needs to be run when an item is found/purchased
-    fn get_loot_special_names_slot(
-        adventurer: Adventurer, bag: Bag, loot_statistics: ItemPrimitive
-    ) -> ItemPrimitive;
-
-    // on contract side we check if item.metadata > 10 if it is pass in second metadata storage
-    fn set_loot_special_names(
-        ref self: LootItemSpecialNamesStorage,
-        loot_statistics: ItemPrimitive,
-        loot_special_names: LootItemSpecialNames
-    );
-
-    fn get_loot_special_names(
-        self: LootItemSpecialNamesStorage, loot_statistics: ItemPrimitive
-    ) -> LootItemSpecialNames;
-}
-
+#[generate_trait]
 impl ImplLootItemSpecialNames of ILootItemSpecialNames {
     fn get_loot_special_names(
         self: LootItemSpecialNamesStorage, loot_statistics: ItemPrimitive

--- a/contracts/adventurer/src/item_primitive.cairo
+++ b/contracts/adventurer/src/item_primitive.cairo
@@ -1,7 +1,6 @@
 use option::OptionTrait;
 use traits::{TryInto, Into};
 use pack::{pack::{Packing, rshift_split}, constants::pow};
-use debug::PrintTrait;
 
 #[derive(Drop, Copy, PartialEq, Serde)] // 21 bits
 struct ItemPrimitive {

--- a/contracts/beasts/src/beast.cairo
+++ b/contracts/beasts/src/beast.cairo
@@ -5,10 +5,28 @@ use integer::{
 };
 use traits::{TryInto, Into};
 use option::OptionTrait;
-use debug::PrintTrait;
-use super::constants::{BeastId, BeastSettings};
-use combat::constants::{CombatSettings, CombatEnums::{Type, Tier, Slot}};
-use combat::combat::{ImplCombat, CombatSpec, SpecialPowers};
+use super::constants::{BeastId::
+    {
+        Warlock, Typhon, Jiangshi, Anansi, Basilisk, Gorgon, Kitsune, Lich, Chimera, Wendigo,
+        Rakshasa, Werewolf, Banshee, Draugr, Vampire, Goblin, Ghoul, Wraith, Sprite, Kappa, Fairy,
+        Leprechaun, Kelpie, Pixie, Gnome, Griffin, Manticore, Phoenix, Dragon, Minotaur, Qilin,
+        Ammit, Nue, Skinwalker, Chupacabra, Weretiger, Wyvern, Roc, Harpy, Pegasus, Hippogriff,
+        Fenrir, Jaguar, Satori, DireWolf, Bear, Wolf, Mantis, Spider, Rat, Kraken, Colossus, Balrog,
+        Leviathan, Tarrasque, Titan, Nephilim, Behemoth, Hydra, Juggernaut, Oni, Jotunn, Ettin,
+        Cyclops, Giant, NemeanLion, Berserker, Yeti, Golem, Ent, Troll, Bigfoot, Ogre, Orc,
+        Skeleton, MAX_ID
+    },
+    BeastSettings::{
+        STARTER_BEAST_HEALTH, MINIMUM_HEALTH, BEAST_SPECIAL_NAME_UNLOCK_LEVEL, MINIMUM_DAMAGE,
+        STRENGTH_BONUS, MINIMUM_XP_REWARD, GOLD_REWARD_BASE_MINIMUM, GOLD_BASE_REWARD_DIVISOR,
+        GOLD_REWARD_BONUS_DIVISOR, GOLD_REWARD_BONUS_MAX_MULTPLIER
+    }
+};
+
+use combat::{
+    constants::{CombatSettings, CombatEnums::{Type, Tier, Slot}},
+    combat::{ICombat, ImplCombat, CombatSpec, SpecialPowers}
+};
 
 #[derive(Drop, Copy, Serde)] // 24 bits
 struct Beast {
@@ -17,34 +35,7 @@ struct Beast {
     combat_spec: CombatSpec, // Combat Spec
 }
 
-trait IBeast {
-    fn get_beast(adventurer_level: u8, special_names: SpecialPowers, seed: u128) -> Beast;
-    fn get_starter_beast(starter_weapon_type: Type) -> Beast;
-    fn attack(
-        self: Beast, weapon: CombatSpec, adventurer_luck: u8, adventurer_strength: u8, entropy: u128
-    ) -> u16;
-    fn beast_encounter(
-        adventurer_level: u8,
-        adventurer_wisdom: u8,
-        special1_size: u8,
-        special2_size: u8,
-        battle_fixed_seed: u128
-    ) -> (Beast, bool);
-    fn counter_attack(self: Beast, armor: CombatSpec, entropy: u128) -> u16;
-    fn ambush(adventurer_level: u8, adventurer_wisdom: u8, battle_fixed_entropy: u128) -> bool;
-    fn attempt_flee(adventurer_level: u8, adventurer_dexterity: u8, entropy: u128) -> bool;
-    fn get_level(adventurer_level: u8, seed: u128) -> u8;
-    fn get_starting_health(adventurer_level: u8, entropy: u128) -> u16;
-    fn get_special_names(
-        adventurer_level: u8, seed: u128, prefix1_size: u128, prefix2_size: u128
-    ) -> SpecialPowers;
-    fn get_beast_id(seed: u128) -> u8;
-    fn get_xp_reward(self: Beast) -> u16;
-    fn get_gold_reward(self: Beast, entropy: u128) -> u16;
-    fn get_tier(id: u8) -> Tier;
-    fn get_type(id: u8) -> Type;
-}
-
+#[generate_trait]
 impl ImplBeast of IBeast {
     fn get_beast(adventurer_level: u8, special_names: SpecialPowers, seed: u128) -> Beast {
         let beast_id = ImplBeast::get_beast_id(seed);
@@ -66,25 +57,23 @@ impl ImplBeast of IBeast {
     // @param starter_weapon_type: the type of weapon the adventurer starts with
     // @return: a beast that is weak against the weapon type
     fn get_starter_beast(starter_weapon_type: Type) -> Beast {
-        let mut beast_id: u8 = BeastId::Gnome;
+        let mut beast_id: u8 = Gnome;
 
         match starter_weapon_type {
             // if adventurer starts with a magical weapon, they face a troll as their first beast
-            Type::Magic_or_Cloth(()) => beast_id = BeastId::Troll,
+            Type::Magic_or_Cloth(()) => beast_id = Troll,
             // if the adventurer starts with a blade or hide weapon, they face a rat as their first beast
-            Type::Blade_or_Hide(()) => beast_id = BeastId::Gnome,
+            Type::Blade_or_Hide(()) => beast_id = Gnome,
             // if the adventurer starts with a bludgeon or metal weapon, they face a troll as their first beast
-            Type::Bludgeon_or_Metal(()) => beast_id = BeastId::Rat,
+            Type::Bludgeon_or_Metal(()) => beast_id = Rat,
             // starter weapon should never be a necklace or ring
             // but cairo needs us to define all cases so just default to troll
-            Type::Necklace(()) => beast_id = BeastId::Troll,
-            Type::Ring(()) => beast_id = BeastId::Troll,
+            Type::Necklace(()) => beast_id = Troll,
+            Type::Ring(()) => beast_id = Troll,
         }
 
         return Beast {
-            id: beast_id,
-            starting_health: BeastSettings::STARTER_BEAST_HEALTH,
-            combat_spec: CombatSpec {
+            id: beast_id, starting_health: STARTER_BEAST_HEALTH, combat_spec: CombatSpec {
                 tier: ImplBeast::get_tier(beast_id),
                 item_type: ImplBeast::get_type(beast_id),
                 level: 1,
@@ -133,7 +122,7 @@ impl ImplBeast of IBeast {
         // The value of this is an adventurer can battle
         // the same beast across multiple contract calls
         // without having to pay for gas to store the beast
-        let beast_id = (seed % BeastId::MAX_ID) + 1;
+        let beast_id = (seed % MAX_ID) + 1;
 
         // return beast id as a u8
         return U128TryIntoU8::try_into(beast_id).unwrap();
@@ -145,7 +134,7 @@ impl ImplBeast of IBeast {
         // which control when and how quickly beasts health increases
         ImplCombat::get_enemy_starting_health(
             adventurer_level,
-            BeastSettings::MINIMUM_HEALTH,
+            MINIMUM_HEALTH,
             entropy,
             CombatSettings::DIFFICULTY_CLIFF::NORMAL,
             CombatSettings::HEALTH_MULTIPLIER::NORMAL
@@ -156,7 +145,7 @@ impl ImplBeast of IBeast {
         adventurer_level: u8, seed: u128, prefix1_size: u128, prefix2_size: u128
     ) -> SpecialPowers {
         // if adventurer is below level 10, beasts don't get any special powers
-        if (adventurer_level < BeastSettings::BEAST_SPECIAL_NAME_UNLOCK_LEVEL) {
+        if (adventurer_level < BEAST_SPECIAL_NAME_UNLOCK_LEVEL) {
             SpecialPowers { prefix1: 0, prefix2: 0, suffix: 0 }
         } else {
             let beast_prefix1 = U128TryIntoU8::try_into(seed % prefix1_size).unwrap();
@@ -196,7 +185,7 @@ impl ImplBeast of IBeast {
         return ImplCombat::calculate_damage(
             weapon,
             self.combat_spec,
-            BeastSettings::MINIMUM_DAMAGE,
+            MINIMUM_DAMAGE,
             U8IntoU16::into(adventurer_strength),
             is_critical_hit,
             entropy
@@ -214,12 +203,7 @@ impl ImplBeast of IBeast {
 
         // delegate damage calculation to combat system
         return ImplCombat::calculate_damage(
-            self.combat_spec,
-            armor,
-            BeastSettings::MINIMUM_DAMAGE,
-            BeastSettings::STRENGTH_BONUS,
-            is_critical_hit,
-            entropy
+            self.combat_spec, armor, MINIMUM_DAMAGE, STRENGTH_BONUS, is_critical_hit, entropy
         );
     }
 
@@ -253,9 +237,9 @@ impl ImplBeast of IBeast {
     // @param beast: the beast being defeated
     // @return: the xp reward for defeating the beast
     fn get_xp_reward(self: Beast) -> u16 {
-        let xp_reward = ImplCombat::get_xp_reward(self.combat_spec);
-        if (xp_reward < BeastSettings::XP_REWARD_MINIMUM) {
-            return BeastSettings::XP_REWARD_MINIMUM;
+        let xp_reward = self.combat_spec.get_xp_reward();
+        if (xp_reward < MINIMUM_XP_REWARD) {
+            return MINIMUM_XP_REWARD;
         } else {
             return xp_reward;
         }
@@ -263,19 +247,18 @@ impl ImplBeast of IBeast {
 
     fn get_gold_reward(self: Beast, entropy: u128) -> u16 {
         // base for the gold reward is XP which uses beast tier and level
-        let mut base_reward = ImplCombat::get_xp_reward(self.combat_spec)
-            / BeastSettings::GOLD_REWARD_DIVISOR;
-        if (base_reward < BeastSettings::GOLD_REWARD_BASE_MINIMUM) {
-            base_reward = BeastSettings::GOLD_REWARD_BASE_MINIMUM;
+        let mut base_reward = self.combat_spec.get_xp_reward() / GOLD_BASE_REWARD_DIVISOR;
+        if (base_reward < GOLD_REWARD_BASE_MINIMUM) {
+            base_reward = GOLD_REWARD_BASE_MINIMUM;
         }
 
         // gold bonus will be based on 10% increments
-        let bonus_base = base_reward / BeastSettings::GOLD_REWARD_BONUS_DIVISOR;
+        let bonus_base = base_reward / GOLD_REWARD_BONUS_DIVISOR;
 
         // multiplier will be 0-10 inclusive, providing
         // a maximum gold bonus of 100%
         let bonus_multiplier = U128TryIntoU16::try_into(
-            entropy % (1 + BeastSettings::GOLD_REWARD_BONUS_MAX_MULTPLIER)
+            entropy % (1 + GOLD_REWARD_BONUS_MAX_MULTPLIER)
         )
             .unwrap();
 
@@ -284,83 +267,83 @@ impl ImplBeast of IBeast {
     }
 
     fn get_type(id: u8) -> Type {
-        if id == BeastId::Warlock
-            || id == BeastId::Typhon
-            || id == BeastId::Jiangshi
-            || id == BeastId::Anansi
-            || id == BeastId::Basilisk
-            || id == BeastId::Gorgon
-            || id == BeastId::Kitsune
-            || id == BeastId::Lich
-            || id == BeastId::Chimera
-            || id == BeastId::Wendigo
-            || id == BeastId::Rakshasa
-            || id == BeastId::Werewolf
-            || id == BeastId::Banshee
-            || id == BeastId::Draugr
-            || id == BeastId::Vampire
-            || id == BeastId::Goblin
-            || id == BeastId::Ghoul
-            || id == BeastId::Wraith
-            || id == BeastId::Sprite
-            || id == BeastId::Kappa
-            || id == BeastId::Fairy
-            || id == BeastId::Leprechaun
-            || id == BeastId::Kelpie
-            || id == BeastId::Pixie
-            || id == BeastId::Gnome {
+        if id == Warlock
+            || id == Typhon
+            || id == Jiangshi
+            || id == Anansi
+            || id == Basilisk
+            || id == Gorgon
+            || id == Kitsune
+            || id == Lich
+            || id == Chimera
+            || id == Wendigo
+            || id == Rakshasa
+            || id == Werewolf
+            || id == Banshee
+            || id == Draugr
+            || id == Vampire
+            || id == Goblin
+            || id == Ghoul
+            || id == Wraith
+            || id == Sprite
+            || id == Kappa
+            || id == Fairy
+            || id == Leprechaun
+            || id == Kelpie
+            || id == Pixie
+            || id == Gnome {
             return Type::Magic_or_Cloth(());
-        } else if id == BeastId::Griffin
-            || id == BeastId::Manticore
-            || id == BeastId::Phoenix
-            || id == BeastId::Dragon
-            || id == BeastId::Minotaur
-            || id == BeastId::Qilin
-            || id == BeastId::Ammit
-            || id == BeastId::Nue
-            || id == BeastId::Skinwalker
-            || id == BeastId::Chupacabra
-            || id == BeastId::Weretiger
-            || id == BeastId::Wyvern
-            || id == BeastId::Roc
-            || id == BeastId::Harpy
-            || id == BeastId::Pegasus
-            || id == BeastId::Hippogriff
-            || id == BeastId::Fenrir
-            || id == BeastId::Jaguar
-            || id == BeastId::Satori
-            || id == BeastId::DireWolf
-            || id == BeastId::Bear
-            || id == BeastId::Wolf
-            || id == BeastId::Mantis
-            || id == BeastId::Spider
-            || id == BeastId::Rat {
+        } else if id == Griffin
+            || id == Manticore
+            || id == Phoenix
+            || id == Dragon
+            || id == Minotaur
+            || id == Qilin
+            || id == Ammit
+            || id == Nue
+            || id == Skinwalker
+            || id == Chupacabra
+            || id == Weretiger
+            || id == Wyvern
+            || id == Roc
+            || id == Harpy
+            || id == Pegasus
+            || id == Hippogriff
+            || id == Fenrir
+            || id == Jaguar
+            || id == Satori
+            || id == DireWolf
+            || id == Bear
+            || id == Wolf
+            || id == Mantis
+            || id == Spider
+            || id == Rat {
             return Type::Blade_or_Hide(());
-        } else if id == BeastId::Kraken
-            || id == BeastId::Colossus
-            || id == BeastId::Balrog
-            || id == BeastId::Leviathan
-            || id == BeastId::Tarrasque
-            || id == BeastId::Titan
-            || id == BeastId::Nephilim
-            || id == BeastId::Behemoth
-            || id == BeastId::Hydra
-            || id == BeastId::Juggernaut
-            || id == BeastId::Oni
-            || id == BeastId::Jotunn
-            || id == BeastId::Ettin
-            || id == BeastId::Cyclops
-            || id == BeastId::Giant
-            || id == BeastId::NemeanLion
-            || id == BeastId::Berserker
-            || id == BeastId::Yeti
-            || id == BeastId::Golem
-            || id == BeastId::Ent
-            || id == BeastId::Troll
-            || id == BeastId::Bigfoot
-            || id == BeastId::Ogre
-            || id == BeastId::Orc
-            || id == BeastId::Skeleton {
+        } else if id == Kraken
+            || id == Colossus
+            || id == Balrog
+            || id == Leviathan
+            || id == Tarrasque
+            || id == Titan
+            || id == Nephilim
+            || id == Behemoth
+            || id == Hydra
+            || id == Juggernaut
+            || id == Oni
+            || id == Jotunn
+            || id == Ettin
+            || id == Cyclops
+            || id == Giant
+            || id == NemeanLion
+            || id == Berserker
+            || id == Yeti
+            || id == Golem
+            || id == Ent
+            || id == Troll
+            || id == Bigfoot
+            || id == Ogre
+            || id == Orc
+            || id == Skeleton {
             return Type::Bludgeon_or_Metal(());
         }
         // unknown id gets type bludgeon/metal
@@ -368,85 +351,85 @@ impl ImplBeast of IBeast {
     }
 
     fn get_tier(id: u8) -> Tier {
-        if id == BeastId::Warlock
-            || id == BeastId::Typhon
-            || id == BeastId::Jiangshi
-            || id == BeastId::Anansi
-            || id == BeastId::Basilisk
-            || id == BeastId::Griffin
-            || id == BeastId::Manticore
-            || id == BeastId::Phoenix
-            || id == BeastId::Dragon
-            || id == BeastId::Minotaur
-            || id == BeastId::Kraken
-            || id == BeastId::Colossus
-            || id == BeastId::Balrog
-            || id == BeastId::Leviathan
-            || id == BeastId::Tarrasque {
+        if id == Warlock
+            || id == Typhon
+            || id == Jiangshi
+            || id == Anansi
+            || id == Basilisk
+            || id == Griffin
+            || id == Manticore
+            || id == Phoenix
+            || id == Dragon
+            || id == Minotaur
+            || id == Kraken
+            || id == Colossus
+            || id == Balrog
+            || id == Leviathan
+            || id == Tarrasque {
             return Tier::T1(());
-        } else if id == BeastId::Gorgon
-            || id == BeastId::Kitsune
-            || id == BeastId::Lich
-            || id == BeastId::Chimera
-            || id == BeastId::Wendigo
-            || id == BeastId::Qilin
-            || id == BeastId::Ammit
-            || id == BeastId::Nue
-            || id == BeastId::Skinwalker
-            || id == BeastId::Chupacabra
-            || id == BeastId::Titan
-            || id == BeastId::Nephilim
-            || id == BeastId::Behemoth
-            || id == BeastId::Hydra
-            || id == BeastId::Juggernaut {
+        } else if id == Gorgon
+            || id == Kitsune
+            || id == Lich
+            || id == Chimera
+            || id == Wendigo
+            || id == Qilin
+            || id == Ammit
+            || id == Nue
+            || id == Skinwalker
+            || id == Chupacabra
+            || id == Titan
+            || id == Nephilim
+            || id == Behemoth
+            || id == Hydra
+            || id == Juggernaut {
             return Tier::T2(());
-        } else if id == BeastId::Rakshasa
-            || id == BeastId::Werewolf
-            || id == BeastId::Banshee
-            || id == BeastId::Draugr
-            || id == BeastId::Vampire
-            || id == BeastId::Weretiger
-            || id == BeastId::Wyvern
-            || id == BeastId::Roc
-            || id == BeastId::Harpy
-            || id == BeastId::Pegasus
-            || id == BeastId::Oni
-            || id == BeastId::Jotunn
-            || id == BeastId::Ettin
-            || id == BeastId::Cyclops
-            || id == BeastId::Giant {
+        } else if id == Rakshasa
+            || id == Werewolf
+            || id == Banshee
+            || id == Draugr
+            || id == Vampire
+            || id == Weretiger
+            || id == Wyvern
+            || id == Roc
+            || id == Harpy
+            || id == Pegasus
+            || id == Oni
+            || id == Jotunn
+            || id == Ettin
+            || id == Cyclops
+            || id == Giant {
             return Tier::T3(());
-        } else if id == BeastId::Goblin
-            || id == BeastId::Ghoul
-            || id == BeastId::Wraith
-            || id == BeastId::Sprite
-            || id == BeastId::Kappa
-            || id == BeastId::Hippogriff
-            || id == BeastId::Fenrir
-            || id == BeastId::Jaguar
-            || id == BeastId::Satori
-            || id == BeastId::DireWolf
-            || id == BeastId::NemeanLion
-            || id == BeastId::Berserker
-            || id == BeastId::Yeti
-            || id == BeastId::Golem
-            || id == BeastId::Ent {
+        } else if id == Goblin
+            || id == Ghoul
+            || id == Wraith
+            || id == Sprite
+            || id == Kappa
+            || id == Hippogriff
+            || id == Fenrir
+            || id == Jaguar
+            || id == Satori
+            || id == DireWolf
+            || id == NemeanLion
+            || id == Berserker
+            || id == Yeti
+            || id == Golem
+            || id == Ent {
             return Tier::T4(());
-        } else if id == BeastId::Fairy
-            || id == BeastId::Leprechaun
-            || id == BeastId::Kelpie
-            || id == BeastId::Pixie
-            || id == BeastId::Gnome
-            || id == BeastId::Bear
-            || id == BeastId::Wolf
-            || id == BeastId::Mantis
-            || id == BeastId::Spider
-            || id == BeastId::Rat
-            || id == BeastId::Troll
-            || id == BeastId::Bigfoot
-            || id == BeastId::Ogre
-            || id == BeastId::Orc
-            || id == BeastId::Skeleton {
+        } else if id == Fairy
+            || id == Leprechaun
+            || id == Kelpie
+            || id == Pixie
+            || id == Gnome
+            || id == Bear
+            || id == Wolf
+            || id == Mantis
+            || id == Spider
+            || id == Rat
+            || id == Troll
+            || id == Bigfoot
+            || id == Ogre
+            || id == Orc
+            || id == Skeleton {
             return Tier::T5(());
         }
 
@@ -458,23 +441,23 @@ impl ImplBeast of IBeast {
 #[test]
 #[available_gas(300000)]
 fn test_get_tier() {
-    let warlock = BeastId::Warlock;
+    let warlock = Warlock;
     let warlock_tier = ImplBeast::get_tier(warlock);
     assert(warlock_tier == Tier::T1(()), 'Warlock should be T1');
 
-    let juggernaut = BeastId::Juggernaut;
+    let juggernaut = Juggernaut;
     let juggernaut_tier = ImplBeast::get_tier(juggernaut);
     assert(juggernaut_tier == Tier::T2(()), 'Juggernaut should be T2');
 
-    let pegasus = BeastId::Pegasus;
+    let pegasus = Pegasus;
     let pegasus_tier = ImplBeast::get_tier(pegasus);
     assert(pegasus_tier == Tier::T3(()), 'Pegasus should be T3');
 
-    let goblin = BeastId::Goblin;
+    let goblin = Goblin;
     let goblin_tier = ImplBeast::get_tier(goblin);
     assert(goblin_tier == Tier::T4(()), 'Goblin should be T4');
 
-    let bear = BeastId::Bear;
+    let bear = Bear;
     let bear_tier = ImplBeast::get_tier(bear);
     assert(bear_tier == Tier::T5(()), 'Bear should be T5');
 }
@@ -482,19 +465,19 @@ fn test_get_tier() {
 #[test]
 #[available_gas(300000)]
 fn test_get_type() {
-    let warlock_type = ImplBeast::get_type(BeastId::Warlock);
+    let warlock_type = ImplBeast::get_type(Warlock);
     assert(warlock_type == Type::Magic_or_Cloth(()), 'Warlock is magical');
 
-    let juggernaut_type = ImplBeast::get_type(BeastId::Juggernaut);
+    let juggernaut_type = ImplBeast::get_type(Juggernaut);
     assert(juggernaut_type == Type::Bludgeon_or_Metal(()), 'Juggernaut is a brute ');
 
-    let pegasus_type = ImplBeast::get_type(BeastId::Pegasus);
+    let pegasus_type = ImplBeast::get_type(Pegasus);
     assert(pegasus_type == Type::Blade_or_Hide(()), 'Pegasus is a hunter');
 
-    let goblin_type = ImplBeast::get_type(BeastId::Goblin);
+    let goblin_type = ImplBeast::get_type(Goblin);
     assert(goblin_type == Type::Magic_or_Cloth(()), 'Goblin is magical');
 
-    let bear_type = ImplBeast::get_type(BeastId::Bear);
+    let bear_type = ImplBeast::get_type(Bear);
     assert(bear_type == Type::Blade_or_Hide(()), 'Bear is a hunter');
 }
 
@@ -578,7 +561,7 @@ fn test_ambush() {
 #[available_gas(250000)]
 fn test_counter_attack() {
     // initialize warlock beast
-    let warlock = BeastId::Warlock;
+    let warlock = Warlock;
     let mut beast = Beast {
         id: warlock, starting_health: 100, combat_spec: CombatSpec {
             item_type: ImplBeast::get_type(warlock),
@@ -624,7 +607,7 @@ fn test_attack() {
     };
 
     // initialize goblin beast
-    let goblin = BeastId::Goblin;
+    let goblin = Goblin;
     let beast = Beast {
         id: goblin, starting_health: 100, combat_spec: CombatSpec {
             item_type: ImplBeast::get_type(goblin),
@@ -731,26 +714,17 @@ fn test_get_beast_id() {
     let zero_check = 0;
     let beast_id = ImplBeast::get_beast_id(zero_check);
     assert(beast_id != 0, 'beast should not be zero');
-    assert(
-        beast_id <= U128TryIntoU8::try_into(BeastId::MAX_ID).unwrap(),
-        'beast higher than max beastid'
-    );
+    assert(beast_id <= U128TryIntoU8::try_into(MAX_ID).unwrap(), 'beast higher than max beastid');
 
-    let max_beast_id = BeastId::MAX_ID;
+    let max_beast_id = MAX_ID;
     let beast_id = ImplBeast::get_beast_id(max_beast_id);
     assert(beast_id != 0, 'beast should not be zero');
-    assert(
-        beast_id <= U128TryIntoU8::try_into(BeastId::MAX_ID).unwrap(),
-        'beast higher than max beastid'
-    );
+    assert(beast_id <= U128TryIntoU8::try_into(MAX_ID).unwrap(), 'beast higher than max beastid');
 
-    let above_max_beast_id = BeastId::MAX_ID + 1;
+    let above_max_beast_id = MAX_ID + 1;
     let beast_id = ImplBeast::get_beast_id(max_beast_id);
     assert(beast_id != 0, 'beast should not be zero');
-    assert(
-        beast_id <= U128TryIntoU8::try_into(BeastId::MAX_ID).unwrap(),
-        'beast higher than max beastid'
-    );
+    assert(beast_id <= U128TryIntoU8::try_into(MAX_ID).unwrap(), 'beast higher than max beastid');
 }
 
 #[test]
@@ -772,7 +746,7 @@ fn test_get_beast() {
     assert(original_beast.id == new_beast.id, 'seed produced two diff beastIds');
 }
 #[test]
-#[available_gas(200000)]
+#[available_gas(250000)]
 fn test_get_gold_reward() {
     let mut beast = Beast {
         id: 1, starting_health: 100, combat_spec: CombatSpec {
@@ -786,7 +760,7 @@ fn test_get_gold_reward() {
     };
 
     // T1, LVL10 beast will produce a base reward of 50
-    // We will divide this by GOLD_REWARD_DIVISOR which is currently 2
+    // We will divide this by GOLD_BASE_REWARD_DIVISOR which is currently 2
     // to create a base reward of 25. We'll then calculate a gold bonus
     // based on GOLD_REWARD_BONUS_DIVISOR and GOLD_REWARD_BONUS_MAX_MULTPLIER
     // with the current settings, there will be 10 discrete gold bonuses
@@ -794,31 +768,31 @@ fn test_get_gold_reward() {
     // with entropy 0 we hit the 0% bonus case so reward should be 25
     let mut entropy: u128 = 0;
     let gold_reward = beast.get_gold_reward(entropy);
-    assert(gold_reward == 25, 'gold reward should be 25');
+    assert(gold_reward == 12, 'gold reward should be 12');
 
     // increasing entropy to 1 should produce ~10% bonus
     entropy = 1;
     let gold_reward = beast.get_gold_reward(entropy);
-    assert(gold_reward == 31, 'gold reward should be 31');
+    assert(gold_reward == 15, 'gold reward should be 15');
 
     // increasing entropy to 2 should produce ~20% bonus from base
     entropy = 2;
     let gold_reward = beast.get_gold_reward(entropy);
-    assert(gold_reward == 37, 'gold reward should be 37');
+    assert(gold_reward == 18, 'gold reward should be 18');
 
     // increasing entropy to 3 produces maximum bonus with current settings
     // which will be ~100% of the base
     entropy = 3;
     let gold_reward = beast.get_gold_reward(entropy);
-    assert(gold_reward == 43, 'gold reward should be 43');
+    assert(gold_reward == 21, 'gold reward should be 21');
 
     // if we double the beast level, we approximately double the reward
     beast.combat_spec.level = 20;
     let gold_reward = beast.get_gold_reward(entropy);
-    assert(gold_reward == 86, 'lvl 20 max gold reward is 86');
+    assert(gold_reward == 43, 'lvl 20 max gold reward is 43');
 
     // dropping beast from T1 to T5, significantly drops the gold reward
     beast.combat_spec.tier = Tier::T5(());
     let gold_reward = beast.get_gold_reward(entropy);
-    assert(gold_reward == 16, 'lvl20 t5 max gold reward is 16');
+    assert(gold_reward == 8, 'lvl20 t5 max gold reward is 8');
 }

--- a/contracts/beasts/src/constants.cairo
+++ b/contracts/beasts/src/constants.cairo
@@ -22,7 +22,7 @@ mod BeastSettings {
     // increase it to lower gold reward. Note, unlike XP, the amount
     // of gold received after slaying a beast includes a random bonus
     // between 0%-100%
-    const GOLD_REWARD_DIVISOR: u16 = 2;
+    const GOLD_BASE_REWARD_DIVISOR: u16 = 2;
 
     // controls the size of the base gold reward bonus. The higher
     // this number, the smaller the base gold bonus will be. With the
@@ -39,7 +39,7 @@ mod BeastSettings {
     // the actual amount may be slightly higher based on bonus
     const GOLD_REWARD_BASE_MINIMUM: u16 = 4;
 
-    const XP_REWARD_MINIMUM: u16 = 4;
+    const MINIMUM_XP_REWARD: u16 = 1;
 
     const BEAST_SPECIAL_NAME_UNLOCK_LEVEL: u8 = 15;
 }

--- a/contracts/beasts/src/constants.cairo
+++ b/contracts/beasts/src/constants.cairo
@@ -39,7 +39,7 @@ mod BeastSettings {
     // the actual amount may be slightly higher based on bonus
     const GOLD_REWARD_BASE_MINIMUM: u16 = 4;
 
-    const MINIMUM_XP_REWARD: u16 = 1;
+    const MINIMUM_XP_REWARD: u16 = 4;
 
     const BEAST_SPECIAL_NAME_UNLOCK_LEVEL: u8 = 15;
 }

--- a/contracts/combat/src/combat.cairo
+++ b/contracts/combat/src/combat.cairo
@@ -3,11 +3,15 @@ use integer::{
     U8IntoU16, U16IntoU64, U8IntoU64, U64TryIntoU16, U64TryIntoU8, U8IntoU128, U128TryIntoU8,
     U128TryIntoU16, u16_sqrt
 };
-use core::traits::{TryInto, Into};
-use core::traits::DivEq;
-use super::constants::CombatEnums::{Tier, Type, Slot, WeaponEffectiveness};
-use super::constants::CombatSettings;
-use core::debug::PrintTrait;
+use core::traits::{TryInto, Into, DivEq};
+use super::constants::{
+    CombatEnums::{Tier, Type, Slot, WeaponEffectiveness},
+    CombatSettings::{
+        XP_MULTIPLIER, DIFFICULTY_CLIFF, XP_REWARD_DIVISOR, WEAPON_TIER_DAMAGE_MULTIPLIER,
+        ARMOR_TIER_DAMAGE_MULTIPLIER, ELEMENTAL_DAMAGE_BONUS, STRONG_ELEMENTAL_BONUS_MIN,
+        MAX_CRITICAL_HIT_LUCK, LEVEL_MULTIPLIER
+    }
+};
 
 // SpecialPowers contains special names for combat items
 #[derive(Drop, Copy, Serde)]
@@ -26,65 +30,9 @@ struct CombatSpec {
     special_powers: SpecialPowers,
 }
 
-// Combat is a trait that provides functions for calculating damage during on-chain combat
-trait ICombat {
-    fn calculate_damage(
-        weapon: CombatSpec,
-        armor: CombatSpec,
-        minimum_damage: u16,
-        strength_boost: u16,
-        is_critical_hit: bool,
-        entropy: u128,
-    ) -> u16;
-
-    fn get_attack_hp(weapon: CombatSpec) -> u16;
-    fn get_armor_hp(armor: CombatSpec) -> u16;
-
-    fn get_weapon_effectiveness(weapon_type: Type, armor_type: Type) -> WeaponEffectiveness;
-    fn get_elemental_bonus(damage: u16, weapon_effectiveness: WeaponEffectiveness) -> u16;
-
-    fn is_critical_hit(luck: u8, entropy: u128) -> bool;
-    fn critical_hit_bonus(damage: u16, entropy: u128) -> u16;
-
-    fn get_name_prefix1_bonus(
-        damage: u16, weapon_prefix1: u8, armor_prefix1: u8, entropy: u128, 
-    ) -> u16;
-    fn get_name_prefix2_bonus(
-        base_damage: u16, weapon_prefix2: u8, armor_prefix2: u8, entropy: u128, 
-    ) -> u16;
-    fn get_name_damage_bonus(
-        base_damage: u16, weapon_name: SpecialPowers, armor_name: SpecialPowers, entropy: u128
-    ) -> u16;
-
-    fn get_strength_bonus(damage: u16, strength: u16) -> u16;
-    fn get_random_level(
-        adventurer_level: u8, entropy: u128, range_increase_interval: u8, level_multiplier: u8
-    ) -> u8;
-    fn get_enemy_starting_health(
-        adventurer_level: u8,
-        minimum_health: u8,
-        entropy: u128,
-        range_increase_interval: u8,
-        level_multiplier: u8
-    ) -> u16;
-    fn get_random_damage_location(entropy: u128, ) -> Slot;
-    fn get_xp_reward(defeated_entity: CombatSpec) -> u16;
-    fn get_level_from_xp(xp: u16) -> u8;
-
-    fn tier_to_u8(tier: Tier) -> u8;
-    fn u8_to_tier(item_type: u8) -> Tier;
-
-    fn type_to_u8(item_type: Type) -> u8;
-    fn u8_to_type(item_type: u8) -> Type;
-
-    fn slot_to_u8(slot: Slot) -> u8;
-    fn u8_to_slot(item_type: u8) -> Slot;
-
-    fn ability_based_avoid_threat(adventurer_level: u8, relevant_stat: u8, entropy: u128) -> bool;
-}
-
 // ImplCombat is an implementation of the Combat trait
 // It provides functions for calculating combat damage
+#[generate_trait]
 impl ImplCombat of ICombat {
     // calculate_damage calculates the damage done by an entity wielding a weapon against an entity wearing armor
     // @param weapon: the weapon used to attack
@@ -155,19 +103,19 @@ impl ImplCombat of ICombat {
     fn get_attack_hp(weapon: CombatSpec) -> u16 {
         match weapon.tier {
             Tier::T1(()) => {
-                return weapon.level * CombatSettings::WEAPON_TIER_DAMAGE_MULTIPLIER::T1;
+                return weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T1;
             },
             Tier::T2(()) => {
-                return weapon.level * CombatSettings::WEAPON_TIER_DAMAGE_MULTIPLIER::T2;
+                return weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T2;
             },
             Tier::T3(()) => {
-                return weapon.level * CombatSettings::WEAPON_TIER_DAMAGE_MULTIPLIER::T3;
+                return weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T3;
             },
             Tier::T4(()) => {
-                return weapon.level * CombatSettings::WEAPON_TIER_DAMAGE_MULTIPLIER::T4;
+                return weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T4;
             },
             Tier::T5(()) => {
-                return weapon.level * CombatSettings::WEAPON_TIER_DAMAGE_MULTIPLIER::T5;
+                return weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T5;
             }
         }
     }
@@ -178,19 +126,19 @@ impl ImplCombat of ICombat {
     fn get_armor_hp(armor: CombatSpec) -> u16 {
         match armor.tier {
             Tier::T1(()) => {
-                return armor.level * CombatSettings::ARMOR_TIER_DAMAGE_MULTIPLIER::T1;
+                return armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T1;
             },
             Tier::T2(()) => {
-                return armor.level * CombatSettings::ARMOR_TIER_DAMAGE_MULTIPLIER::T2;
+                return armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T2;
             },
             Tier::T3(()) => {
-                return armor.level * CombatSettings::ARMOR_TIER_DAMAGE_MULTIPLIER::T3;
+                return armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T3;
             },
             Tier::T4(()) => {
-                return armor.level * CombatSettings::ARMOR_TIER_DAMAGE_MULTIPLIER::T4;
+                return armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T4;
             },
             Tier::T5(()) => {
-                return armor.level * CombatSettings::ARMOR_TIER_DAMAGE_MULTIPLIER::T5;
+                return armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T5;
             }
         }
     }
@@ -202,7 +150,7 @@ impl ImplCombat of ICombat {
     fn get_elemental_bonus(damage: u16, weapon_effectiveness: WeaponEffectiveness) -> u16 {
         // CombatSettings::ELEMENTAL_DAMAGE_BONUS determines impact of elemental damage
         // default setting is 2 which results in -50%, 0%, or 50% damage bonus for elemental
-        let elemental_damage_effect = damage / CombatSettings::ELEMENTAL_DAMAGE_BONUS;
+        let elemental_damage_effect = damage / ELEMENTAL_DAMAGE_BONUS;
 
         // adjust base damage based on weapon effectiveness
         match weapon_effectiveness {
@@ -214,8 +162,8 @@ impl ImplCombat of ICombat {
             },
             WeaponEffectiveness::Strong(()) => {
                 let elemental_adjusted_damage = damage + elemental_damage_effect;
-                if (elemental_adjusted_damage < CombatSettings::STRONG_ELEMENTAL_BONUS_MIN) {
-                    return CombatSettings::STRONG_ELEMENTAL_BONUS_MIN;
+                if (elemental_adjusted_damage < STRONG_ELEMENTAL_BONUS_MIN) {
+                    return STRONG_ELEMENTAL_BONUS_MIN;
                 } else {
                     return elemental_adjusted_damage;
                 }
@@ -313,8 +261,8 @@ impl ImplCombat of ICombat {
         // maximum luck is governed by CombatSettings::MAX_CRITICAL_HIT_LUCK
         // current setting is 50. With Luck at 50, player has 50% chance of critical hit
         let mut effective_luck = luck;
-        if (luck > CombatSettings::MAX_CRITICAL_HIT_LUCK) {
-            effective_luck = CombatSettings::MAX_CRITICAL_HIT_LUCK;
+        if (luck > MAX_CRITICAL_HIT_LUCK) {
+            effective_luck = MAX_CRITICAL_HIT_LUCK;
         }
 
         // critical hit chance is whole number of luck / 10
@@ -515,22 +463,22 @@ impl ImplCombat of ICombat {
     // get_xp_reward returns the xp reward for defeating an entity
     // @param defeated_entity: the entity that was defeated
     // @return u16: the xp reward for defeating the entity
-    fn get_xp_reward(defeated_entity: CombatSpec) -> u16 {
-        match defeated_entity.tier {
+    fn get_xp_reward(self: CombatSpec) -> u16 {
+        match self.tier {
             Tier::T1(()) => {
-                return CombatSettings::XP_MULTIPLIER::T1 * defeated_entity.level;
+                (XP_MULTIPLIER::T1 * self.level) / XP_REWARD_DIVISOR
             },
             Tier::T2(()) => {
-                return CombatSettings::XP_MULTIPLIER::T2 * defeated_entity.level;
+                (XP_MULTIPLIER::T2 * self.level) / XP_REWARD_DIVISOR
             },
             Tier::T3(()) => {
-                return CombatSettings::XP_MULTIPLIER::T3 * defeated_entity.level;
+                (XP_MULTIPLIER::T3 * self.level) / XP_REWARD_DIVISOR
             },
             Tier::T4(()) => {
-                return CombatSettings::XP_MULTIPLIER::T4 * defeated_entity.level;
+                (XP_MULTIPLIER::T4 * self.level) / XP_REWARD_DIVISOR
             },
             Tier::T5(()) => {
-                return CombatSettings::XP_MULTIPLIER::T5 * defeated_entity.level;
+                (XP_MULTIPLIER::T5 * self.level) / XP_REWARD_DIVISOR
             }
         }
     }
@@ -631,7 +579,7 @@ impl ImplCombat of ICombat {
         // The difficulty cliff serves as a starting cushion for the adventurer before which
         // they can avoid all threats. Once the difficulty cliff has been passed, the adventurer
         // must invest in the proper stats to avoid threats.{Intelligence for obstalce, Wisdom for beast ambushes}
-        return (dice_roll <= (relevant_stat + CombatSettings::DIFFICULTY_CLIFF::NORMAL));
+        return (dice_roll <= (relevant_stat + DIFFICULTY_CLIFF::NORMAL));
     }
 }
 
@@ -1278,7 +1226,6 @@ fn test_calculate_damage() {
     let damage = ImplCombat::calculate_damage(
         weapon, armor, minimum_damage, strength_boost, is_critical_hit, entropy
     );
-    damage.print();
     // even on level 1, it deals more damage than their starter short sword
     assert(damage == 4, 'upgrade to katana: 6HP');
 
@@ -1342,8 +1289,8 @@ fn test_calculate_damage() {
 fn test_get_random_level() {
     let mut adventurer_level = 1;
 
-    let range_level_increase = CombatSettings::DIFFICULTY_CLIFF::NORMAL;
-    let level_multiplier = CombatSettings::LEVEL_MULTIPLIER::NORMAL;
+    let range_level_increase = DIFFICULTY_CLIFF::NORMAL;
+    let level_multiplier = LEVEL_MULTIPLIER::NORMAL;
 
     // entity level and adventurer level will be equivalent up to the difficulty cliff
     let entity_level = ImplCombat::get_random_level(
@@ -1352,7 +1299,7 @@ fn test_get_random_level() {
     assert(entity_level == adventurer_level, 'lvl should eql advr lvl');
 
     // test at just before the difficult level cliff
-    adventurer_level = CombatSettings::DIFFICULTY_CLIFF::NORMAL - 1;
+    adventurer_level = DIFFICULTY_CLIFF::NORMAL - 1;
     let entity_level = ImplCombat::get_random_level(
         adventurer_level, 0, range_level_increase, level_multiplier
     );
@@ -1366,7 +1313,7 @@ fn test_get_random_level() {
     // min_level: 1 + (5 - 3) = 3
     // the max level will be: adventurer_level + (1 + (LEVEL_MULTIPLIER * number of level increases))
     // for current settings that will be: 5 + (1 + (4*1) = 10
-    adventurer_level = CombatSettings::DIFFICULTY_CLIFF::NORMAL + 1;
+    adventurer_level = DIFFICULTY_CLIFF::NORMAL + 1;
     let entity_level = ImplCombat::get_random_level(
         adventurer_level, 0, range_level_increase, level_multiplier
     );
@@ -1415,7 +1362,7 @@ fn test_get_random_level() {
 
     // test 6 * the difficulty cliff for mid-late game
     // difficulty cliff default is 4 so adventurer_level here would be 24
-    adventurer_level = CombatSettings::DIFFICULTY_CLIFF::NORMAL * 6;
+    adventurer_level = DIFFICULTY_CLIFF::NORMAL * 6;
     let entity_level = ImplCombat::get_random_level(
         adventurer_level, 0, range_level_increase, level_multiplier
     );

--- a/contracts/combat/src/constants.cairo
+++ b/contracts/combat/src/constants.cairo
@@ -87,6 +87,10 @@ mod CombatSettings {
         const T5: u16 = 1; // 1 * level
     }
 
+    // The combat get_earned_xp will divide the xp reward by this number
+    // the higher the number, the less xp earned, which makes the game slower
+    const XP_REWARD_DIVISOR: u16 = 2;
+
     // Determines damage multiplier for each tier
     mod WEAPON_TIER_DAMAGE_MULTIPLIER {
         const T1: u16 = 5; // 5 * level

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -14,13 +14,11 @@ mod Game {
     const LOOT_NAME_STORAGE_INDEX_2: u256 = 1;
     const STAT_UPGRADE_POINTS_PER_LEVEL: u8 = 1;
 
-    use game::game::interfaces::{
-        IGame, IERC20Dispatcher, IERC20DispatcherTrait, IERC20LibraryDispatcher
-    };
     use option::OptionTrait;
     use box::BoxTrait;
-    use starknet::get_caller_address;
-    use starknet::{ContractAddress, ContractAddressIntoFelt252, contract_address_const};
+    use starknet::{
+        get_caller_address, ContractAddress, ContractAddressIntoFelt252, contract_address_const
+    };
     use integer::{
         Felt252TryIntoU64, U8IntoU16, U16IntoU64, U16IntoU128, U64IntoU128, U8IntoU128,
         U128TryIntoU8, U64IntoFelt252, U64TryIntoU16
@@ -29,13 +27,16 @@ mod Game {
     use array::ArrayTrait;
     use poseidon::poseidon_hash_span;
 
-    use game::game::constants::{
-        messages, Week, WEEK_2, WEEK_4, WEEK_8, BLOCKS_IN_A_WEEK, COST_TO_PLAY, U64_MAX, U128_MAX
+    use game::game::{
+        interfaces::{IGame, IERC20Dispatcher, IERC20DispatcherTrait, IERC20LibraryDispatcher},
+        constants::{
+            messages, Week, WEEK_2, WEEK_4, WEEK_8, BLOCKS_IN_A_WEEK, COST_TO_PLAY, U64_MAX,
+            U128_MAX
+        }
     };
     use lootitems::{
         loot::{ILoot, Loot, ImplLoot}, statistics::constants::{NamePrefixLength, NameSuffixLength}
     };
-    // use pack::pack::Packing; 
     use pack::{pack::{Packing, rshift_split}, constants::{MASK_16, pow, MASK_8, MASK_BOOL, mask}};
     use survivor::{
         adventurer::{Adventurer, ImplAdventurer, IAdventurer}, adventurer_stats::Stats,
@@ -52,7 +53,7 @@ mod Game {
         adventurer_utils::AdventurerUtils
     };
     use market::market::{ImplMarket, LootWithPrice};
-    use obstacles::obstacle::{ImplObstacle};
+    use obstacles::obstacle::{ImplObstacle, IObstacle};
     use combat::{combat::{CombatSpec, SpecialPowers, ImplCombat}, constants::CombatEnums};
     use beasts::beast::{Beast, IBeast, ImplBeast};
 
@@ -992,7 +993,7 @@ mod Game {
         );
 
         // get the xp reward for the obstacle
-        let xp_reward = ImplObstacle::get_xp_reward(obstacle);
+        let xp_reward = obstacle.get_xp_reward();
 
         // reward adventurer with xp (regarldess of obstacle outcome)
         let (previous_level, new_level) = adventurer.increase_adventurer_xp(xp_reward);

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected: ('Not in battle', 'ENTRYPOINT_FAILED'))]
-    #[available_gas(60000000)]
+    #[available_gas(65000000)]
     fn test_cant_flee_outside_battle() {
         // start adventuer and advance to level 2
         let mut game = lvl_2_adventurer();
@@ -230,9 +230,6 @@ mod tests {
 
         testing::set_block_number(1005);
         game.explore(ADVENTURER_ID);
-
-        // use stat upgrade
-        game.upgrade_stat(ADVENTURER_ID, 0);
 
         // explore again to find a beast
         testing::set_block_number(1006);
@@ -305,7 +302,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected: ('Market item does not exist', 'ENTRYPOINT_FAILED'))]
-    #[available_gas(60000000)]
+    #[available_gas(65000000)]
     fn test_buy_unavailable_item() {
         let mut game = lvl_2_adventurer();
         game.buy_item(ADVENTURER_ID, 200, true);

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -2,7 +2,6 @@ use core::box::BoxTrait;
 #[cfg(test)]
 mod tests {
     use array::ArrayTrait;
-    use debug::PrintTrait;
     use core::result::ResultTrait;
     use core::traits::Into;
     use option::OptionTrait;

--- a/contracts/market/src/market.cairo
+++ b/contracts/market/src/market.cairo
@@ -2,7 +2,6 @@
 use traits::{TryInto, Into};
 use core::clone::Clone;
 use array::ArrayTrait;
-use debug::PrintTrait;
 use option::OptionTrait;
 
 use lootitems::statistics::constants::ItemId;
@@ -21,14 +20,7 @@ struct LootWithPrice {
     price: u16,
 }
 
-trait IMarket {
-    fn get_all_items(seed: u256) -> Array<Loot>;
-    fn get_all_items_with_price(seed: u256) -> Array<LootWithPrice>;
-    fn get_id(seed: u256) -> u8;
-    fn is_item_available(seed: u256, item_id: u8) -> bool;
-    fn get_price(tier: Tier) -> u16;
-}
-
+#[generate_trait]
 impl ImplMarket of IMarket {
     fn get_price(tier: Tier) -> u16 {
         match tier {

--- a/contracts/obstacles/src/constants.cairo
+++ b/contracts/obstacles/src/constants.cairo
@@ -4,7 +4,7 @@ mod ObstacleSettings {
     // Determines the minimum damage an obstacle can do
     const MINIMUM_DAMAGE: u16 = 1;
     const DAMAGE_BOOST: u16 = 0;
-    const MINIMUM_XP_REWARD: u16 = 1;
+    const MINIMUM_XP_REWARD: u16 = 4;
 }
 
 mod ObstacleId {

--- a/contracts/obstacles/src/constants.cairo
+++ b/contracts/obstacles/src/constants.cairo
@@ -4,6 +4,7 @@ mod ObstacleSettings {
     // Determines the minimum damage an obstacle can do
     const MINIMUM_DAMAGE: u16 = 1;
     const DAMAGE_BOOST: u16 = 0;
+    const MINIMUM_XP_REWARD: u16 = 1;
 }
 
 mod ObstacleId {

--- a/contracts/obstacles/src/obstacle.cairo
+++ b/contracts/obstacles/src/obstacle.cairo
@@ -1,3 +1,4 @@
+use combat::combat::ICombat;
 use option::OptionTrait;
 use integer::{U8IntoU16, U128TryIntoU8};
 use super::constants::{ObstacleId, ObstacleSettings};
@@ -9,21 +10,8 @@ struct Obstacle {
     combat_specs: CombatSpec,
 }
 
-trait ObstacleTrait {
-    fn get_damage(obstacle: Obstacle, armor_combat_spec: CombatSpec, entropy: u128) -> u16;
-    fn dodged(adventurer_level: u8, adventurer_intelligence: u8, entropy: u128) -> bool;
-    fn obstacle_encounter(
-        adventurer_level: u8, adventurer_intelligence: u8, entropy: u128
-    ) -> (Obstacle, bool);
-    fn get_obstacle(id: u8, level: u8) -> Obstacle;
-    fn get_random_level(adventurer_level: u8, entropy: u128) -> u8;
-    fn obstacle_encounter_id(entropy: u128) -> u8;
-    fn get_xp_reward(self: Obstacle) -> u16;
-    fn get_tier(id: u8) -> Tier;
-    fn get_type(id: u8) -> Type;
-}
-
-impl ImplObstacle of ObstacleTrait {
+#[generate_trait]
+impl ImplObstacle of IObstacle {
     // obstacle_encounter returns a random obstacle based on the adventurer level and entropy
     // @param adventurer_level: u8 - the adventurer level
     // @param entropy: u128 - entropy for level generation
@@ -180,7 +168,12 @@ impl ImplObstacle of ObstacleTrait {
     // @param obstacle: Obstacle - the obstacle
     // @return u16 - the xp reward
     fn get_xp_reward(self: Obstacle) -> u16 {
-        ImplCombat::get_xp_reward(self.combat_specs)
+        let xp_reward = self.combat_specs.get_xp_reward();
+        if (xp_reward < ObstacleSettings::MINIMUM_XP_REWARD) {
+            return ObstacleSettings::MINIMUM_XP_REWARD;
+        } else {
+            return xp_reward;
+        }
     }
 
     // dodged returns true if the adventurer dodged the obstacle


### PR DESCRIPTION
- item and adventurer level speed reduced by 50%
- use #generate_trait annotation for interface generations
- remove unnecessary imports
- consolidate imports