### PR TITLE
significant event refactoring

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -256,9 +256,7 @@ impl ImplAdventurer of IAdventurer {
     // @return ItemPrimitive: Item at slot
     fn get_item_at_slot(self: Adventurer, slot: Slot) -> ItemPrimitive {
         match slot {
-            Slot::None(()) => ItemPrimitive {
-                id: 0, xp: 0, metadata: 0, 
-            },
+            Slot::None(()) => ItemPrimitive { id: 0, xp: 0, metadata: 0,  },
             Slot::Weapon(()) => self.weapon,
             Slot::Chest(()) => self.chest,
             Slot::Head(()) => self.head,
@@ -339,42 +337,23 @@ impl ImplAdventurer of IAdventurer {
     // @param entropy: Entropy for generating treasure
     // @return TreasureDiscovery: The type of treasure discovered.
     // @return u16: The amount of treasure discovered.
-    fn discover_treasure(ref self: Adventurer, entropy: u128) -> (TreasureDiscovery, u16) {
+    fn discover_treasure(self: Adventurer, entropy: u128) -> (TreasureDiscovery, u16) {
         // generate random item discovery
         let item_type = ExploreUtils::get_random_treasury_discovery(self, entropy);
 
         match item_type {
             TreasureDiscovery::Gold(()) => {
-                // get gold discovery
-                let gold_amount = ExploreUtils::get_gold_discovery(self, entropy);
-                // add it to adventurers gold balance
-                self.add_gold(gold_amount);
-                // no level up possible from gold discovery
-                // so return current level for both previous and new level
-                (TreasureDiscovery::Gold(()), gold_amount)
+                // return discovery type and amount
+                (TreasureDiscovery::Gold(()), ExploreUtils::get_gold_discovery(self, entropy))
             },
             TreasureDiscovery::XP(()) => {
-                // get xp discovery
-                let xp_amount = ExploreUtils::get_xp_discovery(self, entropy);
-                // add it to adventurer's xp 
-                // increase adventurer xp
-                (TreasureDiscovery::XP(()), xp_amount)
+                // return discovery type and amount
+                (TreasureDiscovery::XP(()), ExploreUtils::get_xp_discovery(self, entropy))
             },
             TreasureDiscovery::Health(()) => {
-                // if adventurer's health is already full
-                if (self.has_full_health()) {
-                    // they get 1 gold as a consolation prize
-                    // the primary reason for this is to ensure the adventurers
-                    // state is modified to change the the next explore outcome
-                    self.add_gold(1);
-                    (TreasureDiscovery::Gold(()), 1)
-                } else {
-                    // get health discovery
-                    let health_amount = ExploreUtils::get_health_discovery(self, entropy);
-                    self.add_health(health_amount);
-                    (TreasureDiscovery::Health(()), health_amount)
-                }
-            },
+                // return discovery type and amount
+                (TreasureDiscovery::Health(()), ExploreUtils::get_health_discovery(self, entropy))
+            }
         }
     }
 
@@ -2664,16 +2643,19 @@ fn test_discover_treasure() {
     adventurer.xp = 25;
 
     // disover gold
-    adventurer.discover_treasure(5);
-    assert(adventurer.gold > STARTING_GOLD, 'should have gained gold');
+    let (discovery_type, amount) = adventurer.discover_treasure(5);
+    assert(discovery_type == TreasureDiscovery::Gold(()), 'should have found gold');
+    assert(amount > 0, 'gold should be non-zero');
 
     // discover health
-    adventurer.discover_treasure(6);
-    assert(adventurer.health > STARTING_HEALTH, 'should have gained health');
+    let (discovery_type, amount) = adventurer.discover_treasure(6);
+    assert(discovery_type == TreasureDiscovery::Health(()), 'should have found health');
+    assert(amount > 0, 'health should be non-zero');
 
     // discover xp
-    adventurer.discover_treasure(7);
-    assert(adventurer.xp > 25, 'should have gained xp');
+    let (discovery_type, amount) = adventurer.discover_treasure(7);
+    assert(discovery_type == TreasureDiscovery::XP(()), 'should have found xp');
+    assert(amount > 0, 'xp should be non-zero');
 }
 
 #[test]

--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -256,6 +256,9 @@ impl ImplAdventurer of IAdventurer {
     // @return ItemPrimitive: Item at slot
     fn get_item_at_slot(self: Adventurer, slot: Slot) -> ItemPrimitive {
         match slot {
+            Slot::None(()) => ItemPrimitive {
+                id: 0, xp: 0, metadata: 0, 
+            },
             Slot::Weapon(()) => self.weapon,
             Slot::Chest(()) => self.chest,
             Slot::Head(()) => self.head,
@@ -274,6 +277,7 @@ impl ImplAdventurer of IAdventurer {
     fn is_slot_free(self: Adventurer, item: ItemPrimitive) -> bool {
         let slot = ImplLoot::get_slot(item.id);
         match slot {
+            Slot::None(()) => false,
             Slot::Weapon(()) => self.weapon.id == 0,
             Slot::Chest(()) => self.chest.id == 0,
             Slot::Head(()) => self.head.id == 0,
@@ -333,7 +337,9 @@ impl ImplAdventurer of IAdventurer {
     // Possible discoveries include gold, XP, and health.
     // @param self: Adventurer to discover treasure for
     // @param entropy: Entropy for generating treasure
-    fn discover_treasure(ref self: Adventurer, entropy: u128) -> (TreasureDiscovery, u16, u8, u8) {
+    // @return TreasureDiscovery: The type of treasure discovered.
+    // @return u16: The amount of treasure discovered.
+    fn discover_treasure(ref self: Adventurer, entropy: u128) -> (TreasureDiscovery, u16) {
         // generate random item discovery
         let item_type = ExploreUtils::get_random_treasury_discovery(self, entropy);
 
@@ -345,16 +351,14 @@ impl ImplAdventurer of IAdventurer {
                 self.add_gold(gold_amount);
                 // no level up possible from gold discovery
                 // so return current level for both previous and new level
-                return (
-                    TreasureDiscovery::Gold(()), gold_amount, self.get_level(), self.get_level()
-                );
+                (TreasureDiscovery::Gold(()), gold_amount)
             },
             TreasureDiscovery::XP(()) => {
                 // get xp discovery
                 let xp_amount = ExploreUtils::get_xp_discovery(self, entropy);
                 // add it to adventurer's xp 
-                let (previous_level, new_level) = self.increase_adventurer_xp(xp_amount);
-                return (TreasureDiscovery::XP(()), xp_amount, previous_level, new_level);
+                // increase adventurer xp
+                (TreasureDiscovery::XP(()), xp_amount)
             },
             TreasureDiscovery::Health(()) => {
                 // if adventurer's health is already full
@@ -363,19 +367,12 @@ impl ImplAdventurer of IAdventurer {
                     // the primary reason for this is to ensure the adventurers
                     // state is modified to change the the next explore outcome
                     self.add_gold(1);
-                    return (TreasureDiscovery::Gold(()), 1, self.get_level(), self.get_level());
+                    (TreasureDiscovery::Gold(()), 1)
                 } else {
                     // get health discovery
                     let health_amount = ExploreUtils::get_health_discovery(self, entropy);
                     self.add_health(health_amount);
-                    // no level up possible for health discovery
-                    // so return the current level for both previous and new level
-                    return (
-                        TreasureDiscovery::Health(()),
-                        health_amount,
-                        self.get_level(),
-                        self.get_level()
-                    );
+                    (TreasureDiscovery::Health(()), health_amount)
                 }
             },
         }
@@ -706,6 +703,7 @@ impl ImplAdventurer of IAdventurer {
     fn add_item(ref self: Adventurer, item: ItemPrimitive) {
         let slot = ImplLoot::get_slot(item.id);
         match slot {
+            Slot::None(()) => (),
             Slot::Weapon(()) => self.equip_weapon(item),
             Slot::Chest(()) => self.equip_chest_armor(item),
             Slot::Head(()) => self.equip_head_armor(item),
@@ -2263,7 +2261,7 @@ fn test_increment_stat_valid() {
 
     adventurer.increment_stat(StatisticIndex::STRENGTH);
     assert(adventurer.stats.strength == 1, 'strength');
-    assert(adventurer.stats.dexterity ==  0, 'dexterity should be 0');
+    assert(adventurer.stats.dexterity == 0, 'dexterity should be 0');
     assert(adventurer.stats.intelligence == 0, 'intelligence should be 0');
     assert(adventurer.stats.vitality == 0, 'vitality should be 0');
     assert(adventurer.stats.wisdom == 0, 'wisdom should be 0');

--- a/contracts/adventurer/src/adventurer_utils.cairo
+++ b/contracts/adventurer/src/adventurer_utils.cairo
@@ -38,7 +38,7 @@ impl AdventurerUtils of IAdventurer {
         }
     }
 
-    fn get_random_armor_slot(entropy: u128) -> Slot {
+    fn get_random_attack_location(entropy: u128) -> Slot {
         // project entropy into 0-4 range
         let rnd_slot = entropy % 5;
 
@@ -94,30 +94,30 @@ fn test_get_random_explore() {
 
 #[test]
 #[available_gas(60000)]
-fn test_get_random_armor_slot() {
+fn test_get_random_attack_location() {
     // base cases
     let mut entropy = 0;
-    let mut armor = AdventurerUtils::get_random_armor_slot(entropy);
+    let mut armor = AdventurerUtils::get_random_attack_location(entropy);
     assert(armor == Slot::Chest(()), 'should be chest');
 
     entropy = 1;
-    armor = AdventurerUtils::get_random_armor_slot(entropy);
+    armor = AdventurerUtils::get_random_attack_location(entropy);
     assert(armor == Slot::Head(()), 'should be head');
 
     entropy = 2;
-    armor = AdventurerUtils::get_random_armor_slot(entropy);
+    armor = AdventurerUtils::get_random_attack_location(entropy);
     assert(armor == Slot::Waist(()), 'should be waist');
 
     entropy = 3;
-    armor = AdventurerUtils::get_random_armor_slot(entropy);
+    armor = AdventurerUtils::get_random_attack_location(entropy);
     assert(armor == Slot::Foot(()), 'should be foot');
 
     entropy = 4;
-    armor = AdventurerUtils::get_random_armor_slot(entropy);
+    armor = AdventurerUtils::get_random_attack_location(entropy);
     assert(armor == Slot::Hand(()), 'should be hand');
 
     // rollover and verify armor goes back to chest
     entropy = 5;
-    armor = AdventurerUtils::get_random_armor_slot(entropy);
+    armor = AdventurerUtils::get_random_attack_location(entropy);
     assert(armor == Slot::Chest(()), 'should be chest');
 }

--- a/contracts/beasts/src/beast.cairo
+++ b/contracts/beasts/src/beast.cairo
@@ -78,6 +78,7 @@ impl ImplBeast of IBeast {
         let mut beast_id: u8 = Gnome;
 
         match starter_weapon_type {
+            Type::None(()) => beast_id = Troll,
             // if adventurer starts with a magical weapon, they face a troll as their first beast
             Type::Magic_or_Cloth(()) => beast_id = Troll,
             // if the adventurer starts with a blade or hide weapon, they face a rat as their first beast

--- a/contracts/combat/src/combat.cairo
+++ b/contracts/combat/src/combat.cairo
@@ -90,10 +90,10 @@ impl ImplCombat of ICombat {
         // that the minimum damage is always done
         if (total_attack > (armor_hp + minimum_damage)) {
             // return total attack
-            return total_attack - armor_hp;
+            total_attack - armor_hp
         } else {
             // otreturn total attack
-            return minimum_damage;
+            minimum_damage
         }
     }
 
@@ -102,20 +102,21 @@ impl ImplCombat of ICombat {
     // @return u16: the attack HP of the weapon
     fn get_attack_hp(weapon: CombatSpec) -> u16 {
         match weapon.tier {
+            Tier::None(()) => 0,
             Tier::T1(()) => {
-                return weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T1;
+                weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T1
             },
             Tier::T2(()) => {
-                return weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T2;
+                weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T2
             },
             Tier::T3(()) => {
-                return weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T3;
+                weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T3
             },
             Tier::T4(()) => {
-                return weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T4;
+                weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T4
             },
             Tier::T5(()) => {
-                return weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T5;
+                weapon.level * WEAPON_TIER_DAMAGE_MULTIPLIER::T5
             }
         }
     }
@@ -125,20 +126,21 @@ impl ImplCombat of ICombat {
     // @return u16: the armor HP of the armor
     fn get_armor_hp(armor: CombatSpec) -> u16 {
         match armor.tier {
+            Tier::None(()) => 0,
             Tier::T1(()) => {
-                return armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T1;
+                armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T1
             },
             Tier::T2(()) => {
-                return armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T2;
+                armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T2
             },
             Tier::T3(()) => {
-                return armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T3;
+                armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T3
             },
             Tier::T4(()) => {
-                return armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T4;
+                armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T4
             },
             Tier::T5(()) => {
-                return armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T5;
+                armor.level * ARMOR_TIER_DAMAGE_MULTIPLIER::T5
             }
         }
     }
@@ -155,17 +157,17 @@ impl ImplCombat of ICombat {
         // adjust base damage based on weapon effectiveness
         match weapon_effectiveness {
             WeaponEffectiveness::Weak(()) => {
-                return damage - elemental_damage_effect;
+                damage - elemental_damage_effect
             },
             WeaponEffectiveness::Fair(()) => {
-                return damage;
+                damage
             },
             WeaponEffectiveness::Strong(()) => {
                 let elemental_adjusted_damage = damage + elemental_damage_effect;
                 if (elemental_adjusted_damage < STRONG_ELEMENTAL_BONUS_MIN) {
-                    return STRONG_ELEMENTAL_BONUS_MIN;
+                    STRONG_ELEMENTAL_BONUS_MIN
                 } else {
-                    return elemental_adjusted_damage;
+                    elemental_adjusted_damage
                 }
             }
         }
@@ -178,77 +180,92 @@ impl ImplCombat of ICombat {
     // @return WeaponEffectiveness: the effectiveness of the weapon against the armor
     fn get_weapon_effectiveness(weapon_type: Type, armor_type: Type) -> WeaponEffectiveness {
         match weapon_type {
+            Type::None(()) => {
+                WeaponEffectiveness::Fair(())
+            },
             // Magic is strong against metal, fair against cloth, and weak against hide
             Type::Magic_or_Cloth(()) => {
                 match armor_type {
+                    // weapon is strong against no armor
+                    Type::None(()) => {
+                        WeaponEffectiveness::Strong(())
+                    },
                     Type::Magic_or_Cloth(()) => {
-                        return WeaponEffectiveness::Fair(());
+                        WeaponEffectiveness::Fair(())
                     },
                     Type::Blade_or_Hide(()) => {
-                        return WeaponEffectiveness::Weak(());
+                        WeaponEffectiveness::Weak(())
                     },
                     Type::Bludgeon_or_Metal(()) => {
-                        return WeaponEffectiveness::Strong(());
+                        WeaponEffectiveness::Strong(())
                     },
                     // should not happen but compiler requires exhaustive match
                     Type::Necklace(()) => {
-                        return WeaponEffectiveness::Fair(());
+                        WeaponEffectiveness::Fair(())
                     },
                     // should not happen but compiler requires exhaustive match
                     Type::Ring(()) => {
-                        return WeaponEffectiveness::Fair(());
+                        WeaponEffectiveness::Fair(())
                     }
                 }
             },
             // Blade is strong against cloth, fair against hide, and weak against metal
             Type::Blade_or_Hide(()) => {
                 match armor_type {
+                    // weapon is strong against no armor
+                    Type::None(()) => {
+                        WeaponEffectiveness::Strong(())
+                    },
                     Type::Magic_or_Cloth(()) => {
-                        return WeaponEffectiveness::Strong(());
+                        WeaponEffectiveness::Strong(())
                     },
                     Type::Blade_or_Hide(()) => {
-                        return WeaponEffectiveness::Fair(());
+                        WeaponEffectiveness::Fair(())
                     },
                     Type::Bludgeon_or_Metal(()) => {
-                        return WeaponEffectiveness::Weak(());
+                        WeaponEffectiveness::Weak(())
                     },
                     // should not happen but compiler requires exhaustive match
                     Type::Necklace(()) => {
-                        return WeaponEffectiveness::Fair(());
+                        WeaponEffectiveness::Fair(())
                     },
                     // should not happen but compiler requires exhaustive match
                     Type::Ring(()) => {
-                        return WeaponEffectiveness::Fair(());
+                        WeaponEffectiveness::Fair(())
                     }
                 }
             },
             // Bludgeon is strong against hide, fair against metal, and weak against cloth
             Type::Bludgeon_or_Metal(()) => {
                 match armor_type {
+                    // weapon is strong against no armor
+                    Type::None(()) => {
+                        WeaponEffectiveness::Strong(())
+                    },
                     Type::Magic_or_Cloth(()) => {
-                        return WeaponEffectiveness::Weak(());
+                        WeaponEffectiveness::Weak(())
                     },
                     Type::Blade_or_Hide(()) => {
-                        return WeaponEffectiveness::Strong(());
+                        WeaponEffectiveness::Strong(())
                     },
                     Type::Bludgeon_or_Metal(()) => {
-                        return WeaponEffectiveness::Fair(());
+                        WeaponEffectiveness::Fair(())
                     },
                     // should not happen but compiler requires exhaustive match
                     Type::Necklace(()) => {
-                        return WeaponEffectiveness::Fair(());
+                        WeaponEffectiveness::Fair(())
                     },
                     // should not happen but compiler requires exhaustive match
                     Type::Ring(()) => {
-                        return WeaponEffectiveness::Fair(());
+                        WeaponEffectiveness::Fair(())
                     }
                 }
             },
             Type::Necklace(()) => {
-                return WeaponEffectiveness::Fair(());
+                WeaponEffectiveness::Fair(())
             },
             Type::Ring(()) => {
-                return WeaponEffectiveness::Fair(());
+                WeaponEffectiveness::Fair(())
             },
         }
     }
@@ -276,10 +293,10 @@ impl ImplCombat of ICombat {
         // if the critical hit random number is 0 (no remainder)
         if (critical_hit_outcome == 0) {
             // return true
-            return true;
+            true
         } else {
             // otherwise return false
-            return false;
+            false
         }
     }
 
@@ -295,7 +312,7 @@ impl ImplCombat of ICombat {
         let damage_multplier = U128TryIntoU16::try_into(entropy % 4).unwrap();
 
         // multiply base damage boost (25% of original damage) by damage multiplier (1-4)
-        return damage_boost_base * (damage_multplier + 1);
+        damage_boost_base * (damage_multplier + 1)
     }
 
     // get_special2_bonus returns the bonus damage done by a weapon as a result of the weapon special2
@@ -307,20 +324,17 @@ impl ImplCombat of ICombat {
     fn get_special2_bonus(
         damage: u16, weapon_prefix1: u8, armor_prefix1: u8, entropy: u128, 
     ) -> u16 {
-        // is the weapon does not have a prefix
-        if (weapon_prefix1 == 0) {
-            // return zero
-            return 0;
-        // if the weapon prefix is the same as the armor prefix
-        } else if (weapon_prefix1 == armor_prefix1) {
+        // is the weapon prefix matches the armor prefix
+        if (weapon_prefix1 == armor_prefix1) {
+            // grant bonus
             let damage_multplier = U128TryIntoU16::try_into(entropy % 4).unwrap();
 
             // result will be base damage * (4-7) which will equate to a 4-7x damage bonus
-            return damage * (damage_multplier + 4);
+            (damage * (damage_multplier + 4))
+        } else {
+            // fall through return zero
+            0
         }
-
-        // fall through return zero
-        0
     }
 
     // get_special3_bonus returns the bonus damage done by a weapon as a result of the weapon special3
@@ -332,12 +346,8 @@ impl ImplCombat of ICombat {
     fn get_special3_bonus(
         base_damage: u16, weapon_prefix2: u8, armor_prefix2: u8, entropy: u128, 
     ) -> u16 {
-        // is the weapon does not have a prefix
-        if (weapon_prefix2 == 0) {
-            // return zero
-            return 0;
-        // if the weapon prefix is the same as the armor prefix
-        } else if (weapon_prefix2 == armor_prefix2) {
+        // is the weapon prefix2 matches the armor prefix2
+        if (weapon_prefix2 == armor_prefix2) {
             // divide base damage by 4 to get 25% of original damage
             let damage_boost_base = base_damage / 4;
 
@@ -345,11 +355,11 @@ impl ImplCombat of ICombat {
             let damage_multplier = U128TryIntoU16::try_into(entropy % 4).unwrap();
 
             // multiply base damage boost (25% of original damage) by damage multiplier (1-4)
-            return damage_boost_base * (damage_multplier + 1);
+            damage_boost_base * (damage_multplier + 1)
+        } else {
+            // fall through return zero
+            0
         }
-
-        // fall through return zero
-        0
     }
 
     // get_special_name_damage_bonus returns the bonus damage for special item
@@ -370,7 +380,7 @@ impl ImplCombat of ICombat {
         );
 
         // return the sum of the name prefix and name suffix bonuses
-        return special2_bonus + special3_bonus;
+        special2_bonus + special3_bonus
     }
 
     // get_adventurer_strength_bonus returns the bonus damage for adventurer strength
@@ -380,10 +390,10 @@ impl ImplCombat of ICombat {
     fn get_strength_bonus(damage: u16, strength: u16) -> u16 {
         if (strength == 0) {
             // if the adventurer has no strength, return zero
-            return 0;
+            0
         } else {
             // each strength stat point is worth 20% of the original damage
-            return (damage * strength * 20) / 100;
+            (damage * strength * 20) / 100
         }
     }
 
@@ -399,28 +409,28 @@ impl ImplCombat of ICombat {
         // If adventurer has not exceeded the difficult cliff level
         if (adventurer_level <= range_increase_interval) {
             // return the adventurer level
-            return adventurer_level;
+            adventurer_level
+        } else {
+            // If adventurer has exceeded the difficult cliff level
+            // the entity level will be randomnly scoped around the adventurer level
+            // the max level of entitys will increase every N levels based on 
+            // the DIFFICULTY_CLIFF setting. The higher this setting, the less frequently the max level will increase
+            let entity_level_multplier = 1 + (adventurer_level / range_increase_interval);
+
+            // maximum range of the entity level will be the above multplier * the entity difficulty
+            let entity_level_range = U8IntoU128::into(entity_level_multplier * level_multiplier);
+
+            // calculate the entity level 
+            let entity_level_boost = entropy % entity_level_range;
+
+            // add the entity level boost to the adventurer level - difficulty cliff
+            // this will produce a level between (adventurer level - difficulty cliff) and entity_level_multplier * entity_constants::Settings::entity_LEVEL_RANGE
+            let entity_level = entity_level_boost
+                + U8IntoU128::into((adventurer_level - entity_level_multplier));
+
+            // return the entity level as a u16
+            U128TryIntoU8::try_into(entity_level).unwrap()
         }
-
-        // If adventurer has exceeded the difficult cliff level
-        // the entity level will be randomnly scoped around the adventurer level
-        // the max level of entitys will increase every N levels based on 
-        // the DIFFICULTY_CLIFF setting. The higher this setting, the less frequently the max level will increase
-        let entity_level_multplier = 1 + (adventurer_level / range_increase_interval);
-
-        // maximum range of the entity level will be the above multplier * the entity difficulty
-        let entity_level_range = U8IntoU128::into(entity_level_multplier * level_multiplier);
-
-        // calculate the entity level 
-        let entity_level_boost = entropy % entity_level_range;
-
-        // add the entity level boost to the adventurer level - difficulty cliff
-        // this will produce a level between (adventurer level - difficulty cliff) and entity_level_multplier * entity_constants::Settings::entity_LEVEL_RANGE
-        let entity_level = entity_level_boost
-            + U8IntoU128::into((adventurer_level - entity_level_multplier));
-
-        // return the entity level as a u16
-        return U128TryIntoU8::try_into(entity_level).unwrap();
     }
 
     // get_enemy_starting_health returns the starting health for an entity
@@ -442,10 +452,10 @@ impl ImplCombat of ICombat {
 
         // the remainder of entropy divided by max_health provides entity health
         // we then add 1 to minimum_health to prevent starting health of zero
-        return U128TryIntoU16::try_into(
+        U128TryIntoU16::try_into(
             U8IntoU128::into(adventurer_level + minimum_health) + (entropy % max_health)
         )
-            .unwrap();
+            .unwrap()
     }
 
 
@@ -454,9 +464,9 @@ impl ImplCombat of ICombat {
     // @return u8: the level for the given xp
     fn get_level_from_xp(xp: u16) -> u8 {
         if (xp > 0) {
-            return u16_sqrt(xp);
+            u16_sqrt(xp)
         } else {
-            return 1;
+            1
         }
     }
 
@@ -465,6 +475,9 @@ impl ImplCombat of ICombat {
     // @return u16: the xp reward for defeating the entity
     fn get_xp_reward(self: CombatSpec) -> u16 {
         match self.tier {
+            Tier::None(()) => {
+                0
+            },
             Tier::T1(()) => {
                 (XP_MULTIPLIER::T1 * self.level) / XP_REWARD_DIVISOR
             },
@@ -487,11 +500,12 @@ impl ImplCombat of ICombat {
         // generate random damage location based on Item Slot which has
         // armor in slots 2-6 inclusive
         let damage_location = 2 + (entropy % 6);
-        return ImplCombat::u8_to_slot(U128TryIntoU8::try_into(damage_location).unwrap());
+        ImplCombat::u8_to_slot(U128TryIntoU8::try_into(damage_location).unwrap())
     }
 
     fn tier_to_u8(tier: Tier) -> u8 {
         match tier {
+            Tier::None(()) => 0,
             Tier::T1(()) => 1,
             Tier::T2(()) => 2,
             Tier::T3(()) => 3,
@@ -501,6 +515,7 @@ impl ImplCombat of ICombat {
     }
     fn type_to_u8(item_type: Type) -> u8 {
         match item_type {
+            Type::None(()) => 0,
             Type::Magic_or_Cloth(()) => 1,
             Type::Blade_or_Hide(()) => 2,
             Type::Bludgeon_or_Metal(()) => 3,
@@ -510,30 +525,37 @@ impl ImplCombat of ICombat {
     }
     fn u8_to_type(item_type: u8) -> Type {
         if (item_type == 1) {
-            return Type::Magic_or_Cloth(());
+            Type::Magic_or_Cloth(())
         } else if (item_type == 2) {
-            return Type::Blade_or_Hide(());
+            Type::Blade_or_Hide(())
         } else if (item_type == 3) {
-            return Type::Bludgeon_or_Metal(());
+            Type::Bludgeon_or_Metal(())
         } else if (item_type == 4) {
-            return Type::Necklace(());
+            Type::Necklace(())
+        } else if (item_type == 5) {
+            Type::Ring(())
+        } else {
+            Type::None(())
         }
-        return Type::Ring(());
     }
     fn u8_to_tier(item_type: u8) -> Tier {
         if (item_type == 1) {
-            return Tier::T1(());
+            Tier::T1(())
         } else if (item_type == 2) {
-            return Tier::T2(());
+            Tier::T2(())
         } else if (item_type == 3) {
-            return Tier::T3(());
+            Tier::T3(())
         } else if (item_type == 4) {
-            return Tier::T4(());
+            Tier::T4(())
+        } else if (item_type == 5) {
+            Tier::T5(())
+        } else {
+            Tier::None(())
         }
-        return Tier::T5(());
     }
     fn slot_to_u8(slot: Slot) -> u8 {
         match slot {
+            Slot::None(()) => 0,
             Slot::Weapon(()) => 1,
             Slot::Chest(()) => 2,
             Slot::Head(()) => 3,
@@ -546,21 +568,23 @@ impl ImplCombat of ICombat {
     }
     fn u8_to_slot(item_type: u8) -> Slot {
         if (item_type == 1) {
-            return Slot::Weapon(());
+            Slot::Weapon(())
         } else if (item_type == 2) {
-            return Slot::Chest(());
+            Slot::Chest(())
         } else if (item_type == 3) {
-            return Slot::Head(());
+            Slot::Head(())
         } else if (item_type == 4) {
-            return Slot::Waist(());
+            Slot::Waist(())
         } else if (item_type == 5) {
-            return Slot::Foot(());
+            Slot::Foot(())
         } else if (item_type == 6) {
-            return Slot::Hand(());
+            Slot::Hand(())
         } else if (item_type == 7) {
-            return Slot::Neck(());
+            Slot::Neck(())
+        } else if (item_type == 8) {
+            Slot::Ring(())
         } else {
-            return Slot::Ring(());
+            Slot::None(())
         }
     }
 
@@ -579,7 +603,7 @@ impl ImplCombat of ICombat {
         // The difficulty cliff serves as a starting cushion for the adventurer before which
         // they can avoid all threats. Once the difficulty cliff has been passed, the adventurer
         // must invest in the proper stats to avoid threats.{Intelligence for obstalce, Wisdom for beast ambushes}
-        return (dice_roll <= (relevant_stat + DIFFICULTY_CLIFF::NORMAL));
+        (dice_roll <= (relevant_stat + DIFFICULTY_CLIFF::NORMAL))
     }
 }
 
@@ -1161,19 +1185,13 @@ fn test_calculate_damage() {
     // initialize weapon
     let weapon_specials = SpecialPowers { special1: 0, special2: 0, special3: 0 };
     let mut weapon = CombatSpec {
-        item_type: Type::Blade_or_Hide(()),
-        tier: Tier::T5(()),
-        level: 1,
-        specials: weapon_specials
+        item_type: Type::Blade_or_Hide(()), tier: Tier::T5(()), level: 1, specials: weapon_specials
     };
 
     // initialize armor
     let armor_specials = SpecialPowers { special1: 0, special2: 0, special3: 0 };
     let mut armor = CombatSpec {
-        item_type: Type::Blade_or_Hide(()),
-        tier: Tier::T5(()),
-        level: 1,
-        specials: armor_specials
+        item_type: Type::Blade_or_Hide(()), tier: Tier::T5(()), level: 1, specials: armor_specials
     };
 
     // initialize other combat parameters

--- a/contracts/combat/src/combat.cairo
+++ b/contracts/combat/src/combat.cairo
@@ -325,7 +325,7 @@ impl ImplCombat of ICombat {
         damage: u16, weapon_prefix1: u8, armor_prefix1: u8, entropy: u128, 
     ) -> u16 {
         // is the weapon prefix matches the armor prefix
-        if (weapon_prefix1 == armor_prefix1) {
+        if (weapon_prefix1 != 0 && weapon_prefix1 == armor_prefix1) {
             // grant bonus
             let damage_multplier = U128TryIntoU16::try_into(entropy % 4).unwrap();
 
@@ -347,7 +347,7 @@ impl ImplCombat of ICombat {
         base_damage: u16, weapon_prefix2: u8, armor_prefix2: u8, entropy: u128, 
     ) -> u16 {
         // is the weapon prefix2 matches the armor prefix2
-        if (weapon_prefix2 == armor_prefix2) {
+        if (weapon_prefix2 != 0 && weapon_prefix2 == armor_prefix2) {
             // divide base damage by 4 to get 25% of original damage
             let damage_boost_base = base_damage / 4;
 

--- a/contracts/combat/src/constants.cairo
+++ b/contracts/combat/src/constants.cairo
@@ -8,6 +8,7 @@ mod CombatEnums {
 
     #[derive(Copy, Drop, PartialEq, Serde)]
     enum Type {
+        None: (),
         Magic_or_Cloth: (),
         Blade_or_Hide: (),
         Bludgeon_or_Metal: (),
@@ -17,6 +18,7 @@ mod CombatEnums {
 
     #[derive(Copy, Drop, PartialEq, Serde)]
     enum Tier {
+        None: (),
         T1: (),
         T2: (),
         T3: (),
@@ -26,6 +28,7 @@ mod CombatEnums {
 
     #[derive(Copy, Drop, PartialEq, Serde)]
     enum Slot {
+        None: (),
         Weapon: (),
         Chest: (),
         Head: (),

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -78,17 +78,18 @@ mod Game {
     enum Event {
         StartGame: StartGame,
         StatUpgraded: StatUpgraded,
-        DiscoverHealth: DiscoverHealth,
-        DiscoverGold: DiscoverGold,
-        DiscoverXP: DiscoverXP,
-        DiscoverObstacle: DiscoverObstacle,
-        DiscoverBeast: DiscoverBeast,
-        AttackBeast: AttackBeast,
+        DiscoveredHealth: DiscoveredHealth,
+        DiscoveredGold: DiscoveredGold,
+        DiscoveredXP: DiscoveredXP,
+        DiscoveredObstacle: DiscoveredObstacle,
+        DiscoveredBeast: DiscoveredBeast,
+        AttackedBeast: AttackedBeast,
+        AttackedByBeast: AttackedByBeast,
         SlayedBeast: SlayedBeast,
         FleeAttempt: FleeAttempt,
         PurchasedItem: PurchasedItem,
-        EquipItem: EquipItem,
-        GreatnessIncreased: GreatnessIncreased,
+        EquippedItem: EquippedItem,
+        ItemLeveledUp: ItemLeveledUp,
         ItemSpecialUnlocked: ItemSpecialUnlocked,
         PurchasedPotion: PurchasedPotion,
         NewHighScore: NewHighScore,
@@ -859,9 +860,9 @@ mod Game {
 
         // emit BeastDiscovered
         let starter_beast = ImplBeast::get_starter_beast(ImplLoot::get_type(starting_weapon));
-        __event__DiscoverBeast(
+        __event__DiscoveredBeast(
             ref self,
-            DiscoverBeast {
+            DiscoveredBeast {
                 adventurer_state: AdventurerState {
                     owner: get_caller_address(),
                     adventurer_id: adventurer_id,
@@ -871,11 +872,7 @@ mod Game {
                     item_type: starter_beast.combat_spec.item_type,
                     level: starter_beast.combat_spec.level,
                     specials: starter_beast.combat_spec.specials
-                },
-                health: starter_beast.starting_health,
-                ambushed: false,
-                damage_taken: 0,
-                damage_location: ImplCombat::slot_to_u8(CombatEnums::Slot::Ring(())) 
+                }, health: starter_beast.starting_health, ambushed: false
             }
         );
 
@@ -938,35 +935,10 @@ mod Game {
                     beast_seed
                 );
 
-                // initialize the beast health. This is the only timeD beast.starting_health should be
-                // used. In subsequent calls to attack the beast, adventurer.beast_health should be used as the persistent
-                // storage of the beast health
-                adventurer.beast_health = beast.starting_health;
-
-                // get random attack location
-                let damage_slot = AdventurerUtils::get_random_armor_slot(sub_explore_rnd);
-
-                // initialize damage taken to zero
-                let mut damage_taken = 0;
-
-                // if adventurer was ambushed
-                if (was_ambushed) {
-                    // determine damage (adventurer dieing will be handled as part of the counter attack)
-                    let damage_taken = _beast_counter_attack(
-                        ref self, ref adventurer, adventurer_id, damage_slot, beast, beast_seed
-                    );
-                }
-
-                //                 struct CombatSpec {
-                //     tier: Tier,
-                //     item_type: Type,
-                //     level: u16,
-                //     specials: SpecialPowers,
-                // }
                 // Emit Discover Beast event
-                __event__DiscoverBeast(
+                __event__DiscoveredBeast(
                     ref self,
-                    DiscoverBeast {
+                    DiscoveredBeast {
                         adventurer_state: AdventurerState {
                             owner: get_caller_address(),
                             adventurer_id: adventurer_id,
@@ -976,30 +948,32 @@ mod Game {
                             item_type: beast.combat_spec.item_type,
                             level: beast.combat_spec.level,
                             specials: beast.combat_spec.specials
-                        },
-                        ambushed: was_ambushed,
-                        damage_taken: damage_taken,
-                        health: beast.starting_health,
-                        damage_location: ImplCombat::slot_to_u8(damage_slot)  
+                        }, ambushed: was_ambushed, health: beast.starting_health,
                     }
                 );
 
-                // and if the adventurer is dead
-                if (adventurer.health == 0) {
-                    // emit adventurer died
-                    // note we technically could do this inside of _beast_counter_attack but
-                    // doing so would result in AdventurerDied being emitted before
-                    // the DiscoverBeast for the beast that killed them.
-                    __event_AdventurerDied(
+                // initialize the beast health. This is the only timeD beast.starting_health should be
+                // used. In subsequent calls to attack the beast, adventurer.beast_health should be used as the persistent
+                // storage of the beast health
+                adventurer.beast_health = beast.starting_health;
+
+                // get random attack location
+                let damage_slot = AdventurerUtils::get_random_attack_location(sub_explore_rnd);
+
+                // initialize damage taken to zero
+                let mut damage_taken = 0;
+
+                // if adventurer was ambushed
+                if (was_ambushed) {
+                    // determine damage (adventurer dieing will be handled as part of the counter attack)
+                    _beast_counter_attack(
                         ref self,
-                        AdventurerState {
-                            owner: get_caller_address(),
-                            adventurer_id: adventurer_id,
-                            adventurer: adventurer
-                        },
-                        killed_by_beast: true,
-                        killed_by_obstacle: false,
-                        killer_id: beast.id
+                        ref adventurer,
+                        adventurer_id,
+                        damage_slot,
+                        beast,
+                        beast_seed,
+                        sub_explore_rnd
                     );
                 }
             },
@@ -1014,29 +988,26 @@ mod Game {
                 );
             },
             ExploreResult::Treasure(()) => {
-                let (treasure_type, amount, previous_level, new_level) = adventurer
-                    .discover_treasure(sub_explore_rnd);
-                let adventurer_state = AdventurerState {
-                    owner: get_caller_address(),
-                    adventurer_id: adventurer_id,
-                    adventurer: adventurer
-                };
+                let (treasure_type, amount) = adventurer.discover_treasure(sub_explore_rnd);
                 match treasure_type {
                     TreasureDiscovery::Gold(()) => {
-                        __event__DiscoverGold(ref self, adventurer_state, amount);
+                        __event__DiscoveredGold(ref self, adventurer_id, adventurer, amount);
                     },
                     TreasureDiscovery::XP(()) => {
-                        __event__DiscoverXP(ref self, adventurer_state, amount);
-                        // check if xp discovery leveled up adventurer
+                        // apply XP to adventurer
+                        let (previous_level, new_level) = adventurer.increase_adventurer_xp(amount);
+                        // emit discovered xp event
+                        __event__DiscoveredXP(ref self, adventurer_id, adventurer, amount);
+                        // check for level up
                         if (new_level > previous_level) {
-                            // level up event emitted within function
+                            // process level up
                             _handle_adventurer_level_up(
                                 ref self, ref adventurer, adventurer_id, previous_level, new_level
                             );
                         }
                     },
                     TreasureDiscovery::Health(()) => {
-                        __event__DiscoverHealth(ref self, adventurer_state, amount);
+                        __event__DiscoveredHealth(ref self, adventurer_id, adventurer, amount);
                     },
                 }
             },
@@ -1060,35 +1031,13 @@ mod Game {
             adventurer.get_level(), adventurer.stats.intelligence, entropy
         );
 
-        // get the xp reward for the obstacle
-        let xp_reward = obstacle.get_xp_reward();
-
-        // reward adventurer with xp (regarldess of obstacle outcome)
-        let (previous_level, new_level) = adventurer.increase_adventurer_xp(xp_reward);
-        if (new_level > previous_level) {
-            _handle_adventurer_level_up(
-                ref self, ref adventurer, adventurer_id, previous_level, new_level
-            );
-        }
-
-        // allocate XP to equipped items
-        _grant_xp_to_equipped_items(
-            ref self,
-            adventurer_id,
-            ref adventurer,
-            ref name_storage1,
-            ref name_storage2,
-            xp_reward,
-            entropy
-        );
-
         let mut damage_taken: u16 = 0;
         let mut damage_location: u8 = 0;
 
         // if the obstacle was not dodged
         if (!dodged) {
             // get adventurer armor at the random location the obstacle is dealing damage to
-            let damage_slot = AdventurerUtils::get_random_armor_slot(entropy);
+            let damage_slot = AdventurerUtils::get_random_attack_location(entropy);
             let damage_location = ImplCombat::slot_to_u8(damage_slot);
             let armor = adventurer.get_item_at_slot(damage_slot);
 
@@ -1100,26 +1049,49 @@ mod Game {
 
             // deduct the health from the adventurer
             adventurer.deduct_health(damage_taken);
-        }
 
-        // emit obstacle discover event
-        __event__DiscoverObstacle(
-            ref self,
-            DiscoverObstacle {
-                adventurer_state: AdventurerState {
-                    owner: get_caller_address(),
-                    adventurer_id: adventurer_id,
-                    adventurer: adventurer
-                },
-                id: obstacle.id,
-                level: obstacle.combat_specs.level,
-                dodged: dodged,
-                damage_taken: damage_taken,
-                damage_location: damage_location,
-                xp_earned_adventurer: xp_reward,
-                xp_earned_items: xp_reward * ITEM_XP_MULTIPLIER,
+            // get the xp reward for the obstacle
+            let xp_reward = obstacle.get_xp_reward();
+
+            // increase adventurer xp
+            let (previous_level, new_level) = adventurer.increase_adventurer_xp(xp_reward);
+
+            // emit obstacle discover event
+            __event__DiscoveredObstacle(
+                ref self,
+                DiscoveredObstacle {
+                    adventurer_state: AdventurerState {
+                        owner: get_caller_address(),
+                        adventurer_id: adventurer_id,
+                        adventurer: adventurer
+                    },
+                    id: obstacle.id,
+                    level: obstacle.combat_specs.level,
+                    dodged: dodged,
+                    damage_taken: damage_taken,
+                    damage_location: damage_location,
+                    xp_earned_adventurer: xp_reward,
+                    xp_earned_items: xp_reward * ITEM_XP_MULTIPLIER,
+                }
+            );
+
+            if (new_level > previous_level) {
+                _handle_adventurer_level_up(
+                    ref self, ref adventurer, adventurer_id, previous_level, new_level
+                );
             }
-        );
+
+            // allocate XP to equipped items
+            _grant_xp_to_equipped_items(
+                ref self,
+                adventurer_id,
+                ref adventurer,
+                ref name_storage1,
+                ref name_storage2,
+                xp_reward,
+                entropy
+            );
+        }
 
         // if obstacle killed adventurer
         if (adventurer.health == 0) {
@@ -1154,7 +1126,7 @@ mod Game {
     // @param prefixes_assigned A boolean indicating whether a prefix was assigned to the item when it leveled up.
     // @param special_names The ItemSpecials object storing the special names for the item.
     //
-    // The function first checks if the item's new level is higher than its previous level. If it is, it generates a 'GreatnessIncreased' event.
+    // The function first checks if the item's new level is higher than its previous level. If it is, it generates a 'ItemLeveledUp' event.
     // The function then checks if a suffix was assigned to the item when it leveled up. If it was, it generates an 'ItemSpecialUnlocked' event.
     // Lastly, the function checks if a prefix was assigned to the item when it leveled up. If it was, it generates an 'ItemSpecialUnlocked' event.
     fn handle_item_leveling_events(
@@ -1173,7 +1145,7 @@ mod Game {
         // if the new level is higher than the previous level
         if (new_level > previous_level) {
             // generate greatness increased event
-            __event_GreatnessIncreased(
+            __event_ItemLeveledUp(
                 ref self,
                 AdventurerState {
                     owner: get_caller_address(),
@@ -1459,6 +1431,7 @@ mod Game {
             + adventurer_entropy
             + U16IntoU128::into(adventurer.health + adventurer.beast_health);
 
+        // get the damage dealt to the beast
         let damage_dealt = beast
             .attack(
                 _get_combat_spec(@self, adventurer_id, adventurer.weapon),
@@ -1466,6 +1439,29 @@ mod Game {
                 adventurer.stats.strength,
                 attack_entropy
             );
+
+        // emit attack beast event
+        __event__AttackedBeast(
+            ref self,
+            AttackedBeast {
+                adventurer_state: AdventurerState {
+                    owner: get_caller_address(),
+                    adventurer_id: adventurer_id,
+                    adventurer: adventurer
+                    },
+                    seed: beast_seed,
+                    id: beast.id,
+                    health: adventurer.beast_health,
+                    beast_specs: CombatSpec {
+                    tier: beast.combat_spec.tier,
+                    item_type: beast.combat_spec.item_type,
+                    level: beast.combat_spec.level,
+                    specials: beast.combat_spec.specials
+                },
+                damage: damage_dealt,
+                location: ImplCombat::slot_to_u8(CombatEnums::Slot::None(())),
+            }
+        );
         // if the amount of damage dealt to beast exceeds its health
         if (damage_dealt >= adventurer.beast_health) {
             // the beast is dead so set health to zero
@@ -1474,31 +1470,13 @@ mod Game {
             // grant equipped items and adventurer xp for the encounter
             let xp_earned = beast.get_xp_reward();
 
-            // grant adventuer xp
-            let (previous_level, new_level) = adventurer.increase_adventurer_xp(xp_earned);
-
-            // if adventurers new level is greater than previous level
-            if (new_level > previous_level) {
-                _handle_adventurer_level_up(
-                    ref self, ref adventurer, adventurer_id, previous_level, new_level
-                );
-            }
-
-            // grant equipped items xp
-            _grant_xp_to_equipped_items(
-                ref self,
-                adventurer_id,
-                ref adventurer,
-                ref name_storage1,
-                ref name_storage2,
-                xp_earned,
-                attack_entropy
-            );
-
             // grant adventurer gold reward. We use battle fixed entropy
             // to fix this result at the start of the battle, mitigating simulate-and-wait strategies
             let gold_reward = beast.get_gold_reward(beast_seed);
             adventurer.add_gold(gold_reward);
+
+            // grant adventuer xp
+            let (previous_level, new_level) = adventurer.increase_adventurer_xp(xp_earned);
 
             // emit slayed beast event
             __event__SlayedBeast(
@@ -1524,61 +1502,42 @@ mod Game {
                     gold_earned: gold_reward
                 }
             );
-        } else {
-            // beast has more health than was dealt so subtract damage dealt
-            adventurer.beast_health = adventurer.beast_health - damage_dealt;
 
-            // then handle the beast counter attack
-
-            // start by generating a random attack location
-            let attack_location = AdventurerUtils::get_random_armor_slot(attack_entropy);
-
-            // then calling internal function to calculate damage
-            let damage_taken = _beast_counter_attack(
-                ref self, ref adventurer, adventurer_id, attack_location, beast, attack_entropy
-            );
-
-            // if adventurer health is zero (beast_counter_attack checks for underflow)
-            if (adventurer.health == 0) {
-                // emit adventurer died
-                // note we technically could do this inside of _beast_counter_attack but
-                // doing so would result in AdventurerDied being emitted before
-                // the DiscoverBeast for the beast that killed them.
-                __event_AdventurerDied(
-                    ref self,
-                    AdventurerState {
-                        owner: get_caller_address(),
-                        adventurer_id: adventurer_id,
-                        adventurer: adventurer
-                    },
-                    killed_by_beast: true,
-                    killed_by_obstacle: false,
-                    killer_id: beast.id
+            // if adventurers new level is greater than previous level
+            if (new_level > previous_level) {
+                _handle_adventurer_level_up(
+                    ref self, ref adventurer, adventurer_id, previous_level, new_level
                 );
             }
 
-            // emit attack beast event
-            __event__AttackBeast(
+            // grant equipped items xp
+            _grant_xp_to_equipped_items(
                 ref self,
-                AttackBeast {
-                    adventurer_state: AdventurerState {
-                        owner: get_caller_address(),
-                        adventurer_id: adventurer_id,
-                        adventurer: adventurer
-                        },
-                        seed: beast_seed,
-                        id: beast.id,
-                        health: adventurer.beast_health,
-                        beast_specs: CombatSpec {
-                        tier: beast.combat_spec.tier,
-                        item_type: beast.combat_spec.item_type,
-                        level: beast.combat_spec.level,
-                        specials: beast.combat_spec.specials
-                    },
-                    damage_dealt: damage_dealt,
-                    damage_taken: damage_taken,
-                    damage_location: ImplCombat::slot_to_u8(attack_location),
-                }
+                adventurer_id,
+                ref adventurer,
+                ref name_storage1,
+                ref name_storage2,
+                xp_earned,
+                attack_entropy
+            );
+        } else {
+            // handle beast counter attack
+
+            // deduct adventurer damage from beast health
+            adventurer.beast_health = adventurer.beast_health - damage_dealt;
+
+            // get random attack location
+            let attack_location = AdventurerUtils::get_random_attack_location(attack_entropy);
+
+            // calculate beast attack damage
+            _beast_counter_attack(
+                ref self,
+                ref adventurer,
+                adventurer_id,
+                attack_location,
+                beast,
+                beast_seed,
+                attack_entropy
             );
         }
     }
@@ -1589,8 +1548,9 @@ mod Game {
         adventurer_id: u256,
         attack_location: CombatEnums::Slot,
         beast: Beast,
+        beast_seed: u128,
         entropy: u128
-    ) -> u16 {
+    ) {
         // https://github.com/starkware-libs/cairo/issues/2942
         // internal::revoke_ap_tracking();
         // generate a random attack slot for the beast and get the armor the adventurer has at that slot
@@ -1600,22 +1560,52 @@ mod Game {
         let armor_combat_spec = _get_combat_spec(@self, adventurer_id, armor);
 
         // process beast counter attack
-        let damage_taken = beast.counter_attack(armor_combat_spec, entropy);
+        let damage = beast.counter_attack(armor_combat_spec, entropy);
 
         // if the damage taken is greater than or equal to adventurers health
         // the adventurer is dead
-        let adventurer_died = (damage_taken >= adventurer.health);
+        let adventurer_died = (damage >= adventurer.health);
         if (adventurer_died) {
             // set their health to 0
             adventurer.health = 0;
-            // TODO: Check for Top score
-            return damage_taken;
-        } // if the adventurer is not dead
-        else {
+            __event_AdventurerDied(
+                ref self,
+                AdventurerState {
+                    owner: get_caller_address(),
+                    adventurer_id: adventurer_id,
+                    adventurer: adventurer
+                },
+                killed_by_beast: true,
+                killed_by_obstacle: false,
+                killer_id: beast.id
+            );
+        // TODO: Check for Top score
+        } else {
+            // if the adventurer is not dead
             // deduct the damage dealt
-            adventurer.deduct_health(damage_taken);
-            return damage_taken;
+            adventurer.deduct_health(damage);
         }
+
+        // emit attack by beast event
+        __event__AttackedByBeast(
+            ref self,
+            AttackedByBeast {
+                adventurer_state: AdventurerState {
+                    owner: get_caller_address(),
+                    adventurer_id: adventurer_id,
+                    adventurer: adventurer
+                    },
+                    seed: beast_seed,
+                    id: beast.id,
+                    health: adventurer.beast_health,
+                    beast_specs: CombatSpec {
+                    tier: beast.combat_spec.tier,
+                    item_type: beast.combat_spec.item_type,
+                    level: beast.combat_spec.level,
+                    specials: beast.combat_spec.specials
+                }, damage: damage, location: ImplCombat::slot_to_u8(attack_location),
+            }
+        );
     }
 
     fn _flee(ref self: ContractState, ref adventurer: Adventurer, adventurer_id: u256) {
@@ -1671,12 +1661,17 @@ mod Game {
         } else {
             // if flee attempt was unsuccessful the beast counter attacks
             // adventurer death will be handled as part of counter attack
-            let attack_slot = AdventurerUtils::get_random_armor_slot(ambush_entropy);
+            let attack_slot = AdventurerUtils::get_random_attack_location(ambush_entropy);
             attack_location = ImplCombat::slot_to_u8(attack_slot);
-            damage_taken =
-                _beast_counter_attack(
-                    ref self, ref adventurer, adventurer_id, attack_slot, beast, ambush_entropy
-                );
+            _beast_counter_attack(
+                ref self,
+                ref adventurer,
+                adventurer_id,
+                attack_slot,
+                beast,
+                beast_seed,
+                ambush_entropy
+            );
         }
 
         // emit flee attempt event
@@ -1696,7 +1691,7 @@ mod Game {
                     item_type: beast.combat_spec.item_type,
                     level: beast.combat_spec.level,
                     specials: beast.combat_spec.specials
-                }, damage_taken: damage_taken, damage_location: attack_location, fled
+                }, fled
             }
         );
 
@@ -1759,7 +1754,7 @@ mod Game {
         _apply_stat_boots(@self, adventurer_id, ref adventurer, name_storage1, name_storage2);
 
         // emit equipped item event
-        __event_EquipItem(
+        __event_EquippedItem(
             ref self,
             AdventurerStateWithBag {
                 adventurer_state: AdventurerState {
@@ -1826,11 +1821,11 @@ mod Game {
                 // add item to the adventurer's bag
                 bag.add_item(unequipping_item);
 
+                // get the item id of the item being unequipped
                 unequipped_item_id = unequipping_item.id;
 
                 // pack and save bag
                 _pack_bag(ref self, adventurer_id, bag);
-                return;
             }
         } else {
             // if adventurers didn't opt to equip the newly purchased item
@@ -2003,6 +1998,10 @@ mod Game {
         previous_level: u8,
         new_level: u8,
     ) {
+        // add stat upgrades points to adventurer
+        let stat_upgrade_points = (new_level - previous_level) * STAT_UPGRADE_POINTS_PER_LEVEL;
+        adventurer.add_stat_upgrade_points(stat_upgrade_points);
+
         // emit level up event
         __event_AdventurerLeveledUp(
             ref self,
@@ -2012,10 +2011,6 @@ mod Game {
             previous_level: previous_level,
             new_level: new_level
         );
-
-        // add stat upgrades points to adventurer
-        let stat_upgrade_points = (new_level - previous_level) * STAT_UPGRADE_POINTS_PER_LEVEL;
-        adventurer.add_stat_upgrade_points(stat_upgrade_points);
 
         // emit new items availble with available items
         __event_NewItemsAvailable(
@@ -2395,25 +2390,25 @@ mod Game {
     }
 
     #[derive(Drop, starknet::Event)]
-    struct DiscoverHealth {
+    struct DiscoveredHealth {
         adventurer_state: AdventurerState,
         health_amount: u16
     }
 
     #[derive(Drop, starknet::Event)]
-    struct DiscoverGold {
+    struct DiscoveredGold {
         adventurer_state: AdventurerState,
         gold_amount: u16
     }
 
     #[derive(Drop, starknet::Event)]
-    struct DiscoverXP {
+    struct DiscoveredXP {
         adventurer_state: AdventurerState,
         xp_amount: u16
     }
 
     #[derive(Drop, starknet::Event)]
-    struct DiscoverObstacle {
+    struct DiscoveredObstacle {
         adventurer_state: AdventurerState,
         id: u8,
         level: u16,
@@ -2425,27 +2420,35 @@ mod Game {
     }
 
     #[derive(Drop, starknet::Event)]
-    struct DiscoverBeast {
+    struct DiscoveredBeast {
         adventurer_state: AdventurerState,
         seed: u128,
         id: u8,
         health: u16,
         beast_specs: CombatSpec,
-        ambushed: bool,
-        damage_taken: u16,
-        damage_location: u8,
+        ambushed: bool
     }
 
     #[derive(Drop, starknet::Event)]
-    struct AttackBeast {
+    struct AttackedBeast {
         adventurer_state: AdventurerState,
         seed: u128,
         id: u8,
         health: u16,
         beast_specs: CombatSpec,
-        damage_dealt: u16,
-        damage_taken: u16,
-        damage_location: u8,
+        damage: u16,
+        location: u8,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct AttackedByBeast {
+        adventurer_state: AdventurerState,
+        seed: u128,
+        id: u8,
+        health: u16,
+        beast_specs: CombatSpec,
+        damage: u16,
+        location: u8,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -2468,9 +2471,7 @@ mod Game {
         id: u8,
         health: u16,
         beast_specs: CombatSpec,
-        fled: bool,
-        damage_taken: u16,
-        damage_location: u8,
+        fled: bool
     }
 
     #[derive(Drop, starknet::Event)]
@@ -2483,14 +2484,14 @@ mod Game {
     }
 
     #[derive(Drop, starknet::Event)]
-    struct EquipItem {
+    struct EquippedItem {
         adventurer_state_with_bag: AdventurerStateWithBag,
         equipped_item_id: u8,
         unequipped_item_id: u8,
     }
 
     #[derive(Drop, starknet::Event)]
-    struct GreatnessIncreased {
+    struct ItemLeveledUp {
         adventurer_state: AdventurerState,
         item_id: u8,
         previous_level: u8,
@@ -2565,36 +2566,73 @@ mod Game {
         self.emit(Event::StatUpgraded(StatUpgraded { adventurer_state, stat_id }));
     }
 
-    fn __event__DiscoverHealth(
-        ref self: ContractState, adventurer_state: AdventurerState, health_amount: u16
+    fn __event__DiscoveredHealth(
+        ref self: ContractState, adventurer_id: u256, adventurer: Adventurer, health_amount: u16
     ) {
-        self.emit(Event::DiscoverHealth(DiscoverHealth { adventurer_state, health_amount }));
+        self
+            .emit(
+                Event::DiscoveredHealth(
+                    DiscoveredHealth {
+                        adventurer_state: AdventurerState {
+                            owner: get_caller_address(),
+                            adventurer_id: adventurer_id,
+                            adventurer: adventurer
+                        }, health_amount
+                    }
+                )
+            );
     }
 
-    fn __event__DiscoverGold(
-        ref self: ContractState, adventurer_state: AdventurerState, gold_amount: u16
+    fn __event__DiscoveredGold(
+        ref self: ContractState, adventurer_id: u256, adventurer: Adventurer, gold_amount: u16
     ) {
-        self.emit(Event::DiscoverGold(DiscoverGold { adventurer_state, gold_amount }));
+        self
+            .emit(
+                Event::DiscoveredGold(
+                    DiscoveredGold {
+                        adventurer_state: AdventurerState {
+                            owner: get_caller_address(),
+                            adventurer_id: adventurer_id,
+                            adventurer: adventurer
+                        }, gold_amount
+                    }
+                )
+            );
     }
 
-    fn __event__DiscoverXP(
-        ref self: ContractState, adventurer_state: AdventurerState, xp_amount: u16
+    fn __event__DiscoveredXP(
+        ref self: ContractState, adventurer_id: u256, adventurer: Adventurer, xp_amount: u16
     ) {
-        self.emit(Event::DiscoverXP(DiscoverXP { adventurer_state, xp_amount }));
+        self
+            .emit(
+                Event::DiscoveredXP(
+                    DiscoveredXP {
+                        adventurer_state: AdventurerState {
+                            owner: get_caller_address(),
+                            adventurer_id: adventurer_id,
+                            adventurer: adventurer
+                        }, xp_amount
+                    }
+                )
+            );
     }
 
-    fn __event__DiscoverObstacle(
-        ref self: ContractState, disover_obstacle_event: DiscoverObstacle
+    fn __event__DiscoveredObstacle(
+        ref self: ContractState, disover_obstacle_event: DiscoveredObstacle
     ) {
-        self.emit(Event::DiscoverObstacle(disover_obstacle_event));
+        self.emit(Event::DiscoveredObstacle(disover_obstacle_event));
     }
 
-    fn __event__DiscoverBeast(ref self: ContractState, discover_beast_event: DiscoverBeast, ) {
-        self.emit(Event::DiscoverBeast(discover_beast_event));
+    fn __event__DiscoveredBeast(ref self: ContractState, discover_beast_event: DiscoveredBeast, ) {
+        self.emit(Event::DiscoveredBeast(discover_beast_event));
     }
 
-    fn __event__AttackBeast(ref self: ContractState, attack_beast: AttackBeast, ) {
-        self.emit(Event::AttackBeast(attack_beast));
+    fn __event__AttackedBeast(ref self: ContractState, attack_beast: AttackedBeast, ) {
+        self.emit(Event::AttackedBeast(attack_beast));
+    }
+
+    fn __event__AttackedByBeast(ref self: ContractState, attack_by_beast: AttackedByBeast, ) {
+        self.emit(Event::AttackedByBeast(attack_by_beast));
     }
 
     fn __event__SlayedBeast(ref self: ContractState, slayed_beast: SlayedBeast, ) {
@@ -2623,7 +2661,7 @@ mod Game {
             );
     }
 
-    fn __event_EquipItem(
+    fn __event_EquippedItem(
         ref self: ContractState,
         adventurer_state_with_bag: AdventurerStateWithBag,
         equipped_item_id: u8,
@@ -2631,14 +2669,14 @@ mod Game {
     ) {
         self
             .emit(
-                Event::EquipItem(
-                    EquipItem { adventurer_state_with_bag, equipped_item_id, unequipped_item_id }
+                Event::EquippedItem(
+                    EquippedItem { adventurer_state_with_bag, equipped_item_id, unequipped_item_id }
                 )
             );
     }
 
 
-    fn __event_GreatnessIncreased(
+    fn __event_ItemLeveledUp(
         ref self: ContractState,
         adventurer_state: AdventurerState,
         item_id: u8,
@@ -2647,8 +2685,8 @@ mod Game {
     ) {
         self
             .emit(
-                Event::GreatnessIncreased(
-                    GreatnessIncreased { adventurer_state, item_id, previous_level, new_level }
+                Event::ItemLeveledUp(
+                    ItemLeveledUp { adventurer_state, item_id, previous_level, new_level }
                 )
             );
     }

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -991,6 +991,9 @@ mod Game {
                 let (treasure_type, amount) = adventurer.discover_treasure(sub_explore_rnd);
                 match treasure_type {
                     TreasureDiscovery::Gold(()) => {
+                        // add gold to adventurer
+                        adventurer.add_gold(amount);
+                        // emit discovered gold event
                         __event__DiscoveredGold(ref self, adventurer_id, adventurer, amount);
                     },
                     TreasureDiscovery::XP(()) => {
@@ -1007,6 +1010,12 @@ mod Game {
                         }
                     },
                     TreasureDiscovery::Health(()) => {
+                        if (adventurer.has_full_health()) {
+                            // add gold to ensure adventurer state changes
+                            adventurer.add_gold(1);
+                        } else {
+                            adventurer.add_health(amount);
+                        }
                         __event__DiscoveredHealth(ref self, adventurer_id, adventurer, amount);
                     },
                 }

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -236,22 +236,6 @@ mod tests {
         testing::set_block_number(1006);
         game.explore(ADVENTURER_ID);
 
-        // use stat upgrade
-        game.upgrade_stat(ADVENTURER_ID, 0);
-
-        testing::set_block_number(1007);
-        game.explore(ADVENTURER_ID);
-
-        // use stat upgrade
-        game.upgrade_stat(ADVENTURER_ID, 0);
-
-        testing::set_block_number(1008);
-        game.explore(ADVENTURER_ID);
-        testing::set_block_number(1009);
-        game.explore(ADVENTURER_ID);
-        testing::set_block_number(1010);
-        game.explore(ADVENTURER_ID);
-
         let updated_adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(updated_adventurer.beast_health > 0, 'should have found a beast');
 
@@ -402,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    #[available_gas(61000000)]
+    #[available_gas(62000000)]
     fn test_buy_potions() {
         let mut game = new_adventurer_lvl2_with_idle_penalty();
 

--- a/contracts/loot/src/statistics/item_slot_length.cairo
+++ b/contracts/loot/src/statistics/item_slot_length.cairo
@@ -6,6 +6,7 @@ use combat::constants::CombatEnums::Slot;
 
 fn get(slot: Slot) -> u8 {
     match slot {
+        Slot::None(()) => 0,
         Slot::Weapon(()) => ItemSlotLength::SlotItemsLengthWeapon,
         Slot::Chest(()) => ItemSlotLength::SlotItemsLengthChest,
         Slot::Head(()) => ItemSlotLength::SlotItemsLengthHead,

--- a/contracts/market/src/market.cairo
+++ b/contracts/market/src/market.cairo
@@ -24,6 +24,7 @@ struct LootWithPrice {
 impl ImplMarket of IMarket {
     fn get_price(tier: Tier) -> u16 {
         match tier {
+            Tier::None(()) => 0,
             Tier::T1(()) => 5 * TIER_PRICE,
             Tier::T2(()) => 4 * TIER_PRICE,
             Tier::T3(()) => 3 * TIER_PRICE,


### PR DESCRIPTION
- Renames DisoverHealth to DiscoveredHealth
- Renames DiscoverGold to DiscoveredGold
- Renames DiscoverXP to DiscoveredXP
- Renames DiscoverObstacle to DiscoveredObstacle
- Renames EquipItem to EquippedItem
- Renames GreatnessIncreased to ItemLeveledUp
- Renames AttackBeast to AttackedBeast
- Splits up Beast combat event into AttackedBeast and AttackedByBeast
- DiscoverXP, AttackedBeast, and SlayedBeast will now all be emitted before AdventurerLeveledUp Event
- Fixes bug in which AdventurerLeveledUp event did not include stat upgrade points
 - Fixes bug in which PurchasedItem is not being emitted when equip=true