### PR TITLE
adds contract support for multi item purchases

### DIFF
--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -4,7 +4,7 @@ use survivor::{
     item_meta::{ItemSpecials, ItemSpecialsStorage}
 };
 use lootitems::loot::{Loot};
-use market::market::LootWithPrice;
+use market::market::{LootWithPrice, ItemPurchase};
 use beasts::beast::Beast;
 
 #[starknet::interface]
@@ -21,6 +21,7 @@ trait IGame<TContractState> {
     fn flee(ref self: TContractState, adventurer_id: u256);
     fn equip(ref self: TContractState, adventurer_id: u256, items: Span<u8>);
     fn drop(ref self: TContractState, adventurer_id: u256, items: Span<u8>);
+    fn buy_items(ref self: TContractState, adventurer_id: u256, items: Span<ItemPurchase>);
     fn buy_item(ref self: TContractState, adventurer_id: u256, item_id: u8, equip: bool);
     fn buy_potion(ref self: TContractState, adventurer_id: u256);
     fn buy_potions(ref self: TContractState, adventurer_id: u256, amount: u8);

--- a/contracts/market/src/market.cairo
+++ b/contracts/market/src/market.cairo
@@ -20,6 +20,12 @@ struct LootWithPrice {
     price: u16,
 }
 
+#[derive(Copy, Drop, Serde)]
+struct ItemPurchase {
+    item_id: u8,
+    equip: bool,
+}
+
 #[generate_trait]
 impl ImplMarket of IMarket {
     fn get_price(tier: Tier) -> u16 {


### PR DESCRIPTION
- provides external buy_items that takes in adventurer_id and an Array of <item_id, equip>
- includes contract test