### PR TITLE
Generalize item names to item specials

### DIFF
--- a/contracts/adventurer/src/item_meta.cairo
+++ b/contracts/adventurer/src/item_meta.cairo
@@ -23,9 +23,9 @@ mod STORAGE {
 
 #[derive(Drop, Copy, Serde)]
 struct ItemSpecials {
+    special1: u8, // 4 bit
     special2: u8, // 7 bits
     special3: u8, // 5 bits
-    special1: u8, // 4 bit
 }
 
 // Player can have a total of 20 items. We map the items index to a slot in the metadata

--- a/contracts/adventurer/src/item_meta.cairo
+++ b/contracts/adventurer/src/item_meta.cairo
@@ -22,52 +22,52 @@ mod STORAGE {
 }
 
 #[derive(Drop, Copy, Serde)]
-struct LootItemSpecialNames {
-    name_prefix: u8, // 7 bits
-    name_suffix: u8, // 5 bits
-    item_suffix: u8, // 4 bit
+struct ItemSpecials {
+    special2: u8, // 7 bits
+    special3: u8, // 5 bits
+    special1: u8, // 4 bit
 }
 
 // Player can have a total of 20 items. We map the items index to a slot in the metadata
 #[derive(Drop, Copy, Serde)]
-struct LootItemSpecialNamesStorage {
-    item_1: LootItemSpecialNames,
-    item_2: LootItemSpecialNames,
-    item_3: LootItemSpecialNames,
-    item_4: LootItemSpecialNames,
-    item_5: LootItemSpecialNames,
-    item_6: LootItemSpecialNames,
-    item_7: LootItemSpecialNames,
-    item_8: LootItemSpecialNames,
-    item_9: LootItemSpecialNames,
-    item_10: LootItemSpecialNames,
+struct ItemSpecialsStorage {
+    item_1: ItemSpecials,
+    item_2: ItemSpecials,
+    item_3: ItemSpecials,
+    item_4: ItemSpecials,
+    item_5: ItemSpecials,
+    item_6: ItemSpecials,
+    item_7: ItemSpecials,
+    item_8: ItemSpecials,
+    item_9: ItemSpecials,
+    item_10: ItemSpecials,
 }
 
-impl LootItemSpecialNamesPacking of Packing<LootItemSpecialNames> {
-    fn pack(self: LootItemSpecialNames) -> felt252 {
-        (self.name_prefix.into()
-            + self.name_suffix.into() * pow::TWO_POW_7
-            + self.item_suffix.into() * pow::TWO_POW_12)
+impl ItemSpecialsPacking of Packing<ItemSpecials> {
+    fn pack(self: ItemSpecials) -> felt252 {
+        (self.special2.into()
+            + self.special3.into() * pow::TWO_POW_7
+            + self.special1.into() * pow::TWO_POW_12)
             .try_into()
-            .expect('pack LootItemSpecialNames')
+            .expect('pack ItemSpecials')
     }
 
-    fn unpack(packed: felt252) -> LootItemSpecialNames {
+    fn unpack(packed: felt252) -> ItemSpecials {
         let packed = packed.into();
-        let (packed, name_prefix) = rshift_split(packed, pow::TWO_POW_7);
-        let (packed, name_suffix) = rshift_split(packed, pow::TWO_POW_5);
-        let (_, item_suffix) = rshift_split(packed, pow::TWO_POW_4);
+        let (packed, special2) = rshift_split(packed, pow::TWO_POW_7);
+        let (packed, special3) = rshift_split(packed, pow::TWO_POW_5);
+        let (_, special1) = rshift_split(packed, pow::TWO_POW_4);
 
-        LootItemSpecialNames {
-            name_prefix: name_prefix.try_into().expect('unpack LISN name_prefix'),
-            name_suffix: name_suffix.try_into().expect('unpack LISN name_suffix'),
-            item_suffix: item_suffix.try_into().expect('unpack LISN item_suffix')
+        ItemSpecials {
+            special2: special2.try_into().expect('unpack LISN special2'),
+            special3: special3.try_into().expect('unpack LISN special3'),
+            special1: special1.try_into().expect('unpack LISN special1')
         }
     }
 }
 
-impl LootItemSpecialNamesStoragePacking of Packing<LootItemSpecialNamesStorage> {
-    fn pack(self: LootItemSpecialNamesStorage) -> felt252 {
+impl ItemSpecialsStoragePacking of Packing<ItemSpecialsStorage> {
+    fn pack(self: ItemSpecialsStorage) -> felt252 {
         (self.item_1.pack().into()
             + self.item_2.pack().into() * pow::TWO_POW_16
             + self.item_3.pack().into() * pow::TWO_POW_32
@@ -82,7 +82,7 @@ impl LootItemSpecialNamesStoragePacking of Packing<LootItemSpecialNamesStorage> 
             .expect('pack LISNS')
     }
 
-    fn unpack(packed: felt252) -> LootItemSpecialNamesStorage {
+    fn unpack(packed: felt252) -> ItemSpecialsStorage {
         let packed = packed.into();
         let (packed, item_1) = rshift_split(packed, pow::TWO_POW_16);
         let (packed, item_2) = rshift_split(packed, pow::TWO_POW_16);
@@ -95,7 +95,7 @@ impl LootItemSpecialNamesStoragePacking of Packing<LootItemSpecialNamesStorage> 
         let (packed, item_9) = rshift_split(packed, pow::TWO_POW_16);
         let (_, item_10) = rshift_split(packed, pow::TWO_POW_16);
 
-        LootItemSpecialNamesStorage {
+        ItemSpecialsStorage {
             item_1: Packing::unpack(item_1.try_into().expect('unpack LISNS item_1')),
             item_2: Packing::unpack(item_2.try_into().expect('unpack LISNS item_2')),
             item_3: Packing::unpack(item_3.try_into().expect('unpack LISNS item_3')),
@@ -111,10 +111,10 @@ impl LootItemSpecialNamesStoragePacking of Packing<LootItemSpecialNamesStorage> 
 }
 
 #[generate_trait]
-impl ImplLootItemSpecialNames of ILootItemSpecialNames {
+impl ImplItemSpecials of IItemSpecials {
     fn get_loot_special_names(
-        self: LootItemSpecialNamesStorage, loot_statistics: ItemPrimitive
-    ) -> LootItemSpecialNames {
+        self: ItemSpecialsStorage, loot_statistics: ItemPrimitive
+    ) -> ItemSpecials {
         if loot_statistics.metadata == STORAGE::INDEX_1 {
             return self.item_1;
         } else if loot_statistics.metadata == STORAGE::INDEX_2 {
@@ -212,9 +212,9 @@ impl ImplLootItemSpecialNames of ILootItemSpecialNames {
         }
     }
     fn set_loot_special_names(
-        ref self: LootItemSpecialNamesStorage,
+        ref self: ItemSpecialsStorage,
         loot_statistics: ItemPrimitive,
-        loot_special_names: LootItemSpecialNames
+        loot_special_names: ItemSpecials
     ) {
         if loot_statistics.metadata == STORAGE::INDEX_1 {
             self.item_1 = loot_special_names;
@@ -243,71 +243,71 @@ impl ImplLootItemSpecialNames of ILootItemSpecialNames {
 #[test]
 #[available_gas(5000000)]
 fn test_item_meta_packing() {
-    let storage = LootItemSpecialNamesStorage {
-        item_1: LootItemSpecialNames {
-            name_prefix: 11, name_suffix: 1, item_suffix: 15, 
-            }, item_2: LootItemSpecialNames {
-            name_prefix: 22, name_suffix: 2, item_suffix: 14, 
-            }, item_3: LootItemSpecialNames {
-            name_prefix: 33, name_suffix: 3, item_suffix: 13, 
-            }, item_4: LootItemSpecialNames {
-            name_prefix: 44, name_suffix: 4, item_suffix: 12, 
-            }, item_5: LootItemSpecialNames {
-            name_prefix: 55, name_suffix: 5, item_suffix: 11, 
-            }, item_6: LootItemSpecialNames {
-            name_prefix: 66, name_suffix: 6, item_suffix: 10, 
-            }, item_7: LootItemSpecialNames {
-            name_prefix: 77, name_suffix: 7, item_suffix: 9, 
-            }, item_8: LootItemSpecialNames {
-            name_prefix: 88, name_suffix: 8, item_suffix: 8, 
-            }, item_9: LootItemSpecialNames {
-            name_prefix: 99, name_suffix: 9, item_suffix: 7, 
-            }, item_10: LootItemSpecialNames {
-            name_prefix: 111, name_suffix: 10, item_suffix: 6, 
+    let storage = ItemSpecialsStorage {
+        item_1: ItemSpecials {
+            special2: 11, special3: 1, special1: 15, 
+            }, item_2: ItemSpecials {
+            special2: 22, special3: 2, special1: 14, 
+            }, item_3: ItemSpecials {
+            special2: 33, special3: 3, special1: 13, 
+            }, item_4: ItemSpecials {
+            special2: 44, special3: 4, special1: 12, 
+            }, item_5: ItemSpecials {
+            special2: 55, special3: 5, special1: 11, 
+            }, item_6: ItemSpecials {
+            special2: 66, special3: 6, special1: 10, 
+            }, item_7: ItemSpecials {
+            special2: 77, special3: 7, special1: 9, 
+            }, item_8: ItemSpecials {
+            special2: 88, special3: 8, special1: 8, 
+            }, item_9: ItemSpecials {
+            special2: 99, special3: 9, special1: 7, 
+            }, item_10: ItemSpecials {
+            special2: 111, special3: 10, special1: 6, 
         }
     };
 
-    let unpacked: LootItemSpecialNamesStorage = Packing::unpack(storage.pack());
+    let unpacked: ItemSpecialsStorage = Packing::unpack(storage.pack());
 
-    assert(unpacked.item_1.name_prefix == storage.item_1.name_prefix, 'item_1 name_prefix');
-    assert(unpacked.item_1.name_suffix == storage.item_1.name_suffix, 'item_1 name_suffix');
-    assert(unpacked.item_1.item_suffix == storage.item_1.item_suffix, 'item_1 item_suffix');
+    assert(unpacked.item_1.special2 == storage.item_1.special2, 'item_1 special2');
+    assert(unpacked.item_1.special3 == storage.item_1.special3, 'item_1 special3');
+    assert(unpacked.item_1.special1 == storage.item_1.special1, 'item_1 special1');
 
-    assert(unpacked.item_2.name_prefix == storage.item_2.name_prefix, 'item_2 name_prefix');
-    assert(unpacked.item_2.name_suffix == storage.item_2.name_suffix, 'item_2 name_suffix');
-    assert(unpacked.item_2.item_suffix == storage.item_2.item_suffix, 'item_2 item_suffix');
+    assert(unpacked.item_2.special2 == storage.item_2.special2, 'item_2 special2');
+    assert(unpacked.item_2.special3 == storage.item_2.special3, 'item_2 special3');
+    assert(unpacked.item_2.special1 == storage.item_2.special1, 'item_2 special1');
 
-    assert(unpacked.item_3.name_prefix == storage.item_3.name_prefix, 'item_3 name_prefix');
-    assert(unpacked.item_3.name_suffix == storage.item_3.name_suffix, 'item_3 name_suffix');
-    assert(unpacked.item_3.item_suffix == storage.item_3.item_suffix, 'item_3 item_suffix');
+    assert(unpacked.item_3.special2 == storage.item_3.special2, 'item_3 special2');
+    assert(unpacked.item_3.special3 == storage.item_3.special3, 'item_3 special3');
+    assert(unpacked.item_3.special1 == storage.item_3.special1, 'item_3 special1');
 
-    assert(unpacked.item_4.name_prefix == storage.item_4.name_prefix, 'item_4 name_prefix');
-    assert(unpacked.item_4.name_suffix == storage.item_4.name_suffix, 'item_4 name_suffix');
-    assert(unpacked.item_4.item_suffix == storage.item_4.item_suffix, 'item_4 item_suffix');
+    assert(unpacked.item_4.special2 == storage.item_4.special2, 'item_4 special2');
+    assert(unpacked.item_4.special3 == storage.item_4.special3, 'item_4 special3');
+    assert(unpacked.item_4.special1 == storage.item_4.special1, 'item_4 special1');
 
-    assert(unpacked.item_5.name_prefix == storage.item_5.name_prefix, 'item_5 name_prefix');
-    assert(unpacked.item_5.name_suffix == storage.item_5.name_suffix, 'item_5 name_suffix');
-    assert(unpacked.item_5.item_suffix == storage.item_5.item_suffix, 'item_5 item_suffix');
+    assert(unpacked.item_5.special2 == storage.item_5.special2, 'item_5 special2');
+    assert(unpacked.item_5.special3 == storage.item_5.special3, 'item_5 special3');
+    assert(unpacked.item_5.special1 == storage.item_5.special1, 'item_5 special1');
 
-    assert(unpacked.item_6.name_prefix == storage.item_6.name_prefix, 'item_6 name_prefix');
-    assert(unpacked.item_6.name_suffix == storage.item_6.name_suffix, 'item_6 name_suffix');
-    assert(unpacked.item_6.item_suffix == storage.item_6.item_suffix, 'item_6 item_suffix');
+    assert(unpacked.item_6.special2 == storage.item_6.special2, 'item_6 special2');
+    assert(unpacked.item_6.special3 == storage.item_6.special3, 'item_6 special3');
+    assert(unpacked.item_6.special1 == storage.item_6.special1, 'item_6 special1');
 
-    assert(unpacked.item_7.name_prefix == storage.item_7.name_prefix, 'item_7 name_prefix');
-    assert(unpacked.item_7.name_suffix == storage.item_7.name_suffix, 'item_7 name_suffix');
-    assert(unpacked.item_7.item_suffix == storage.item_7.item_suffix, 'item_7 item_suffix');
+    assert(unpacked.item_7.special2 == storage.item_7.special2, 'item_7 special2');
+    assert(unpacked.item_7.special3 == storage.item_7.special3, 'item_7 special3');
+    assert(unpacked.item_7.special1 == storage.item_7.special1, 'item_7 special1');
 
-    assert(unpacked.item_8.name_prefix == storage.item_8.name_prefix, 'item_8 name_prefix');
-    assert(unpacked.item_8.name_suffix == storage.item_8.name_suffix, 'item_8 name_suffix');
-    assert(unpacked.item_8.item_suffix == storage.item_8.item_suffix, 'item_8 item_suffix');
+    assert(unpacked.item_8.special2 == storage.item_8.special2, 'item_8 special2');
+    assert(unpacked.item_8.special3 == storage.item_8.special3, 'item_8 special3');
+    assert(unpacked.item_8.special1 == storage.item_8.special1, 'item_8 special1');
 
-    assert(unpacked.item_9.name_prefix == storage.item_9.name_prefix, 'item_9 name_prefix');
-    assert(unpacked.item_9.name_suffix == storage.item_9.name_suffix, 'item_9 name_suffix');
-    assert(unpacked.item_9.item_suffix == storage.item_9.item_suffix, 'item_9 item_suffix');
+    assert(unpacked.item_9.special2 == storage.item_9.special2, 'item_9 special2');
+    assert(unpacked.item_9.special3 == storage.item_9.special3, 'item_9 special3');
+    assert(unpacked.item_9.special1 == storage.item_9.special1, 'item_9 special1');
 
-    assert(unpacked.item_10.name_prefix == storage.item_10.name_prefix, 'item_10 name_prefix');
-    assert(unpacked.item_10.name_suffix == storage.item_10.name_suffix, 'item_10 name_suffix');
-    assert(unpacked.item_10.item_suffix == storage.item_10.item_suffix, 'item_10 item_suffix');
+    assert(unpacked.item_10.special2 == storage.item_10.special2, 'item_10 special2');
+    assert(unpacked.item_10.special3 == storage.item_10.special3, 'item_10 special3');
+    assert(unpacked.item_10.special1 == storage.item_10.special1, 'item_10 special1');
 }
 
 #[test]
@@ -354,7 +354,7 @@ fn test_get_item_metadata_slot() {
 
     let new_item = ItemPrimitive { id: 1, xp: 1, metadata: 0 };
 
-    let item = ILootItemSpecialNames::get_loot_special_names_slot(adventurer, bag, new_item);
+    let item = IItemSpecials::get_loot_special_names_slot(adventurer, bag, new_item);
 
     assert(item.metadata == 19, 'ItemPrimitive');
 }
@@ -362,52 +362,52 @@ fn test_get_item_metadata_slot() {
 #[test]
 #[available_gas(5000000)]
 fn test_set_item_metadata_slot() {
-    let mut item_meta_storage = LootItemSpecialNamesStorage {
-        item_1: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-            }, item_2: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-            }, item_3: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-            }, item_4: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-            }, item_5: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-            }, item_6: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-            }, item_7: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-            }, item_8: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-            }, item_9: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
-            }, item_10: LootItemSpecialNames {
-            name_prefix: 0, name_suffix: 0, item_suffix: 0, 
+    let mut item_meta_storage = ItemSpecialsStorage {
+        item_1: ItemSpecials {
+            special2: 0, special3: 0, special1: 0, 
+            }, item_2: ItemSpecials {
+            special2: 0, special3: 0, special1: 0, 
+            }, item_3: ItemSpecials {
+            special2: 0, special3: 0, special1: 0, 
+            }, item_4: ItemSpecials {
+            special2: 0, special3: 0, special1: 0, 
+            }, item_5: ItemSpecials {
+            special2: 0, special3: 0, special1: 0, 
+            }, item_6: ItemSpecials {
+            special2: 0, special3: 0, special1: 0, 
+            }, item_7: ItemSpecials {
+            special2: 0, special3: 0, special1: 0, 
+            }, item_8: ItemSpecials {
+            special2: 0, special3: 0, special1: 0, 
+            }, item_9: ItemSpecials {
+            special2: 0, special3: 0, special1: 0, 
+            }, item_10: ItemSpecials {
+            special2: 0, special3: 0, special1: 0, 
         }
     };
 
     let loot_statistics_1 = ItemPrimitive { id: 102, xp: 0, metadata: 1 };
 
-    let loot_special_names_2 = LootItemSpecialNames {
-        name_prefix: 12, name_suffix: 11, item_suffix: 13
+    let loot_special_names_2 = ItemSpecials {
+        special2: 12, special3: 11, special1: 13
     };
 
     item_meta_storage.set_loot_special_names(loot_statistics_1, loot_special_names_2);
 
-    assert(item_meta_storage.item_1.name_prefix == 12, 'should be 12');
-    assert(item_meta_storage.item_1.name_suffix == 11, 'should be 11');
-    assert(item_meta_storage.item_1.item_suffix == 13, 'should be 13');
+    assert(item_meta_storage.item_1.special2 == 12, 'should be 12');
+    assert(item_meta_storage.item_1.special3 == 11, 'should be 11');
+    assert(item_meta_storage.item_1.special1 == 13, 'should be 13');
 
     let loot_statistics_2 = ItemPrimitive { id: 102, xp: 0, metadata: 2 };
 
-    let loot_special_names_2 = LootItemSpecialNames {
-        name_prefix: 12, name_suffix: 11, item_suffix: 13
+    let loot_special_names_2 = ItemSpecials {
+        special2: 12, special3: 11, special1: 13
     };
 
     item_meta_storage.set_loot_special_names(loot_statistics_2, loot_special_names_2);
-    assert(item_meta_storage.item_2.name_prefix == 12, 'should be 12');
-    assert(item_meta_storage.item_2.name_suffix == 11, 'should be 11');
-    assert(item_meta_storage.item_2.item_suffix == 13, 'should be 13');
+    assert(item_meta_storage.item_2.special2 == 12, 'should be 12');
+    assert(item_meta_storage.item_2.special3 == 11, 'should be 11');
+    assert(item_meta_storage.item_2.special1 == 13, 'should be 13');
 }
 
 #[test]
@@ -424,86 +424,86 @@ fn test_get_item_metadata() {
     let item_linen_gloves = ItemPrimitive { id: 9, xp: 1, metadata: 9 };
     let item_crown = ItemPrimitive { id: 10, xp: 1, metadata: 10 };
 
-    let mut item_meta_storage = LootItemSpecialNamesStorage {
-        item_1: LootItemSpecialNames {
-            name_prefix: 2, name_suffix: 2, item_suffix: 10, 
-            }, item_2: LootItemSpecialNames {
-            name_prefix: 4, name_suffix: 3, item_suffix: 11, 
-            }, item_3: LootItemSpecialNames {
-            name_prefix: 5, name_suffix: 4, item_suffix: 11, 
-            }, item_4: LootItemSpecialNames {
-            name_prefix: 6, name_suffix: 5, item_suffix: 3, 
-            }, item_5: LootItemSpecialNames {
-            name_prefix: 8, name_suffix: 6, item_suffix: 2, 
-            }, item_6: LootItemSpecialNames {
-            name_prefix: 9, name_suffix: 7, item_suffix: 1, 
-            }, item_7: LootItemSpecialNames {
-            name_prefix: 11, name_suffix: 8, item_suffix: 5, 
-            }, item_8: LootItemSpecialNames {
-            name_prefix: 2, name_suffix: 9, item_suffix: 6, 
-            }, item_9: LootItemSpecialNames {
-            name_prefix: 3, name_suffix: 0, item_suffix: 7, 
-            }, item_10: LootItemSpecialNames {
-            name_prefix: 11, name_suffix: 8, item_suffix: 5, 
+    let mut item_meta_storage = ItemSpecialsStorage {
+        item_1: ItemSpecials {
+            special2: 2, special3: 2, special1: 10, 
+            }, item_2: ItemSpecials {
+            special2: 4, special3: 3, special1: 11, 
+            }, item_3: ItemSpecials {
+            special2: 5, special3: 4, special1: 11, 
+            }, item_4: ItemSpecials {
+            special2: 6, special3: 5, special1: 3, 
+            }, item_5: ItemSpecials {
+            special2: 8, special3: 6, special1: 2, 
+            }, item_6: ItemSpecials {
+            special2: 9, special3: 7, special1: 1, 
+            }, item_7: ItemSpecials {
+            special2: 11, special3: 8, special1: 5, 
+            }, item_8: ItemSpecials {
+            special2: 2, special3: 9, special1: 6, 
+            }, item_9: ItemSpecials {
+            special2: 3, special3: 0, special1: 7, 
+            }, item_10: ItemSpecials {
+            special2: 11, special3: 8, special1: 5, 
         }
     };
 
     let meta_data = item_meta_storage.get_loot_special_names(item_pendant);
 
-    assert(meta_data.name_prefix == 2, 'item_pendant.name_prefix');
-    assert(meta_data.name_suffix == 2, 'item_pendant.name_suffix');
-    assert(meta_data.item_suffix == 10, 'item_pendant.item_suffix');
+    assert(meta_data.special2 == 2, 'item_pendant.special2');
+    assert(meta_data.special3 == 2, 'item_pendant.special3');
+    assert(meta_data.special1 == 10, 'item_pendant.special1');
     let meta_data = item_meta_storage.get_loot_special_names(item_silver_ring);
 
-    assert(meta_data.name_prefix == 4, 'item_silver_ring.name_prefix');
-    assert(meta_data.name_suffix == 3, 'item_silver_ring.name_suffix');
-    assert(meta_data.item_suffix == 11, 'item_silver_ring.item_suffix');
+    assert(meta_data.special2 == 4, 'item_silver_ring.special2');
+    assert(meta_data.special3 == 3, 'item_silver_ring.special3');
+    assert(meta_data.special1 == 11, 'item_silver_ring.special1');
 
     let meta_data = item_meta_storage.get_loot_special_names(item_silk_robe);
 
-    assert(meta_data.name_prefix == 5, 'item_silk_robe.name_prefix');
-    assert(meta_data.name_suffix == 4, 'item_silk_robe.name_suffix');
-    assert(meta_data.item_suffix == 11, 'item_silk_robe.item_suffix');
+    assert(meta_data.special2 == 5, 'item_silk_robe.special2');
+    assert(meta_data.special3 == 4, 'item_silk_robe.special3');
+    assert(meta_data.special1 == 11, 'item_silk_robe.special1');
 
     let meta_data = item_meta_storage.get_loot_special_names(item_iron_sword);
 
-    assert(meta_data.name_prefix == 6, 'item_iron_sword.name_prefix');
-    assert(meta_data.name_suffix == 5, 'item_iron_sword.name_suffix');
-    assert(meta_data.item_suffix == 3, 'item_iron_sword.item_suffix');
+    assert(meta_data.special2 == 6, 'item_iron_sword.special2');
+    assert(meta_data.special3 == 5, 'item_iron_sword.special3');
+    assert(meta_data.special1 == 3, 'item_iron_sword.special1');
 
     let meta_data = item_meta_storage.get_loot_special_names(item_katana);
 
-    assert(meta_data.name_prefix == 8, 'item_katana');
-    assert(meta_data.name_suffix == 6, 'item_katana');
-    assert(meta_data.item_suffix == 2, 'item_katana');
+    assert(meta_data.special2 == 8, 'item_katana');
+    assert(meta_data.special3 == 6, 'item_katana');
+    assert(meta_data.special1 == 2, 'item_katana');
 
     let meta_data = item_meta_storage.get_loot_special_names(item_falchion);
 
-    assert(meta_data.name_prefix == 9, 'item_falchion');
-    assert(meta_data.name_suffix == 7, 'item_falchion');
-    assert(meta_data.item_suffix == 1, 'item_falchion');
+    assert(meta_data.special2 == 9, 'item_falchion');
+    assert(meta_data.special3 == 7, 'item_falchion');
+    assert(meta_data.special1 == 1, 'item_falchion');
 
     let meta_data = item_meta_storage.get_loot_special_names(item_leather_gloves);
 
-    assert(meta_data.name_prefix == 11, 'item_leather_gloves');
-    assert(meta_data.name_suffix == 8, 'item_leather_gloves');
-    assert(meta_data.item_suffix == 5, 'item_leather_gloves');
+    assert(meta_data.special2 == 11, 'item_leather_gloves');
+    assert(meta_data.special3 == 8, 'item_leather_gloves');
+    assert(meta_data.special1 == 5, 'item_leather_gloves');
 
     let meta_data = item_meta_storage.get_loot_special_names(item_silk_gloves);
 
-    assert(meta_data.name_prefix == 2, 'item_silk_gloves');
-    assert(meta_data.name_suffix == 9, 'item_silk_gloves');
-    assert(meta_data.item_suffix == 6, 'item_silk_gloves');
+    assert(meta_data.special2 == 2, 'item_silk_gloves');
+    assert(meta_data.special3 == 9, 'item_silk_gloves');
+    assert(meta_data.special1 == 6, 'item_silk_gloves');
 
     let meta_data = item_meta_storage.get_loot_special_names(item_linen_gloves);
 
-    assert(meta_data.name_prefix == 3, 'item_linen_gloves');
-    assert(meta_data.name_suffix == 0, 'item_linen_gloves');
-    assert(meta_data.item_suffix == 7, 'item_linen_gloves');
+    assert(meta_data.special2 == 3, 'item_linen_gloves');
+    assert(meta_data.special3 == 0, 'item_linen_gloves');
+    assert(meta_data.special1 == 7, 'item_linen_gloves');
 
     let meta_data = item_meta_storage.get_loot_special_names(item_crown);
 
-    assert(meta_data.name_prefix == 11, 'item_crown');
-    assert(meta_data.name_suffix == 8, 'item_crown');
-    assert(meta_data.item_suffix == 5, 'item_crown');
+    assert(meta_data.special2 == 11, 'item_crown');
+    assert(meta_data.special3 == 8, 'item_crown');
+    assert(meta_data.special1 == 5, 'item_crown');
 }

--- a/contracts/combat/src/combat.cairo
+++ b/contracts/combat/src/combat.cairo
@@ -72,7 +72,7 @@ impl ImplCombat of ICombat {
         }
 
         // get special name damage bonus
-        let name_prefix_bonus = ImplCombat::get_name_damage_bonus(
+        let special2_bonus = ImplCombat::get_name_damage_bonus(
             base_attack_hp, weapon.special_powers, armor.special_powers, entropy
         );
 
@@ -82,7 +82,7 @@ impl ImplCombat of ICombat {
         // total attack hit points
         let total_attack = elemental_adjusted_attack
             + critical_hit_bonus
-            + name_prefix_bonus
+            + special2_bonus
             + strength_bonus;
 
         // if the total attack is greater than the armor HP plus the minimum damage
@@ -298,13 +298,13 @@ impl ImplCombat of ICombat {
         return damage_boost_base * (damage_multplier + 1);
     }
 
-    // get_name_prefix1_bonus returns the bonus damage done by a weapon as a result of the first part of its name
+    // get_special21_bonus returns the bonus damage done by a weapon as a result of the first part of its name
     // @param damage: the base damage done by the attacker
     // @param weapon_name: the name of the weapon used to attack
     // @param armor_name: the name of the armor worn by the defender
     // @param entropy: entropy for randomizing name prefix damage bonus
     // @return u16: the bonus damage done by a name prefix
-    fn get_name_prefix1_bonus(
+    fn get_special21_bonus(
         damage: u16, weapon_prefix1: u8, armor_prefix1: u8, entropy: u128, 
     ) -> u16 {
         // is the weapon does not have a prefix
@@ -323,13 +323,13 @@ impl ImplCombat of ICombat {
         0
     }
 
-    // get_name_prefix2_bonus returns the bonus damage done by a weapon as a result of the second part of its name
+    // get_special22_bonus returns the bonus damage done by a weapon as a result of the second part of its name
     // @param base_damage: the base damage done by the attacker
     // @param weapon_name: the name of the weapon used by the attacker
     // @param armor_name: the name of the armor worn by the defender
     // @param entropy: entropy for randomizing name prefix 2 damage bonus
     // @return u16: the bonus damage done by a weapon as a result of the second part of its name
-    fn get_name_prefix2_bonus(
+    fn get_special22_bonus(
         base_damage: u16, weapon_prefix2: u8, armor_prefix2: u8, entropy: u128, 
     ) -> u16 {
         // is the weapon does not have a prefix
@@ -361,16 +361,16 @@ impl ImplCombat of ICombat {
     fn get_name_damage_bonus(
         base_damage: u16, weapon_name: SpecialPowers, armor_name: SpecialPowers, entropy: u128
     ) -> u16 {
-        let name_prefix1_bonus = ImplCombat::get_name_prefix1_bonus(
+        let special21_bonus = ImplCombat::get_special21_bonus(
             base_damage, weapon_name.prefix1, armor_name.prefix1, entropy
         );
 
-        let name_prefix2_bonus = ImplCombat::get_name_prefix2_bonus(
+        let special22_bonus = ImplCombat::get_special22_bonus(
             base_damage, weapon_name.prefix2, armor_name.prefix2, entropy
         );
 
         // return the sum of the name prefix and name suffix bonuses
-        return name_prefix1_bonus + name_prefix2_bonus;
+        return special21_bonus + special22_bonus;
     }
 
     // get_adventurer_strength_bonus returns the bonus damage for adventurer strength
@@ -1028,7 +1028,7 @@ fn test_get_elemental_bonus() {
 
 #[test]
 #[available_gas(90000)]
-fn test_get_name_prefix1_bonus() {
+fn test_get_special21_bonus() {
     let base_damage = 100;
     let mut entropy = 0;
 
@@ -1036,52 +1036,52 @@ fn test_get_name_prefix1_bonus() {
     let mut armor_special_names = SpecialPowers { prefix1: 0, prefix2: 0, suffix: 0,  };
 
     // weapon without special name should have no bonus
-    let name_prefix1_bonus = ImplCombat::get_name_prefix1_bonus(
+    let special21_bonus = ImplCombat::get_special21_bonus(
         base_damage, weapon_special_names.prefix1, armor_special_names.prefix1, entropy
     );
-    assert(name_prefix1_bonus == 0, 'should be no bonus');
+    assert(special21_bonus == 0, 'should be no bonus');
 
     // assign armor a prefix1 name and ensure lack of weapon special name still results in no bonus
     armor_special_names.prefix1 = 1;
-    let name_prefix1_bonus = ImplCombat::get_name_prefix1_bonus(
+    let special21_bonus = ImplCombat::get_special21_bonus(
         base_damage, weapon_special_names.prefix1, armor_special_names.prefix1, entropy
     );
-    assert(name_prefix1_bonus == 0, 'should be no bonus');
+    assert(special21_bonus == 0, 'should be no bonus');
 
     // give weapon matching prefix1 to qualify it for bonus
     // actual amount (4x-7x) will depend on entropy
     // entropy 0: 4x
     weapon_special_names.prefix1 = 1;
-    let name_prefix1_bonus = ImplCombat::get_name_prefix1_bonus(
+    let special21_bonus = ImplCombat::get_special21_bonus(
         base_damage, weapon_special_names.prefix1, armor_special_names.prefix1, entropy
     );
-    assert(name_prefix1_bonus == 400, 'should be +400hp bonus');
+    assert(special21_bonus == 400, 'should be +400hp bonus');
 
     // entropy 1: 5x
     entropy = 1;
-    let name_prefix1_bonus = ImplCombat::get_name_prefix1_bonus(
+    let special21_bonus = ImplCombat::get_special21_bonus(
         base_damage, weapon_special_names.prefix1, armor_special_names.prefix1, entropy
     );
-    assert(name_prefix1_bonus == 500, 'should be +500hp bonus');
+    assert(special21_bonus == 500, 'should be +500hp bonus');
 
     // entropy 2: 6x
     entropy = 2;
-    let name_prefix1_bonus = ImplCombat::get_name_prefix1_bonus(
+    let special21_bonus = ImplCombat::get_special21_bonus(
         base_damage, weapon_special_names.prefix1, armor_special_names.prefix1, entropy
     );
-    assert(name_prefix1_bonus == 600, 'should be +600hp bonus');
+    assert(special21_bonus == 600, 'should be +600hp bonus');
 
     // entropy 3: 7x
     entropy = 3;
-    let name_prefix1_bonus = ImplCombat::get_name_prefix1_bonus(
+    let special21_bonus = ImplCombat::get_special21_bonus(
         base_damage, weapon_special_names.prefix1, armor_special_names.prefix1, entropy
     );
-    assert(name_prefix1_bonus == 700, 'should be +700hp bonus');
+    assert(special21_bonus == 700, 'should be +700hp bonus');
 }
 
 #[test]
 #[available_gas(130000)]
-fn test_get_name_prefix2_bonus() {
+fn test_get_special22_bonus() {
     let base_damage = 100;
     let mut entropy = 0;
 
@@ -1089,47 +1089,47 @@ fn test_get_name_prefix2_bonus() {
     let mut armor_special_names = SpecialPowers { prefix1: 0, prefix2: 0, suffix: 0,  };
 
     // weapon without special name should have no bonus
-    let name_prefix2_bonus = ImplCombat::get_name_prefix2_bonus(
+    let special22_bonus = ImplCombat::get_special22_bonus(
         base_damage, weapon_special_names.prefix2, armor_special_names.prefix2, entropy
     );
-    assert(name_prefix2_bonus == 0, 'no prefix2 == no bonus');
+    assert(special22_bonus == 0, 'no prefix2 == no bonus');
 
     // assign armor a prefix2 name and ensure lack of weapon special name still results in no bonus
     armor_special_names.prefix2 = 1;
-    let name_prefix2_bonus = ImplCombat::get_name_prefix2_bonus(
+    let special22_bonus = ImplCombat::get_special22_bonus(
         base_damage, weapon_special_names.prefix2, armor_special_names.prefix2, entropy
     );
-    assert(name_prefix2_bonus == 0, 'no prefix2 == no bonus');
+    assert(special22_bonus == 0, 'no prefix2 == no bonus');
 
     // give weapon matching prefix2 to qualify it for bonus
     // actual amount (25% - 100%) will depend on entropy
     // entropy 0: 25%
     weapon_special_names.prefix2 = 1;
-    let name_prefix2_bonus = ImplCombat::get_name_prefix2_bonus(
+    let special22_bonus = ImplCombat::get_special22_bonus(
         base_damage, weapon_special_names.prefix2, armor_special_names.prefix2, entropy
     );
-    assert(name_prefix2_bonus == 25, 'should be +25hp bonus');
+    assert(special22_bonus == 25, 'should be +25hp bonus');
 
     // entropy 1: 50%
     entropy = 1;
-    let name_prefix2_bonus = ImplCombat::get_name_prefix2_bonus(
+    let special22_bonus = ImplCombat::get_special22_bonus(
         base_damage, weapon_special_names.prefix2, armor_special_names.prefix2, entropy
     );
-    assert(name_prefix2_bonus == 50, 'should be +50hp bonus');
+    assert(special22_bonus == 50, 'should be +50hp bonus');
 
     // entropy 2: 75%
     entropy = 2;
-    let name_prefix2_bonus = ImplCombat::get_name_prefix2_bonus(
+    let special22_bonus = ImplCombat::get_special22_bonus(
         base_damage, weapon_special_names.prefix2, armor_special_names.prefix2, entropy
     );
-    assert(name_prefix2_bonus == 75, 'should be +75hp bonus');
+    assert(special22_bonus == 75, 'should be +75hp bonus');
 
     // entropy 3: 100%
     entropy = 3;
-    let name_prefix2_bonus = ImplCombat::get_name_prefix2_bonus(
+    let special22_bonus = ImplCombat::get_special22_bonus(
         base_damage, weapon_special_names.prefix2, armor_special_names.prefix2, entropy
     );
-    assert(name_prefix2_bonus == 100, 'should be +100hp bonus');
+    assert(special22_bonus == 100, 'should be +100hp bonus');
 }
 
 #[test]

--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -1,7 +1,7 @@
 use starknet::ContractAddress;
 use survivor::{
     bag::Bag, adventurer::{Adventurer, Stats}, adventurer_meta::AdventurerMetadata,
-    item_meta::LootItemSpecialNames
+    item_meta::ItemSpecials
 };
 use lootitems::loot::{Loot};
 use market::market::LootWithPrice;
@@ -48,14 +48,14 @@ trait IGame<TContractState> {
     fn get_ring_greatness(self: @TContractState, adventurer_id: u256) -> u8;
 
     // item details
-    fn get_equipped_weapon_names(self: @TContractState, adventurer_id: u256) -> LootItemSpecialNames;
-    fn get_equipped_chest_names(self: @TContractState, adventurer_id: u256) -> LootItemSpecialNames;
-    fn get_equipped_head_names(self: @TContractState, adventurer_id: u256) -> LootItemSpecialNames;
-    fn get_equipped_waist_names(self: @TContractState, adventurer_id: u256) -> LootItemSpecialNames;
-    fn get_equipped_foot_names(self: @TContractState, adventurer_id: u256) -> LootItemSpecialNames;
-    fn get_equipped_hand_names(self: @TContractState, adventurer_id: u256) -> LootItemSpecialNames;
-    fn get_equipped_necklace_names(self: @TContractState, adventurer_id: u256) -> LootItemSpecialNames;
-    fn get_equipped_ring_names(self: @TContractState, adventurer_id: u256) -> LootItemSpecialNames;
+    fn get_equipped_weapon_names(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
+    fn get_equipped_chest_names(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
+    fn get_equipped_head_names(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
+    fn get_equipped_waist_names(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
+    fn get_equipped_foot_names(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
+    fn get_equipped_hand_names(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
+    fn get_equipped_necklace_names(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
+    fn get_equipped_ring_names(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
 
     // adventurer stats
     fn get_base_stats(self: @TContractState, adventurer_id: u256) -> Stats;

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -47,8 +47,8 @@ mod Game {
             adventurer_constants::{POTION_HEALTH_AMOUNT, ITEM_XP_MULTIPLIER}
         },
         item_meta::{
-            ImplLootItemSpecialNames, LootItemSpecialNames, ILootItemSpecialNames,
-            LootItemSpecialNamesStorage
+            ImplItemSpecials, ItemSpecials, IItemSpecials,
+            ItemSpecialsStorage
         },
         adventurer_utils::AdventurerUtils
     };
@@ -455,49 +455,49 @@ mod Game {
         }
         fn get_equipped_weapon_names(
             self: @ContractState, adventurer_id: u256
-        ) -> LootItemSpecialNames {
+        ) -> ItemSpecials {
             let adventurer = _unpack_adventurer(self, adventurer_id);
             _get_special_names(self, adventurer_id, adventurer.weapon)
         }
         fn get_equipped_chest_names(
             self: @ContractState, adventurer_id: u256
-        ) -> LootItemSpecialNames {
+        ) -> ItemSpecials {
             let adventurer = _unpack_adventurer(self, adventurer_id);
             _get_special_names(self, adventurer_id, adventurer.chest)
         }
         fn get_equipped_head_names(
             self: @ContractState, adventurer_id: u256
-        ) -> LootItemSpecialNames {
+        ) -> ItemSpecials {
             let adventurer = _unpack_adventurer(self, adventurer_id);
             _get_special_names(self, adventurer_id, adventurer.head)
         }
         fn get_equipped_waist_names(
             self: @ContractState, adventurer_id: u256
-        ) -> LootItemSpecialNames {
+        ) -> ItemSpecials {
             let adventurer = _unpack_adventurer(self, adventurer_id);
             _get_special_names(self, adventurer_id, adventurer.waist)
         }
         fn get_equipped_foot_names(
             self: @ContractState, adventurer_id: u256
-        ) -> LootItemSpecialNames {
+        ) -> ItemSpecials {
             let adventurer = _unpack_adventurer(self, adventurer_id);
             _get_special_names(self, adventurer_id, adventurer.foot)
         }
         fn get_equipped_hand_names(
             self: @ContractState, adventurer_id: u256
-        ) -> LootItemSpecialNames {
+        ) -> ItemSpecials {
             let adventurer = _unpack_adventurer(self, adventurer_id);
             _get_special_names(self, adventurer_id, adventurer.hand)
         }
         fn get_equipped_necklace_names(
             self: @ContractState, adventurer_id: u256
-        ) -> LootItemSpecialNames {
+        ) -> ItemSpecials {
             let adventurer = _unpack_adventurer(self, adventurer_id);
             _get_special_names(self, adventurer_id, adventurer.neck)
         }
         fn get_equipped_ring_names(
             self: @ContractState, adventurer_id: u256
-        ) -> LootItemSpecialNames {
+        ) -> ItemSpecials {
             let adventurer = _unpack_adventurer(self, adventurer_id);
             _get_special_names(self, adventurer_id, adventurer.ring)
         }
@@ -850,8 +850,8 @@ mod Game {
         ref self: ContractState,
         ref adventurer: Adventurer,
         adventurer_id: u256,
-        ref name_storage1: LootItemSpecialNamesStorage,
-        ref name_storage2: LootItemSpecialNamesStorage
+        ref name_storage1: ItemSpecialsStorage,
+        ref name_storage2: ItemSpecialsStorage
     ) {
         // https://github.com/starkware-libs/cairo/issues/2942
         // internal::revoke_ap_tracking();
@@ -985,8 +985,8 @@ mod Game {
         ref self: ContractState,
         ref adventurer: Adventurer,
         adventurer_id: u256,
-        ref name_storage1: LootItemSpecialNamesStorage,
-        ref name_storage2: LootItemSpecialNamesStorage,
+        ref name_storage1: ItemSpecialsStorage,
+        ref name_storage2: ItemSpecialsStorage,
         entropy: u128
     ) -> Adventurer {
         // https://github.com/starkware-libs/cairo/issues/2942
@@ -1088,7 +1088,7 @@ mod Game {
     // @param new_level The new level of the item after it possibly leveled up.
     // @param suffix_assigned A boolean indicating whether a suffix was assigned to the item when it leveled up.
     // @param prefixes_assigned A boolean indicating whether a prefix was assigned to the item when it leveled up.
-    // @param special_names The LootItemSpecialNames object storing the special names for the item.
+    // @param special_names The ItemSpecials object storing the special names for the item.
     //
     // The function first checks if the item's new level is higher than its previous level. If it is, it generates a 'GreatnessIncreased' event.
     // The function then checks if a suffix was assigned to the item when it leveled up. If it was, it generates an 'ItemSuffixDiscovered' event.
@@ -1102,7 +1102,7 @@ mod Game {
         new_level: u8,
         suffix_assigned: bool,
         prefixes_assigned: bool,
-        special_names: LootItemSpecialNames
+        special_names: ItemSpecials
     ) {
         // https://github.com/starkware-libs/cairo/issues/2942
         // internal::revoke_ap_tracking();
@@ -1168,8 +1168,8 @@ mod Game {
         ref self: ContractState,
         adventurer_id: u256,
         ref adventurer: Adventurer,
-        ref name_storage1: LootItemSpecialNamesStorage,
-        ref name_storage2: LootItemSpecialNamesStorage,
+        ref name_storage1: ItemSpecialsStorage,
+        ref name_storage2: ItemSpecialsStorage,
         value: u16,
         entropy: u128
     ) {
@@ -1300,8 +1300,8 @@ mod Game {
     // @param adventurer A reference to the Adventurer object. This object represents the adventurer who owns the item.
     // @param item A reference to the ItemPrimitive object. This object represents the item to which XP will be granted.
     // @param amount The amount of experience points to be added to the item before applying the item XP multiplier.
-    // @param name_storage1 A reference to the LootItemSpecialNamesStorage object. This object stores the special names for items that an adventurer may possess.
-    // @param name_storage2 A reference to the LootItemSpecialNamesStorage object. This object stores the special names for items that an adventurer may possess.
+    // @param name_storage1 A reference to the ItemSpecialsStorage object. This object stores the special names for items that an adventurer may possess.
+    // @param name_storage2 A reference to the ItemSpecialsStorage object. This object stores the special names for items that an adventurer may possess.
     // @param entropy An unsigned integer used for entropy generation. This is often derived from a source of randomness.
     //
     // The function first calculates the XP increase by applying a multiplier to the provided 'amount'.
@@ -1314,8 +1314,8 @@ mod Game {
         ref adventurer: Adventurer,
         ref item: ItemPrimitive,
         xp_increase: u16,
-        ref name_storage1: LootItemSpecialNamesStorage,
-        ref name_storage2: LootItemSpecialNamesStorage,
+        ref name_storage1: ItemSpecialsStorage,
+        ref name_storage2: ItemSpecialsStorage,
         entropy: u128
     ) {
         // https://github.com/starkware-libs/cairo/issues/2942
@@ -1358,8 +1358,8 @@ mod Game {
         ref self: ContractState,
         ref adventurer: Adventurer,
         adventurer_id: u256,
-        ref name_storage1: LootItemSpecialNamesStorage,
-        ref name_storage2: LootItemSpecialNamesStorage
+        ref name_storage1: ItemSpecialsStorage,
+        ref name_storage2: ItemSpecialsStorage
     ) {
         // https://github.com/starkware-libs/cairo/issues/2942
         // internal::revoke_ap_tracking();
@@ -1720,7 +1720,7 @@ mod Game {
         let mut bag = _bag_unpacked(@self, adventurer_id);
 
         // get item and determine metadata slot
-        let item = ImplLootItemSpecialNames::get_loot_special_names_slot(
+        let item = ImplItemSpecials::get_loot_special_names_slot(
             adventurer, bag, ImplBagActions::new_item(item_id)
         );
 
@@ -1849,8 +1849,8 @@ mod Game {
     fn _unpack_adventurer_apply_stat_boost(
         self: @ContractState,
         adventurer_id: u256,
-        name_storage1: LootItemSpecialNamesStorage,
-        name_storage2: LootItemSpecialNamesStorage
+        name_storage1: ItemSpecialsStorage,
+        name_storage2: ItemSpecialsStorage
     ) -> Adventurer {
         // unpack adventurer
         let mut adventurer: Adventurer = Packing::unpack(self._adventurer.read(adventurer_id));
@@ -1862,8 +1862,8 @@ mod Game {
         ref self: ContractState,
         adventurer_id: u256,
         ref adventurer: Adventurer,
-        name_storage1: LootItemSpecialNamesStorage,
-        name_storage2: LootItemSpecialNamesStorage
+        name_storage1: ItemSpecialsStorage,
+        name_storage2: ItemSpecialsStorage
     ) {
         // remove stat boosts
         _remove_stat_boots(@self, adventurer_id, ref adventurer, name_storage1, name_storage2);
@@ -1875,8 +1875,8 @@ mod Game {
         self: @ContractState,
         adventurer_id: u256,
         ref adventurer: Adventurer,
-        name_storage1: LootItemSpecialNamesStorage,
-        name_storage2: LootItemSpecialNamesStorage
+        name_storage1: ItemSpecialsStorage,
+        name_storage2: ItemSpecialsStorage
     ) -> Adventurer {
         // apply stat boosts to adventurer from item names
         adventurer.apply_item_stat_boosts(name_storage1, name_storage2);
@@ -1893,8 +1893,8 @@ mod Game {
         self: @ContractState,
         adventurer_id: u256,
         ref adventurer: Adventurer,
-        name_storage1: LootItemSpecialNamesStorage,
-        name_storage2: LootItemSpecialNamesStorage
+        name_storage1: ItemSpecialsStorage,
+        name_storage2: ItemSpecialsStorage
     ) {
         // apply stat boosts to adventurer from item names
         adventurer.apply_item_stat_boosts(name_storage1, name_storage2);
@@ -1974,7 +1974,7 @@ mod Game {
         ref self: ContractState,
         adventurer_id: u256,
         storage_index: u256,
-        loot_special_names_storage: LootItemSpecialNamesStorage,
+        loot_special_names_storage: ItemSpecialsStorage,
     ) {
         self
             ._loot_special_names
@@ -1983,14 +1983,14 @@ mod Game {
 
     fn _loot_special_names_storage_unpacked(
         self: @ContractState, adventurer_id: u256, storage_index: u256
-    ) -> LootItemSpecialNamesStorage {
+    ) -> ItemSpecialsStorage {
         Packing::unpack(self._loot_special_names.read((adventurer_id, storage_index)))
     }
 
     fn _get_special_names(
         self: @ContractState, adventurer_id: u256, item: ItemPrimitive
-    ) -> LootItemSpecialNames {
-        ImplLootItemSpecialNames::get_loot_special_names(
+    ) -> ItemSpecials {
+        ImplItemSpecials::get_loot_special_names(
             _loot_special_names_storage_unpacked(
                 self, adventurer_id, _get_storage_index(self, item.metadata)
             ),
@@ -2157,7 +2157,7 @@ mod Game {
             };
         } else {
             // if it's above 15, fetch the special names
-            let item_details = ImplLootItemSpecialNames::get_loot_special_names(
+            let item_details = ImplItemSpecials::get_loot_special_names(
                 _loot_special_names_storage_unpacked(
                     self, adventurer_id, _get_storage_index(self, item.metadata)
                 ),
@@ -2169,9 +2169,9 @@ mod Game {
                 item_type: ImplLoot::get_type(item.id),
                 level: U8IntoU16::into(item.get_greatness()),
                 special_powers: SpecialPowers {
-                    prefix1: item_details.name_prefix,
-                    prefix2: item_details.name_suffix,
-                    suffix: item_details.item_suffix
+                    prefix1: item_details.special2,
+                    prefix2: item_details.special3,
+                    suffix: item_details.special1
                 }
             };
         }
@@ -2379,13 +2379,13 @@ mod Game {
     #[derive(Drop, starknet::Event)]
     struct ItemPrefixDiscovered {
         adventurer_state: AdventurerState,
-        special_names: LootItemSpecialNames
+        special_names: ItemSpecials
     }
 
     #[derive(Drop, starknet::Event)]
     struct ItemSuffixDiscovered {
         adventurer_state: AdventurerState,
-        special_names: LootItemSpecialNames
+        special_names: ItemSpecials
     }
 
     #[derive(Drop, starknet::Event)]
@@ -2523,7 +2523,7 @@ mod Game {
     fn __event_ItemPrefixDiscovered(
         ref self: ContractState,
         adventurer_state: AdventurerState,
-        special_names: LootItemSpecialNames
+        special_names: ItemSpecials
     ) {
         self
             .emit(
@@ -2536,7 +2536,7 @@ mod Game {
     fn __event_ItemSuffixDiscovered(
         ref self: ContractState,
         adventurer_state: AdventurerState,
-        special_names: LootItemSpecialNames
+        special_names: ItemSpecials
     ) {
         self
             .emit(

--- a/contracts/loot/src/loot.cairo
+++ b/contracts/loot/src/loot.cairo
@@ -13,8 +13,8 @@ use super::{
         }
     },
     utils::NameUtils::{
-        is_name_suffix_set1, is_name_suffix_set2, is_name_suffix_set3, is_item_suffix_set1,
-        is_item_suffix_set2, is_name_prefix_set1, is_name_prefix_set2, is_name_prefix_set3
+        is_special3_set1, is_special3_set2, is_special3_set3, is_special1_set1,
+        is_special1_set2, is_special2_set1, is_special2_set2, is_special2_set3
     }
 };
 
@@ -41,31 +41,31 @@ impl ImplLoot of ILoot {
             + item_index::get(item_id).into()
     }
 
-    // get_name_prefix returns the name prefix of an item (Agony, Apocalypse, Armageddon, etc)
+    // get_special2 returns the name prefix of an item (Agony, Apocalypse, Armageddon, etc)
     // @param self The item.
     // @param entropy The entropy.
     // @return The name prefix id.
-    fn get_name_prefix(item_id: u8, entropy: u128) -> u8 {
+    fn get_special2(item_id: u8, entropy: u128) -> u8 {
         (ImplLoot::generate_naming_seed(item_id, entropy) % NamePrefixLength.into() + 1)
             .try_into()
             .unwrap()
     }
 
-    // get_name_suffix returns the name suffix of an item (Bane, Root, Bite, etc)
+    // get_special3 returns the name suffix of an item (Bane, Root, Bite, etc)
     // @param self The item.
     // @param entropy The entropy.
     // @return The name suffix id.
-    fn get_name_suffix(item_id: u8, entropy: u128) -> u8 {
+    fn get_special3(item_id: u8, entropy: u128) -> u8 {
         (ImplLoot::generate_naming_seed(item_id, entropy) % NameSuffixLength.into() + 1)
             .try_into()
             .unwrap()
     }
 
-    // get_item_suffix returns the item suffix of an item (of_Power, of_Giant, of_Titans, etc)
+    // get_special1 returns the item suffix of an item (of_Power, of_Giant, of_Titans, etc)
     // @param self The item.
     // @param entropy The entropy.
     // @return The item suffix id.
-    fn get_item_suffix(item_id: u8, entropy: u128) -> u8 {
+    fn get_special1(item_id: u8, entropy: u128) -> u8 {
         (ImplLoot::generate_naming_seed(item_id, entropy) % ItemSuffixLength.into() + 1)
             .try_into()
             .unwrap()
@@ -164,7 +164,7 @@ impl PackingLoot of Packing<Loot> {
 
 #[test]
 #[available_gas(4000000)]
-fn test_item_suffix() {
+fn test_special1() {
     let mut i: usize = 0;
     loop {
         if i > U8IntoU32::into(ItemSuffixLength) {
@@ -172,18 +172,18 @@ fn test_item_suffix() {
         }
 
         // verify Grimoires only get item suffixes from set 1 (Power, Titans, Perfection, etc)
-        let grimoire_suffix = ImplLoot::get_item_suffix(ItemId::Grimoire, U32IntoU128::into(i));
-        let valid_grimoire_name = is_item_suffix_set1(grimoire_suffix);
+        let grimoire_suffix = ImplLoot::get_special1(ItemId::Grimoire, U32IntoU128::into(i));
+        let valid_grimoire_name = is_special1_set1(grimoire_suffix);
         assert(valid_grimoire_name, 'invalid grimoire item suffix');
 
         // verify Katanas only get item suffixes from set 2 (Giant, Skill, Brilliance, etc)
-        let katana_suffix = ImplLoot::get_item_suffix(ItemId::Katana, U32IntoU128::into(i));
-        let valid_katana_name = is_item_suffix_set2(katana_suffix);
+        let katana_suffix = ImplLoot::get_special1(ItemId::Katana, U32IntoU128::into(i));
+        let valid_katana_name = is_special1_set2(katana_suffix);
         assert(valid_katana_name, 'invalid katana item suffix');
 
         // verify dragonskin gloves only get suffixes from set 1
-        let ghost_wand_suffix = ImplLoot::get_item_suffix(ItemId::GhostWand, U32IntoU128::into(i));
-        let valid_ghost_wand_suffix = is_item_suffix_set1(ghost_wand_suffix);
+        let ghost_wand_suffix = ImplLoot::get_special1(ItemId::GhostWand, U32IntoU128::into(i));
+        let valid_ghost_wand_suffix = is_special1_set1(ghost_wand_suffix);
         assert(valid_ghost_wand_suffix, 'invalid ghost wand suffix');
 
         // increment counter
@@ -193,7 +193,7 @@ fn test_item_suffix() {
 
 #[test]
 #[available_gas(40000000)]
-fn test_item_name_suffix() {
+fn test_item_special3() {
     let mut i: usize = 0;
 
     // Items to test
@@ -230,7 +230,7 @@ fn test_item_name_suffix() {
         //
         // Katanas are always 'X Grasp'
         assert(
-            ImplLoot::get_name_suffix(
+            ImplLoot::get_special3(
                 ItemId::Katana, U32IntoU128::into(i)
             ) == ItemNameSuffix::Grasp,
             'katana should be grasp'
@@ -238,7 +238,7 @@ fn test_item_name_suffix() {
 
         // Warhammers are always 'X Bane'
         assert(
-            ImplLoot::get_name_suffix(
+            ImplLoot::get_special3(
                 ItemId::Warhammer, U32IntoU128::into(i)
             ) == ItemNameSuffix::Bane,
             'warhammer should be bane'
@@ -246,7 +246,7 @@ fn test_item_name_suffix() {
 
         // Books are always 'X Moon'
         assert(
-            ImplLoot::get_name_suffix(ItemId::Book, U32IntoU128::into(i)) == ItemNameSuffix::Moon,
+            ImplLoot::get_special3(ItemId::Book, U32IntoU128::into(i)) == ItemNameSuffix::Moon,
             'book should be moon'
         );
 
@@ -254,21 +254,21 @@ fn test_item_name_suffix() {
         //
         // Divine Robes are always {X Bane, X Song, X Instrument, X Shadow, X Growl, X Form} (set 1)
         assert(
-            is_name_suffix_set1(
-                ImplLoot::get_name_suffix(ItemId::DivineRobe, U32IntoU128::into(i))
+            is_special3_set1(
+                ImplLoot::get_special3(ItemId::DivineRobe, U32IntoU128::into(i))
             ),
             'invalid divine robe name suffix'
         );
 
         // Chain Mail is always {X Root, X Roar, X Glow, X Whisper, X Tear, X Sun} (set 2)
         assert(
-            is_name_suffix_set2(ImplLoot::get_name_suffix(ItemId::ChainMail, U32IntoU128::into(i))),
+            is_special3_set2(ImplLoot::get_special3(ItemId::ChainMail, U32IntoU128::into(i))),
             'invalid chain mail name suffix'
         );
 
         // Demon Husks are always {X Bite, X Grasp, X Bender, X Shout, X Peak, X Moon} (set 3)
         assert(
-            is_name_suffix_set3(ImplLoot::get_name_suffix(ItemId::DemonHusk, U32IntoU128::into(i))),
+            is_special3_set3(ImplLoot::get_special3(ItemId::DemonHusk, U32IntoU128::into(i))),
             'invalid demon husk name suffix'
         );
         //
@@ -277,22 +277,22 @@ fn test_item_name_suffix() {
         //
         // Ancient Helms use name suffix set 1
         assert(
-            is_name_suffix_set1(
-                ImplLoot::get_name_suffix(ItemId::AncientHelm, U32IntoU128::into(i))
+            is_special3_set1(
+                ImplLoot::get_special3(ItemId::AncientHelm, U32IntoU128::into(i))
             ),
             'invalid war cap name suffix'
         );
 
         // Crown uses name suffix set 2
         assert(
-            is_name_suffix_set2(ImplLoot::get_name_suffix(ItemId::Crown, U32IntoU128::into(i))),
+            is_special3_set2(ImplLoot::get_special3(ItemId::Crown, U32IntoU128::into(i))),
             'invalid crown name suffix'
         );
 
         // Divine Hood uses name suffix set 3
         assert(
-            is_name_suffix_set3(
-                ImplLoot::get_name_suffix(ItemId::DivineHood, U32IntoU128::into(i))
+            is_special3_set3(
+                ImplLoot::get_special3(ItemId::DivineHood, U32IntoU128::into(i))
             ),
             'invalid divine hood name suffix'
         );
@@ -302,24 +302,24 @@ fn test_item_name_suffix() {
         //
         // Ornate Belt uses name suffix set 1
         assert(
-            is_name_suffix_set1(
-                ImplLoot::get_name_suffix(ItemId::OrnateBelt, U32IntoU128::into(i))
+            is_special3_set1(
+                ImplLoot::get_special3(ItemId::OrnateBelt, U32IntoU128::into(i))
             ),
             'invalid ornate belt suffix'
         );
 
         // Brightsilk Sash uses name suffix set 2
         assert(
-            is_name_suffix_set2(
-                ImplLoot::get_name_suffix(ItemId::BrightsilkSash, U32IntoU128::into(i))
+            is_special3_set2(
+                ImplLoot::get_special3(ItemId::BrightsilkSash, U32IntoU128::into(i))
             ),
             'invalid brightsilk sash suffix'
         );
 
         // Hard Leather Belt uses name set 3
         assert(
-            is_name_suffix_set3(
-                ImplLoot::get_name_suffix(ItemId::HardLeatherBelt, U32IntoU128::into(i))
+            is_special3_set3(
+                ImplLoot::get_special3(ItemId::HardLeatherBelt, U32IntoU128::into(i))
             ),
             'wrong hard leather belt suffix'
         );
@@ -329,24 +329,24 @@ fn test_item_name_suffix() {
         //
         // Holy Graves uses name suffix set 1
         assert(
-            is_name_suffix_set1(
-                ImplLoot::get_name_suffix(ItemId::HolyGreaves, U32IntoU128::into(i))
+            is_special3_set1(
+                ImplLoot::get_special3(ItemId::HolyGreaves, U32IntoU128::into(i))
             ),
             'invalid holy greaves suffix'
         );
 
         // Heavy Boots use name suffix set 2
         assert(
-            is_name_suffix_set2(
-                ImplLoot::get_name_suffix(ItemId::HeavyBoots, U32IntoU128::into(i))
+            is_special3_set2(
+                ImplLoot::get_special3(ItemId::HeavyBoots, U32IntoU128::into(i))
             ),
             'invalid heavy boots suffix'
         );
 
         // Silk Slippers use name suffix set 3
         assert(
-            is_name_suffix_set3(
-                ImplLoot::get_name_suffix(ItemId::SilkSlippers, U32IntoU128::into(i))
+            is_special3_set3(
+                ImplLoot::get_special3(ItemId::SilkSlippers, U32IntoU128::into(i))
             ),
             'invalid silk slippers suffix'
         );
@@ -356,24 +356,24 @@ fn test_item_name_suffix() {
         //
         // Holy Gauntlets use name suffix set 1
         assert(
-            is_name_suffix_set1(
-                ImplLoot::get_name_suffix(ItemId::HolyGauntlets, U32IntoU128::into(i))
+            is_special3_set1(
+                ImplLoot::get_special3(ItemId::HolyGauntlets, U32IntoU128::into(i))
             ),
             'invalid holy gauntlets suffix'
         );
 
         // Linen Gloves use name suffix set 2
         assert(
-            is_name_suffix_set2(
-                ImplLoot::get_name_suffix(ItemId::LinenGloves, U32IntoU128::into(i))
+            is_special3_set2(
+                ImplLoot::get_special3(ItemId::LinenGloves, U32IntoU128::into(i))
             ),
             'invalid linen gloves suffix'
         );
 
         // Hard Leather Gloves use name suffix set 3
         assert(
-            is_name_suffix_set3(
-                ImplLoot::get_name_suffix(ItemId::HardLeatherGloves, U32IntoU128::into(i))
+            is_special3_set3(
+                ImplLoot::get_special3(ItemId::HardLeatherGloves, U32IntoU128::into(i))
             ),
             'invalid hard lthr gloves suffix'
         );
@@ -383,19 +383,19 @@ fn test_item_name_suffix() {
         //
         // Neckalce uses name suffix set 1
         assert(
-            is_name_suffix_set1(ImplLoot::get_name_suffix(ItemId::Necklace, U32IntoU128::into(i))),
+            is_special3_set1(ImplLoot::get_special3(ItemId::Necklace, U32IntoU128::into(i))),
             'invalid Necklace name suffix'
         );
 
         // Amulets use name suffix set 2
         assert(
-            is_name_suffix_set2(ImplLoot::get_name_suffix(ItemId::Amulet, U32IntoU128::into(i))),
+            is_special3_set2(ImplLoot::get_special3(ItemId::Amulet, U32IntoU128::into(i))),
             'invalid amulet name suffix'
         );
 
         // Pendants use name suffix set 3
         assert(
-            is_name_suffix_set3(ImplLoot::get_name_suffix(ItemId::Pendant, U32IntoU128::into(i))),
+            is_special3_set3(ImplLoot::get_special3(ItemId::Pendant, U32IntoU128::into(i))),
             'invalid pendant name suffix'
         );
 
@@ -424,22 +424,22 @@ fn test_item_prefix() {
         }
 
         // divine robe uses name prefix set 1
-        let divine_robe_prefix = ImplLoot::get_name_prefix(
+        let divine_robe_prefix = ImplLoot::get_special2(
             ItemId::DivineRobe, U32IntoU128::into(i)
         );
-        let divine_robe_prefix_valid = is_name_prefix_set1(divine_robe_prefix);
+        let divine_robe_prefix_valid = is_special2_set1(divine_robe_prefix);
         assert(divine_robe_prefix_valid, 'invalid divine robe belt prefix');
 
         // holy chest plate uses name prefix set 2
-        let holy_chestplate_prefix = ImplLoot::get_name_prefix(
+        let holy_chestplate_prefix = ImplLoot::get_special2(
             ItemId::HolyChestplate, U32IntoU128::into(i)
         );
-        let holy_chestplate_prefix_valid = is_name_prefix_set2(holy_chestplate_prefix);
+        let holy_chestplate_prefix_valid = is_special2_set2(holy_chestplate_prefix);
         assert(holy_chestplate_prefix_valid, 'invalid holy chestplate prefix');
 
         // katana uses name prefix set 3
-        let katana_prefix = ImplLoot::get_name_prefix(ItemId::Katana, U32IntoU128::into(i));
-        let katana_prefix_valid = is_name_prefix_set3(katana_prefix);
+        let katana_prefix = ImplLoot::get_special2(ItemId::Katana, U32IntoU128::into(i));
+        let katana_prefix_valid = is_special2_set3(katana_prefix);
         assert(katana_prefix_valid, 'invalid katana prefix');
 
         i += 1;

--- a/contracts/loot/src/utils.cairo
+++ b/contracts/loot/src/utils.cairo
@@ -4,7 +4,7 @@ mod NameUtils {
     // name suffixes are the second part of the prefix aka the "Grasp" part of "Demon Grasp"
     // I realize this is a bit confusing but this is what the
     // loot contract refers to them as so I'm just being consistent with the contract
-    fn is_name_suffix_set1(name: u8) -> bool {
+    fn is_special3_set1(name: u8) -> bool {
         return (name == ItemNameSuffix::Bane
             || name == ItemNameSuffix::Song
             || name == ItemNameSuffix::Instrument
@@ -13,7 +13,7 @@ mod NameUtils {
             || name == ItemNameSuffix::Form);
     }
 
-    fn is_name_suffix_set2(name: u8) -> bool {
+    fn is_special3_set2(name: u8) -> bool {
         return (name == ItemNameSuffix::Root
             || name == ItemNameSuffix::Roar
             || name == ItemNameSuffix::Glow
@@ -22,7 +22,7 @@ mod NameUtils {
             || name == ItemNameSuffix::Sun);
     }
 
-    fn is_name_suffix_set3(name: u8) -> bool {
+    fn is_special3_set3(name: u8) -> bool {
         return (name == ItemNameSuffix::Bite
             || name == ItemNameSuffix::Grasp
             || name == ItemNameSuffix::Bender
@@ -31,7 +31,7 @@ mod NameUtils {
             || name == ItemNameSuffix::Moon);
     }
 
-    fn is_name_prefix_set1(name: u8) -> bool {
+    fn is_special2_set1(name: u8) -> bool {
         if name < 1 || name > 69 {
             false
         } else {
@@ -39,7 +39,7 @@ mod NameUtils {
         }
     }
 
-    fn is_name_prefix_set2(name: u8) -> bool {
+    fn is_special2_set2(name: u8) -> bool {
         if name < 2 || name > 69 {
             false
         } else {
@@ -47,7 +47,7 @@ mod NameUtils {
         }
     }    
 
-    fn is_name_prefix_set3(name: u8) -> bool {
+    fn is_special2_set3(name: u8) -> bool {
         if name < 3 || name > 69 {
             false
         } else {
@@ -56,7 +56,7 @@ mod NameUtils {
     }
 
     // the item suffix is the suffix of the item such as "of Power"
-    fn is_item_suffix_set1(name: u8) -> bool {
+    fn is_special1_set1(name: u8) -> bool {
         return (name == ItemSuffix::of_Power
             || name == ItemSuffix::of_Titans
             || name == ItemSuffix::of_Perfection
@@ -67,7 +67,7 @@ mod NameUtils {
             || name == ItemSuffix::of_Reflection);
     }
 
-    fn is_item_suffix_set2(name: u8) -> bool {
+    fn is_special1_set2(name: u8) -> bool {
         return (name == ItemSuffix::of_Giant
             || name == ItemSuffix::of_Skill
             || name == ItemSuffix::of_Brilliance


### PR DESCRIPTION
To make the contract more generalized, this commit moves away items having SpecialNames and "name_prefix", "name_suffix", and "item_suffix" to having "SpecialPowers" with "special1", "special2", "special3".

For Loot based adventure games, the names will equal the powers but this makes the contract more agnostic