### PR TITLE
G20 stat bonus, event refactoring, and bug fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:    
 
 env:
-  SCARB_VERSION: 0.5.1
+  SCARB_VERSION: 0.5.2
 
 jobs:
   build-contracts:

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ starknet call --function get_xp --address $CONTRACT_ADDRESS --input $ADVENTURER_
 
 ##### Get upgradable stat points
 ```bash
-starknet call --function get_stat_points_available --address $CONTRACT_ADDRESS --input $ADVENTURER_ID 0 --account $ACCOUNT_NAME
+starknet call --function get_stat_upgrades_available --address $CONTRACT_ADDRESS --input $ADVENTURER_ID 0 --account $ACCOUNT_NAME
 ```
 
 ##### Get base charisma stat (doesn't include boost from items)

--- a/contracts/adventurer/Scarb.toml
+++ b/contracts/adventurer/Scarb.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
 
 [dependencies]
-starknet = "2.0.0"
+starknet = "2.0.2"
 pack = { path = "../pack" }
 lootitems = { path = "../loot" }
 obstacles = { path = "../obstacles" }

--- a/contracts/adventurer/src/constants/adventurer_constants.cairo
+++ b/contracts/adventurer/src/constants/adventurer_constants.cairo
@@ -15,6 +15,7 @@ const CHARISMA_POTION_DISCOUNT: u16 = 2;
 const CHARISMA_ITEM_DISCOUNT: u16 = 2;
 const MINIMUM_ITEM_PRICE: u16 = 2;
 const ITEM_MAX_GREATNESS: u8 = 20;
+const ITEM_MAX_XP: u16 = 400;
 const MAX_GREATNESS_STAT_BONUS: u8 = 1;
 
 // Stat Settings
@@ -36,3 +37,5 @@ mod StatisticIndex {
     const WISDOM: u8 = 4;
     const CHARISMA: u8 = 5;
 }
+
+const U128_MAX: u128 = 340282366920938463463374607431768211455;

--- a/contracts/game/src/game/constants.cairo
+++ b/contracts/game/src/game/constants.cairo
@@ -56,3 +56,5 @@ mod WEEK_8 {
     const SECOND_PLACE: u256 = 4; // 4
     const THIRD_PLACE: u256 = 2; // 2
 }
+
+const STARTER_BEAST_ATTACK_DAMAGE: u16 = 10;

--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -10,7 +10,12 @@ use beasts::beast::Beast;
 #[starknet::interface]
 trait IGame<TContractState> {
     // actions ---------------------------------------------------
-    fn start(ref self: TContractState, interface_id: ContractAddress, starting_weapon: u8, adventurer_meta: AdventurerMetadata);
+    fn start(
+        ref self: TContractState,
+        interface_id: ContractAddress,
+        starting_weapon: u8,
+        adventurer_meta: AdventurerMetadata
+    );
     fn explore(ref self: TContractState, adventurer_id: u256);
     fn attack(ref self: TContractState, adventurer_id: u256);
     fn flee(ref self: TContractState, adventurer_id: u256);
@@ -18,46 +23,63 @@ trait IGame<TContractState> {
     fn buy_item(ref self: TContractState, adventurer_id: u256, item_id: u8, equip: bool);
     fn buy_potion(ref self: TContractState, adventurer_id: u256);
     fn buy_potions(ref self: TContractState, adventurer_id: u256, amount: u8);
-    fn upgrade_stat(ref self: TContractState, adventurer_id: u256, stat: u8);
+    fn upgrade_stat(ref self: TContractState, adventurer_id: u256, stat: u8, amount: u8);
     fn slay_idle_adventurer(ref self: TContractState, adventurer_id: u256);
 
-    // view ------------------------------------------------------
-    fn get_adventurer(self: @TContractState, adventurer_id: u256) -> Adventurer;
-    fn get_adventurer_meta(self: @TContractState, adventurer_id: u256) -> AdventurerMetadata;
-    fn get_bag(self: @TContractState, adventurer_id: u256) -> Bag;
-    fn get_items_on_market(self: @TContractState, adventurer_id: u256) -> Array<LootWithPrice>;
-    fn get_potion_price(self: @TContractState, adventurer_id: u256) -> u16;
-    fn get_attacking_beast(self: @TContractState, adventurer_id: u256) -> Beast;
+    // --------- view functions ---------
 
     // adventurer details
+    fn get_adventurer(self: @TContractState, adventurer_id: u256) -> Adventurer;
+    fn get_adventurer_no_boosts(self: @TContractState, adventurer_id: u256) -> Adventurer;
+    fn get_adventurer_meta(self: @TContractState, adventurer_id: u256) -> AdventurerMetadata;
     fn get_health(self: @TContractState, adventurer_id: u256) -> u16;
     fn get_xp(self: @TContractState, adventurer_id: u256) -> u16;
     fn get_level(self: @TContractState, adventurer_id: u256) -> u8;
     fn get_gold(self: @TContractState, adventurer_id: u256) -> u16;
-    fn get_stat_points_available(self: @TContractState, adventurer_id: u256) -> u8;
+    fn get_stat_upgrades_available(self: @TContractState, adventurer_id: u256) -> u8;
     fn get_last_action(self: @TContractState, adventurer_id: u256) -> u16;
 
     // item stats
+    // TODO: get_equipped_items(self: @TContractState, adventurer_id: u256) -> Array<u8>;
     fn get_weapon_greatness(self: @TContractState, adventurer_id: u256) -> u8;
-    fn get_chest_armor_greatness(self: @TContractState, adventurer_id: u256) -> u8;
-    fn get_head_armor_greatness(self: @TContractState, adventurer_id: u256) -> u8;
-    fn get_waist_armor_greatness(self: @TContractState, adventurer_id: u256) -> u8;
-    fn get_foot_armor_greatness(self: @TContractState, adventurer_id: u256) -> u8;
-    fn get_hand_armor_greatness(self: @TContractState, adventurer_id: u256) -> u8;
+    fn get_chest_greatness(self: @TContractState, adventurer_id: u256) -> u8;
+    fn get_head_greatness(self: @TContractState, adventurer_id: u256) -> u8;
+    fn get_waist_greatness(self: @TContractState, adventurer_id: u256) -> u8;
+    fn get_foot_greatness(self: @TContractState, adventurer_id: u256) -> u8;
+    fn get_hand_greatness(self: @TContractState, adventurer_id: u256) -> u8;
     fn get_necklace_greatness(self: @TContractState, adventurer_id: u256) -> u8;
     fn get_ring_greatness(self: @TContractState, adventurer_id: u256) -> u8;
+    fn get_bag(self: @TContractState, adventurer_id: u256) -> Bag;
 
     // item details
     fn get_weapon_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
-    fn get_chest_armor_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
-    fn get_head_armor_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
-    fn get_waist_armor_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
-    fn get_foot_armor_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
-    fn get_hand_armor_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
+    fn get_chest_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
+    fn get_head_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
+    fn get_waist_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
+    fn get_foot_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
+    fn get_hand_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
     fn get_necklace_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
     fn get_ring_specials(self: @TContractState, adventurer_id: u256) -> ItemSpecials;
 
-    // adventurer stats
+    // market details
+    fn get_items_on_market(self: @TContractState, adventurer_id: u256) -> Array<LootWithPrice>;
+    fn get_weapons_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_chest_armor_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_head_armor_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_waist_armor_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_foot_armor_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_hand_armor_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_necklaces_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_rings_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_t1_items_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_t2_items_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_t3_items_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_t4_items_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_t5_items_on_market(self: @TContractState, adventurer_id: u256) -> Array<u8>;
+    fn get_potion_price(self: @TContractState, adventurer_id: u256) -> u16;
+    fn get_attacking_beast(self: @TContractState, adventurer_id: u256) -> Beast;
+
+    // adventurer stats (includes boost)
     fn get_stats(self: @TContractState, adventurer_id: u256) -> Stats;
     fn get_strength(self: @TContractState, adventurer_id: u256) -> u8;
     fn get_dexterity(self: @TContractState, adventurer_id: u256) -> u8;
@@ -66,6 +88,7 @@ trait IGame<TContractState> {
     fn get_wisdom(self: @TContractState, adventurer_id: u256) -> u8;
     fn get_charisma(self: @TContractState, adventurer_id: u256) -> u8;
 
+    // adventurer stats (no boosts)
     fn get_base_stats(self: @TContractState, adventurer_id: u256) -> Stats;
     fn get_base_strength(self: @TContractState, adventurer_id: u256) -> u8;
     fn get_base_dexterity(self: @TContractState, adventurer_id: u256) -> u8;
@@ -78,6 +101,8 @@ trait IGame<TContractState> {
     fn get_beast_health(self: @TContractState, adventurer_id: u256) -> u16;
     fn get_beast_type(self: @TContractState, beast_id: u8) -> u8;
     fn get_beast_tier(self: @TContractState, beast_id: u8) -> u8;
+
+    // TODO: Game settings
 
     // contract details
     fn get_dao_address(self: @TContractState) -> ContractAddress;
@@ -93,7 +118,9 @@ trait IGame<TContractState> {
 
 
 #[starknet::interface]
-trait IERC20<TContractState>  {
-    fn transferFrom(ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256) -> bool;
+trait IERC20<TContractState> {
+    fn transferFrom(
+        ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256
+    ) -> bool;
     fn burn_away(ref self: TContractState, to: ContractAddress, amount: u256);
 }

--- a/contracts/market/src/market.cairo
+++ b/contracts/market/src/market.cairo
@@ -8,7 +8,7 @@ use lootitems::statistics::constants::ItemId;
 use lootitems::loot::{Loot, ILoot, ImplLoot};
 use lootitems::statistics::item_tier;
 
-use combat::constants::CombatEnums::{Tier};
+use combat::constants::CombatEnums::{Tier, Slot};
 
 use super::constants::{NUM_LOOT_ITEMS, NUMBER_OF_ITEMS_PER_LEVEL, OFFSET, TIER_PRICE};
 
@@ -42,7 +42,6 @@ impl ImplMarket of IMarket {
                 break ();
             }
 
-            // TODO: We need to move this to fetch from state - it's too gassy...
             all_items.append(ImplLoot::get_item(ImplMarket::get_id(seed + i)));
             i += OFFSET;
         };
@@ -60,23 +59,57 @@ impl ImplMarket of IMarket {
             }
 
             let id = ImplMarket::get_id(seed + i);
-
-            // id.print();
-
-            // TODO: We need to move this to fetch from state - it's too gassy...
             all_items
                 .append(
                     LootWithPrice {
                         item: ImplLoot::get_item(id),
-                        price: ImplMarket::get_price(
-                            ImplLoot::get_tier(id)
-                        )
+                        price: ImplMarket::get_price(ImplLoot::get_tier(id))
                     }
                 );
             i += OFFSET;
         };
 
         all_items
+    }
+
+    fn get_items_by_slot(seed: u256, slot: Slot) -> Array<u8> {
+        let mut return_ids = ArrayTrait::<u8>::new();
+
+        let mut i: u256 = 0;
+        loop {
+            if i >= OFFSET * NUMBER_OF_ITEMS_PER_LEVEL {
+                break ();
+            }
+
+            let id = ImplMarket::get_id(seed + i);
+            if (ImplLoot::get_slot(id) == slot) {
+                return_ids.append(id);
+            }
+
+            i += OFFSET;
+        };
+
+        return_ids
+    }
+
+    fn get_items_by_tier(seed: u256, tier: Tier) -> Array<u8> {
+        let mut return_ids = ArrayTrait::<u8>::new();
+
+        let mut i: u256 = 0;
+        loop {
+            if i >= OFFSET * NUMBER_OF_ITEMS_PER_LEVEL {
+                break ();
+            }
+
+            let id = ImplMarket::get_id(seed + i);
+            if (ImplLoot::get_tier(id) == tier) {
+                return_ids.append(id);
+            }
+
+            i += OFFSET;
+        };
+
+        return_ids
     }
 
     fn get_id(seed: u256) -> u8 {


### PR DESCRIPTION
- Gives adventurer stat upgrade for getting item to G20
- Adds StatUpgradesAvailable event
- Adds StrengthIncreased, DexterityIncreased, VitalityIncreased, IntelligenceIncreased, WisdomIncreased, CharismaIncreased events
- Splits DiscoveredObstacle into DodgedObstacle and HitByObstacle
- Splits FleeAttempt into FleeFailed and FleeSucceeded
- Adds AmbushedByBeast event
- Starter beast will now ambush adventurer for 10HP
- Changes upgrade_stat(stat_id) to upgrade_stat(stat_id, amount) to support efficient multi stat leveling
- Adds util view functions for inspecting market such as: get_weapons_on_market,  get_t1_items_on_market
- Items now receive XP when an obstacle is dodged or damage is taken
- fixes RND bug in which beasts would attack same location for the entirety of a battle
- small refactor to _start function, moving adventurer entropy to adventurer lib
- fixes item xp overflow bug