### PR TITLE
fix and harden item suffix stat boost

### DIFF
--- a/contracts/adventurer/src/adventurer_meta.cairo
+++ b/contracts/adventurer/src/adventurer_meta.cairo
@@ -35,6 +35,11 @@ impl PackingAdventurerMetadata of Packing<AdventurerMetadata> {
             entropy: entropy.try_into().expect('unpack AdvMetadata entropy')
         }
     }
+
+    // TODO: add overflow pack protection
+    fn overflow_pack_protection(self: AdventurerMetadata) -> AdventurerMetadata {
+        self
+    }
 }
 
 #[cfg(test)]

--- a/contracts/adventurer/src/adventurer_stats.cairo
+++ b/contracts/adventurer/src/adventurer_stats.cairo
@@ -1,6 +1,7 @@
 use option::OptionTrait;
 use traits::{TryInto, Into};
 use pack::{pack::{Packing, rshift_split}, constants::pow};
+use survivor::constants::adventurer_constants::MAX_STAT_VALUE;
 
 #[derive(Drop, Copy, Serde)]
 struct Stats { // 5 bits each
@@ -16,12 +17,14 @@ struct Stats { // 5 bits each
 
 impl StatsPacking of Packing<Stats> {
     fn pack(self: Stats) -> felt252 {
-        (self.strength.into()
-            + self.dexterity.into() * pow::TWO_POW_5
-            + self.vitality.into() * pow::TWO_POW_10
-            + self.intelligence.into() * pow::TWO_POW_15
-            + self.wisdom.into() * pow::TWO_POW_20
-            + self.charisma.into() * pow::TWO_POW_25)
+        let overflow_protected = self.overflow_pack_protection();
+
+        (overflow_protected.strength.into()
+            + overflow_protected.dexterity.into() * pow::TWO_POW_5
+            + overflow_protected.vitality.into() * pow::TWO_POW_10
+            + overflow_protected.intelligence.into() * pow::TWO_POW_15
+            + overflow_protected.wisdom.into() * pow::TWO_POW_20
+            + overflow_protected.charisma.into() * pow::TWO_POW_25)
             .try_into()
             .expect('pack Stats')
     }
@@ -44,80 +47,77 @@ impl StatsPacking of Packing<Stats> {
             charisma: charisma.try_into().expect('unpack Stats charisma')
         }
     }
+
+    fn overflow_pack_protection(self: Stats) -> Stats {
+        let mut overflow_protected_stats = self;
+
+        if self.strength > MAX_STAT_VALUE {
+            overflow_protected_stats.strength = MAX_STAT_VALUE;
+        };
+        if self.dexterity > MAX_STAT_VALUE {
+            overflow_protected_stats.dexterity = MAX_STAT_VALUE;
+        }
+        if self.vitality > MAX_STAT_VALUE {
+            overflow_protected_stats.vitality = MAX_STAT_VALUE;
+        }
+        if self.intelligence > MAX_STAT_VALUE {
+            overflow_protected_stats.intelligence = MAX_STAT_VALUE;
+        }
+        if self.wisdom > MAX_STAT_VALUE {
+            overflow_protected_stats.wisdom = MAX_STAT_VALUE;
+        }
+        if self.charisma > MAX_STAT_VALUE {
+            overflow_protected_stats.charisma = MAX_STAT_VALUE;
+        }
+
+        overflow_protected_stats
+    }
 }
 
 #[test]
 #[available_gas(1500000)]
 fn test_stats_packing() {
-
     // zero case
     let stats = Stats {
-        strength: 0,
-        dexterity: 0,
-        vitality: 0,
-        intelligence: 0,
-        wisdom: 0,
-        charisma: 0
+        strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 0
     };
 
     let packed = stats.pack();
     let unpacked = StatsPacking::unpack(packed);
-    
-    assert(stats.strength ==  unpacked.strength, 'strength should be the same');
-    assert(stats.dexterity ==  unpacked.dexterity, 'dexterity should be the same');
-    assert(stats.vitality ==  unpacked.vitality, 'vitality should be the same');
-    assert(stats.intelligence ==  unpacked.intelligence, 'intelligence should be the same');
-    assert(stats.wisdom ==  unpacked.wisdom, 'wisdom should be the same');
-    assert(stats.charisma ==  unpacked.charisma, 'charisma should be the same');
+    assert(stats.strength == unpacked.strength, 'strength zero case');
+    assert(stats.dexterity == unpacked.dexterity, 'dexterity zero case');
+    assert(stats.vitality == unpacked.vitality, 'vitality zero case');
+    assert(stats.intelligence == unpacked.intelligence, 'intelligence zero case');
+    assert(stats.wisdom == unpacked.wisdom, 'wisdom zero case');
+    assert(stats.charisma == unpacked.charisma, 'charisma zero case');
 
-    // max stat case (2^5 - 1 = 31)
+    // storage limit test (2^5 - 1 = 31)
     let stats = Stats {
-        strength: 31,
-        dexterity: 31,
-        vitality: 31,
-        intelligence: 31,
-        wisdom: 31,
-        charisma: 31
+        strength: 31, dexterity: 31, vitality: 31, intelligence: 31, wisdom: 31, charisma: 31
     };
 
     let packed = stats.pack();
     let unpacked = StatsPacking::unpack(packed);
+    assert(stats.strength == unpacked.strength, 'strength storage limit');
+    assert(stats.dexterity == unpacked.dexterity, 'dexterity storage limit');
+    assert(stats.vitality == unpacked.vitality, 'vitality storage limit');
+    assert(stats.intelligence == unpacked.intelligence, 'intelligence storage limit');
+    assert(stats.wisdom == unpacked.wisdom, 'wisdom storage limit');
+    assert(stats.charisma == unpacked.charisma, 'charisma storage limit');
 
-    assert(stats.strength ==  unpacked.strength, 'strength should be the same');
-    assert(stats.dexterity ==  unpacked.dexterity, 'dexterity should be the same');
-    assert(stats.vitality ==  unpacked.vitality, 'vitality should be the same');
-    assert(stats.intelligence ==  unpacked.intelligence, 'intelligence should be the same');
-    assert(stats.wisdom ==  unpacked.wisdom, 'wisdom should be the same');
-    assert(stats.charisma ==  unpacked.charisma, 'charisma should be the same');
-
-    //overflow case - should overflow back to 0
+    // overflow storage limit using max u8
     let stats = Stats {
-        strength: 32,
-        dexterity: 32,
-        vitality: 32,
-        intelligence: 32,
-        wisdom: 32,
-        charisma: 32
+        strength: 255, dexterity: 255, vitality: 255, intelligence: 255, wisdom: 255, charisma: 255
     };
 
     let packed = stats.pack();
     let unpacked = StatsPacking::unpack(packed);
 
-    // strength will overflow to zero
-    assert(unpacked.strength == 0, 'strength should overflow to 0');
-
-    // strength will overflow 1 into dexterity
-    assert(unpacked.dexterity == 1, 'dexterity should overflow to 1');
-
-    // dexterity will overflow 1 into vitality
-    assert(unpacked.vitality == 1, 'vitality should overflow to 1');
-
-    // vitality will overflow 1 into intelligence
-    assert(unpacked.intelligence == 1, 'intelligence should ovrflw to 1');
-
-    // intelligence will overflow 1 into wisdom
-    assert(unpacked.wisdom == 1, 'wisdom should overflow to 1');
-
-    // wisdom will overflow 1 into charisma
-    assert(unpacked.charisma == 1, 'charisma should overflow to 1');
+    // assert packing function prevented overflow
+    assert(unpacked.strength == MAX_STAT_VALUE, 'strength pack overflow');
+    assert(unpacked.dexterity == MAX_STAT_VALUE, 'dexterity pack overflow');
+    assert(unpacked.vitality == MAX_STAT_VALUE, 'vitality pack overflow');
+    assert(unpacked.intelligence == MAX_STAT_VALUE, 'intelligence pack overflow');
+    assert(unpacked.wisdom == MAX_STAT_VALUE, 'wisdom pack overflow');
+    assert(unpacked.charisma == MAX_STAT_VALUE, 'charisma pack overflow');
 }

--- a/contracts/adventurer/src/adventurer_utils.cairo
+++ b/contracts/adventurer/src/adventurer_utils.cairo
@@ -12,20 +12,22 @@ use pack::pack::{rshift_split};
 
 #[generate_trait]
 impl AdventurerUtils of IAdventurer {
+
+    // @dev Provides overflow protected stat increase.
+    //      This function protects against u8 overflow but allows stat
+    //      to exceed MAX_STAT_VALUE as adventurers live stats are expected
+    //      to exceed MAX_STAT_VALUE. Ensuring a stat does not overflow adventurer packing
+    //      code is the responsibility of the adventurer packing code
+    // @param current_stat The current value of the stat.
+    // @param increase_amount The amount by which to increase the stat.
+    // @return The increased stat value, or `MAX_STAT_VALUE` if an increase would cause an overflow.
     fn overflow_protected_stat_increase(current_stat: u8, increase_amount: u8) -> u8 {
         // u8 overflow check
         if (u8_overflowing_add(current_stat, increase_amount).is_ok()) {
-            // if the strength plus the amount is less than or equal to the max stat value
-            if (current_stat + increase_amount <= MAX_STAT_VALUE) {
-                // add the amount to the strength
-                return current_stat + increase_amount;
-            }
+            current_stat + increase_amount
+        } else {
+            MAX_STAT_VALUE
         }
-
-        // otherwise set the strength to the max stat value
-        // this will happen either in u8 overflow case
-        // or if the strength plus the amount is greater than the max stat value
-        MAX_STAT_VALUE
     }
 
     // get_random_explore returns a random number between 0 and 3 based on provided entropy
@@ -76,12 +78,6 @@ fn test_overflow_protected_stat_increase() {
     // base case
     assert(
         AdventurerUtils::overflow_protected_stat_increase(1, 1) == 2, 'stat should increase by 1'
-    );
-
-    // max stat value case
-    assert(
-        AdventurerUtils::overflow_protected_stat_increase(MAX_STAT_VALUE, 1) == MAX_STAT_VALUE,
-        'stat should not increase'
     );
 
     // u8 overflow case

--- a/contracts/adventurer/src/bag.cairo
+++ b/contracts/adventurer/src/bag.cairo
@@ -47,17 +47,18 @@ trait BagActions {
 impl BagPacking of Packing<Bag> {
     fn pack(self: Bag) -> felt252 {
         (self.item_1.pack().into()
-         + self.item_2.pack().into() * pow::TWO_POW_21
-         + self.item_3.pack().into() * pow::TWO_POW_42
-         + self.item_4.pack().into() * pow::TWO_POW_63
-         + self.item_5.pack().into() * pow::TWO_POW_84
-         + self.item_6.pack().into() * pow::TWO_POW_105
-         + self.item_7.pack().into() * pow::TWO_POW_126
-         + self.item_8.pack().into() * pow::TWO_POW_147
-         + self.item_9.pack().into() * pow::TWO_POW_168
-         + self.item_10.pack().into() * pow::TWO_POW_189
-         + self.item_11.pack().into() * pow::TWO_POW_210
-        ).try_into().expect('pack Bag')
+            + self.item_2.pack().into() * pow::TWO_POW_21
+            + self.item_3.pack().into() * pow::TWO_POW_42
+            + self.item_4.pack().into() * pow::TWO_POW_63
+            + self.item_5.pack().into() * pow::TWO_POW_84
+            + self.item_6.pack().into() * pow::TWO_POW_105
+            + self.item_7.pack().into() * pow::TWO_POW_126
+            + self.item_8.pack().into() * pow::TWO_POW_147
+            + self.item_9.pack().into() * pow::TWO_POW_168
+            + self.item_10.pack().into() * pow::TWO_POW_189
+            + self.item_11.pack().into() * pow::TWO_POW_210)
+            .try_into()
+            .expect('pack Bag')
     }
 
     fn unpack(packed: felt252) -> Bag {
@@ -87,6 +88,11 @@ impl BagPacking of Packing<Bag> {
             item_10: Packing::unpack(item_10.try_into().expect('unpack Bag item_10')),
             item_11: Packing::unpack(item_11.try_into().expect('unpack Bag item_11')),
         }
+    }
+
+    // TODO: add overflow pack protection
+    fn overflow_pack_protection(self: Bag) -> Bag {
+        self
     }
 }
 impl ImplBagActions of BagActions {
@@ -257,7 +263,7 @@ fn test_pack_bag() {
             id: 127, xp: 511, metadata: 31
             }, item_11: ItemPrimitive {
             id: 127, xp: 511, metadata: 31
-            }
+        }
     };
 
     let packed_bag: Bag = Packing::unpack(bag.pack());
@@ -333,7 +339,7 @@ fn test_add_item() {
             id: 0, xp: 0, metadata: 0
             }, item_11: ItemPrimitive {
             id: 0, xp: 0, metadata: 0
-            },
+        },
     };
 
     let item = ItemPrimitive { id: 23, xp: 1, metadata: 5 };
@@ -369,7 +375,7 @@ fn test_is_full() {
             id: 13, xp: 0, metadata: 0
             }, item_11: ItemPrimitive {
             id: 14, xp: 0, metadata: 0
-            },
+        },
     };
 
     assert(bag.is_full() == true, 'Bag should be full');
@@ -400,7 +406,7 @@ fn remove_item() {
             id: 13, xp: 0, metadata: 0
             }, item_11: ItemPrimitive {
             id: 14, xp: 0, metadata: 0
-            },
+        },
     };
 
     bag.remove_item(8);

--- a/contracts/adventurer/src/item_meta.cairo
+++ b/contracts/adventurer/src/item_meta.cairo
@@ -64,6 +64,10 @@ impl ItemSpecialsPacking of Packing<ItemSpecials> {
             special1: special1.try_into().expect('unpack LISN special1')
         }
     }
+    // TODO: add overflow pack protection
+    fn overflow_pack_protection(self: ItemSpecials) -> ItemSpecials {
+        self
+    }
 }
 
 impl ItemSpecialsStoragePacking of Packing<ItemSpecialsStorage> {
@@ -107,6 +111,11 @@ impl ItemSpecialsStoragePacking of Packing<ItemSpecialsStorage> {
             item_9: Packing::unpack(item_9.try_into().expect('unpack LISNS item_9')),
             item_10: Packing::unpack(item_10.try_into().expect('unpack LISNS item_10'))
         }
+    }
+
+    // TODO: add overflow pack protection
+    fn overflow_pack_protection(self: ItemSpecialsStorage) -> ItemSpecialsStorage {
+        self
     }
 }
 
@@ -388,9 +397,7 @@ fn test_set_item_metadata_slot() {
 
     let loot_statistics_1 = ItemPrimitive { id: 102, xp: 0, metadata: 1 };
 
-    let loot_special_names_2 = ItemSpecials {
-        special2: 12, special3: 11, special1: 13
-    };
+    let loot_special_names_2 = ItemSpecials { special2: 12, special3: 11, special1: 13 };
 
     item_meta_storage.set_loot_special_names(loot_statistics_1, loot_special_names_2);
 
@@ -400,9 +407,7 @@ fn test_set_item_metadata_slot() {
 
     let loot_statistics_2 = ItemPrimitive { id: 102, xp: 0, metadata: 2 };
 
-    let loot_special_names_2 = ItemSpecials {
-        special2: 12, special3: 11, special1: 13
-    };
+    let loot_special_names_2 = ItemSpecials { special2: 12, special3: 11, special1: 13 };
 
     item_meta_storage.set_loot_special_names(loot_statistics_2, loot_special_names_2);
     assert(item_meta_storage.item_2.special2 == 12, 'should be 12');

--- a/contracts/adventurer/src/item_primitive.cairo
+++ b/contracts/adventurer/src/item_primitive.cairo
@@ -12,10 +12,9 @@ struct ItemPrimitive {
 
 impl ItemPrimitivePacking of Packing<ItemPrimitive> {
     fn pack(self: ItemPrimitive) -> felt252 {
-        (self.id.into()
-         + self.xp.into() * pow::TWO_POW_7
-         + self.metadata.into() * pow::TWO_POW_16
-        ).try_into().expect('pack ItemPrimitive')
+        (self.id.into() + self.xp.into() * pow::TWO_POW_7 + self.metadata.into() * pow::TWO_POW_16)
+            .try_into()
+            .expect('pack ItemPrimitive')
     }
 
     fn unpack(packed: felt252) -> ItemPrimitive {
@@ -30,16 +29,17 @@ impl ItemPrimitivePacking of Packing<ItemPrimitive> {
             metadata: metadata.try_into().expect('unpack ItemPrimitive metadata')
         }
     }
+
+    // TODO: add overflow pack protection
+    fn overflow_pack_protection(self: ItemPrimitive) -> ItemPrimitive {
+        self
+    }
 }
 
 #[test]
 #[available_gas(500000)]
 fn test_item_primitive_packing() {
-    let item = ItemPrimitive {
-        id: 1,
-        xp: 2,
-        metadata: 3
-    };
+    let item = ItemPrimitive { id: 1, xp: 2, metadata: 3 };
 
     let packed = item.pack();
     let unpacked = ItemPrimitivePacking::unpack(packed);
@@ -49,11 +49,7 @@ fn test_item_primitive_packing() {
     assert(item.metadata == unpacked.metadata, 'metadata should be the same');
 
     // max value case
-    let item = ItemPrimitive {
-        id: 127,
-        xp: 511,
-        metadata: 31
-    };
+    let item = ItemPrimitive { id: 127, xp: 511, metadata: 31 };
 
     let packed = item.pack();
     let unpacked = ItemPrimitivePacking::unpack(packed);
@@ -62,11 +58,7 @@ fn test_item_primitive_packing() {
     assert(item.metadata == unpacked.metadata, 'metadata should be the same');
 
     // overflow case
-    let item = ItemPrimitive {
-        id: 128,
-        xp: 512,
-        metadata: 32
-    };
+    let item = ItemPrimitive { id: 128, xp: 512, metadata: 32 };
     let packed = item.pack();
     let unpacked = ItemPrimitivePacking::unpack(packed);
     assert(unpacked.id == 0, 'id should overflow to 0');

--- a/contracts/loot/src/loot.cairo
+++ b/contracts/loot/src/loot.cairo
@@ -13,8 +13,8 @@ use super::{
         }
     },
     utils::NameUtils::{
-        is_special3_set1, is_special3_set2, is_special3_set3, is_special1_set1,
-        is_special1_set2, is_special2_set1, is_special2_set2, is_special2_set3
+        is_special3_set1, is_special3_set2, is_special3_set3, is_special1_set1, is_special1_set2,
+        is_special2_set1, is_special2_set2, is_special2_set3
     }
 };
 
@@ -133,10 +133,11 @@ impl PackingLoot of Packing<Loot> {
         let item_slot = ImplCombat::slot_to_u8(self.slot);
 
         (self.id.into()
-         + item_tier.into() * pow::TWO_POW_8
-         + item_type.into() * pow::TWO_POW_16
-         + item_slot.into() * pow::TWO_POW_24
-        ).try_into().expect('pack Loot')
+            + item_tier.into() * pow::TWO_POW_8
+            + item_type.into() * pow::TWO_POW_16
+            + item_slot.into() * pow::TWO_POW_24)
+            .try_into()
+            .expect('pack Loot')
     }
 
     // unpack an item from storage
@@ -155,6 +156,11 @@ impl PackingLoot of Packing<Loot> {
             item_type: ImplCombat::u8_to_type(item_type.try_into().expect('unpack Loot item type')),
             slot: ImplCombat::u8_to_slot(item_slot.try_into().expect('unpack Loot slot'))
         }
+    }
+
+    // TODO: add overflow pack protection
+    fn overflow_pack_protection(self: Loot) -> Loot {
+        self
     }
 }
 
@@ -230,17 +236,13 @@ fn test_item_special3() {
         //
         // Katanas are always 'X Grasp'
         assert(
-            ImplLoot::get_special3(
-                ItemId::Katana, U32IntoU128::into(i)
-            ) == ItemNameSuffix::Grasp,
+            ImplLoot::get_special3(ItemId::Katana, U32IntoU128::into(i)) == ItemNameSuffix::Grasp,
             'katana should be grasp'
         );
 
         // Warhammers are always 'X Bane'
         assert(
-            ImplLoot::get_special3(
-                ItemId::Warhammer, U32IntoU128::into(i)
-            ) == ItemNameSuffix::Bane,
+            ImplLoot::get_special3(ItemId::Warhammer, U32IntoU128::into(i)) == ItemNameSuffix::Bane,
             'warhammer should be bane'
         );
 
@@ -254,9 +256,7 @@ fn test_item_special3() {
         //
         // Divine Robes are always {X Bane, X Song, X Instrument, X Shadow, X Growl, X Form} (set 1)
         assert(
-            is_special3_set1(
-                ImplLoot::get_special3(ItemId::DivineRobe, U32IntoU128::into(i))
-            ),
+            is_special3_set1(ImplLoot::get_special3(ItemId::DivineRobe, U32IntoU128::into(i))),
             'invalid divine robe name suffix'
         );
 
@@ -277,9 +277,7 @@ fn test_item_special3() {
         //
         // Ancient Helms use name suffix set 1
         assert(
-            is_special3_set1(
-                ImplLoot::get_special3(ItemId::AncientHelm, U32IntoU128::into(i))
-            ),
+            is_special3_set1(ImplLoot::get_special3(ItemId::AncientHelm, U32IntoU128::into(i))),
             'invalid war cap name suffix'
         );
 
@@ -291,9 +289,7 @@ fn test_item_special3() {
 
         // Divine Hood uses name suffix set 3
         assert(
-            is_special3_set3(
-                ImplLoot::get_special3(ItemId::DivineHood, U32IntoU128::into(i))
-            ),
+            is_special3_set3(ImplLoot::get_special3(ItemId::DivineHood, U32IntoU128::into(i))),
             'invalid divine hood name suffix'
         );
 
@@ -302,25 +298,19 @@ fn test_item_special3() {
         //
         // Ornate Belt uses name suffix set 1
         assert(
-            is_special3_set1(
-                ImplLoot::get_special3(ItemId::OrnateBelt, U32IntoU128::into(i))
-            ),
+            is_special3_set1(ImplLoot::get_special3(ItemId::OrnateBelt, U32IntoU128::into(i))),
             'invalid ornate belt suffix'
         );
 
         // Brightsilk Sash uses name suffix set 2
         assert(
-            is_special3_set2(
-                ImplLoot::get_special3(ItemId::BrightsilkSash, U32IntoU128::into(i))
-            ),
+            is_special3_set2(ImplLoot::get_special3(ItemId::BrightsilkSash, U32IntoU128::into(i))),
             'invalid brightsilk sash suffix'
         );
 
         // Hard Leather Belt uses name set 3
         assert(
-            is_special3_set3(
-                ImplLoot::get_special3(ItemId::HardLeatherBelt, U32IntoU128::into(i))
-            ),
+            is_special3_set3(ImplLoot::get_special3(ItemId::HardLeatherBelt, U32IntoU128::into(i))),
             'wrong hard leather belt suffix'
         );
 
@@ -329,25 +319,19 @@ fn test_item_special3() {
         //
         // Holy Graves uses name suffix set 1
         assert(
-            is_special3_set1(
-                ImplLoot::get_special3(ItemId::HolyGreaves, U32IntoU128::into(i))
-            ),
+            is_special3_set1(ImplLoot::get_special3(ItemId::HolyGreaves, U32IntoU128::into(i))),
             'invalid holy greaves suffix'
         );
 
         // Heavy Boots use name suffix set 2
         assert(
-            is_special3_set2(
-                ImplLoot::get_special3(ItemId::HeavyBoots, U32IntoU128::into(i))
-            ),
+            is_special3_set2(ImplLoot::get_special3(ItemId::HeavyBoots, U32IntoU128::into(i))),
             'invalid heavy boots suffix'
         );
 
         // Silk Slippers use name suffix set 3
         assert(
-            is_special3_set3(
-                ImplLoot::get_special3(ItemId::SilkSlippers, U32IntoU128::into(i))
-            ),
+            is_special3_set3(ImplLoot::get_special3(ItemId::SilkSlippers, U32IntoU128::into(i))),
             'invalid silk slippers suffix'
         );
 
@@ -356,17 +340,13 @@ fn test_item_special3() {
         //
         // Holy Gauntlets use name suffix set 1
         assert(
-            is_special3_set1(
-                ImplLoot::get_special3(ItemId::HolyGauntlets, U32IntoU128::into(i))
-            ),
+            is_special3_set1(ImplLoot::get_special3(ItemId::HolyGauntlets, U32IntoU128::into(i))),
             'invalid holy gauntlets suffix'
         );
 
         // Linen Gloves use name suffix set 2
         assert(
-            is_special3_set2(
-                ImplLoot::get_special3(ItemId::LinenGloves, U32IntoU128::into(i))
-            ),
+            is_special3_set2(ImplLoot::get_special3(ItemId::LinenGloves, U32IntoU128::into(i))),
             'invalid linen gloves suffix'
         );
 
@@ -424,9 +404,7 @@ fn test_item_prefix() {
         }
 
         // divine robe uses name prefix set 1
-        let divine_robe_prefix = ImplLoot::get_special2(
-            ItemId::DivineRobe, U32IntoU128::into(i)
-        );
+        let divine_robe_prefix = ImplLoot::get_special2(ItemId::DivineRobe, U32IntoU128::into(i));
         let divine_robe_prefix_valid = is_special2_set1(divine_robe_prefix);
         assert(divine_robe_prefix_valid, 'invalid divine robe belt prefix');
 

--- a/contracts/pack/src/pack.cairo
+++ b/contracts/pack/src/pack.cairo
@@ -3,6 +3,7 @@ use traits::{Into, TryInto};
 
 trait Packing<T> {
     fn pack(self: T) -> felt252;
+    fn overflow_pack_protection(self: T) -> T;
     fn unpack(packed: felt252) -> T;
 }
 


### PR DESCRIPTION
- suffix stat boosts were being applied on pack and unpack
- adventurer lib was preventing stats from boosting over 31
- add overflow protection to stat packing
- add game test for adventurer to level 11