### PR TITLE
Flexible starting stat and difficulty tuning

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -17,8 +17,7 @@ use super::{
             ITEM_MAX_XP, MAX_ADVENTURER_HEALTH, CHARISMA_ITEM_DISCOUNT, ClassStatBoosts
         },
         discovery_constants::DiscoveryEnums::{ExploreResult, TreasureDiscovery}
-    },
-    adventurer_meta::{AdventurerClass}
+    }
 };
 use pack::{pack::{Packing, rshift_split}, constants::{MASK_16, pow, MASK_8, MASK_BOOL, mask}};
 use lootitems::{
@@ -124,18 +123,29 @@ impl ImplAdventurer of IAdventurer {
     // @param starting_item: the id of the starting item
     // @param block_number: the block number of the block that the adventurer was created in
     // @return Adventurer: the new adventurer
-    fn new(starting_item: u8, adventurer_class: AdventurerClass, block_number: u64) -> Adventurer {
+    fn new(
+        starting_item: u8,
+        block_number: u64,
+        starting_strength: u8,
+        starting_dexterity: u8,
+        starting_vitality: u8,
+        starting_intelligence: u8,
+        starting_wisdom: u8,
+        starting_charsima: u8
+    ) -> Adventurer {
         let current_block_modulo_512: u16 = (block_number % MAX_ADVENTURER_BLOCKS.into())
             .try_into()
             .unwrap();
 
         let mut adventurer = Adventurer {
-            last_action: current_block_modulo_512,
-            health: STARTING_HEALTH,
-            xp: 0,
-            stats: AdventurerUtils::get_class_stats(adventurer_class),
-            gold: STARTING_GOLD,
-            weapon: ItemPrimitive {
+            last_action: current_block_modulo_512, health: STARTING_HEALTH, xp: 0, stats: Stats {
+                strength: starting_strength,
+                dexterity: starting_dexterity,
+                vitality: starting_vitality,
+                intelligence: starting_intelligence,
+                wisdom: starting_wisdom,
+                charisma: starting_charsima
+                }, gold: STARTING_GOLD, weapon: ItemPrimitive {
                 id: starting_item, xp: 0, metadata: 1, 
                 }, chest: ItemPrimitive {
                 id: 0, xp: 0, metadata: 0, 
@@ -158,27 +168,6 @@ impl ImplAdventurer of IAdventurer {
         adventurer.health = adventurer.get_max_health();
         adventurer
     }
-
-    // @notice Adds class-specific stats to an adventurer
-    // @param self The adventurer object to which the class-specific stats are to be added
-    // @param adventurer_class The class of the adventurer for which the stats are being fetched
-    fn add_class_stats(ref self: Adventurer, adventurer_class: AdventurerClass) {
-        self.stats = AdventurerUtils::get_class_stats(adventurer_class);
-    }
-
-    // @notice Gets the stats for a Scout class
-    // @return A Stats object which represents the stats of the Scout class
-    fn get_scout_stats() -> Stats {
-        Stats {
-            strength: ClassStatBoosts::Cleric::STRENGTH,
-            dexterity: ClassStatBoosts::Cleric::DEXTERITY,
-            vitality: ClassStatBoosts::Cleric::VITALITY,
-            intelligence: ClassStatBoosts::Cleric::INTELLIGENCE,
-            wisdom: ClassStatBoosts::Cleric::WISDOM,
-            charisma: ClassStatBoosts::Cleric::VITALITY,
-        }
-    }
-
 
     // @notice Generates market seeds and offsets for an adventurer based on their stat points, 
     // adventurer id, and entropy.
@@ -1405,7 +1394,7 @@ impl ImplAdventurer of IAdventurer {
 #[test]
 #[available_gas(200000)]
 fn test_charisma_adjusted_item_price() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // zero case
     let item_price = adventurer.charisma_adjusted_item_price(0);
@@ -1435,7 +1424,7 @@ fn test_charisma_adjusted_item_price() {
 #[test]
 #[available_gas(290000)]
 fn test_charisma_adjusted_potion_price() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // default case (no charisma discount)
     let potion_price = adventurer.charisma_adjusted_potion_price();
@@ -1466,7 +1455,7 @@ fn test_charisma_adjusted_potion_price() {
 #[test]
 #[available_gas(150000)]
 fn test_get_idle_blocks() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     adventurer.last_action = 1;
 
     // test with current block greater than last action
@@ -1596,118 +1585,18 @@ fn test_packing_stat_overflow_protection() {
 #[test]
 #[available_gas(2000000)]
 fn test_new_adventurer() {
-    let new_adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let new_adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     new_adventurer.pack();
     assert(new_adventurer.health == STARTING_HEALTH, 'wrong starting health');
     assert(new_adventurer.gold == STARTING_GOLD, 'wrong starting gold');
     assert(new_adventurer.xp == 0, 'wrong starting xp');
 }
 
-#[test]
-#[available_gas(2000000)]
-fn test_new_cleric() {
-    let new_adventurer = ImplAdventurer::new(1, AdventurerClass::Cleric(()), 1);
-    assert(
-        new_adventurer.stats.strength == ClassStatBoosts::Cleric::STRENGTH, 'wrong cleric strength'
-    );
-    assert(
-        new_adventurer.stats.dexterity == ClassStatBoosts::Cleric::DEXTERITY,
-        'wrong cleric dexterity'
-    );
-    assert(
-        new_adventurer.stats.vitality == ClassStatBoosts::Cleric::VITALITY, 'wrong cleric vitality'
-    );
-    assert(
-        new_adventurer.stats.intelligence == ClassStatBoosts::Cleric::INTELLIGENCE,
-        'wrong cleric intelligence'
-    );
-    assert(new_adventurer.stats.wisdom == ClassStatBoosts::Cleric::WISDOM, 'wrong cleric wisdom');
-    assert(
-        new_adventurer.stats.charisma == ClassStatBoosts::Cleric::CHARISMA, 'wrong cleric charisma'
-    );
-    assert(
-        new_adventurer.health == STARTING_HEALTH
-            + (new_adventurer.stats.vitality.into() * VITALITY_HEALTH_CAP_INCREASE.into()),
-        'wrong cleric health'
-    );
-}
-#[test]
-#[available_gas(2000000)]
-fn test_new_scout() {
-    let new_adventurer = ImplAdventurer::new(1, AdventurerClass::Scout(()), 1);
-    assert(
-        new_adventurer.stats.strength == ClassStatBoosts::Scout::STRENGTH, 'wrong scout strength'
-    );
-    assert(
-        new_adventurer.stats.dexterity == ClassStatBoosts::Scout::DEXTERITY, 'wrong scout dexterity'
-    );
-    assert(
-        new_adventurer.stats.vitality == ClassStatBoosts::Scout::VITALITY, 'wrong scout vitality'
-    );
-    assert(
-        new_adventurer.stats.intelligence == ClassStatBoosts::Scout::INTELLIGENCE,
-        'wrong scout intelligence'
-    );
-    assert(new_adventurer.stats.wisdom == ClassStatBoosts::Scout::WISDOM, 'wrong scout wisdom');
-    assert(
-        new_adventurer.stats.charisma == ClassStatBoosts::Scout::CHARISMA, 'wrong scout charisma'
-    );
-}
-#[test]
-#[available_gas(2000000)]
-fn test_new_hunter() {
-    let new_adventurer = ImplAdventurer::new(1, AdventurerClass::Hunter(()), 1);
-    assert(
-        new_adventurer.stats.strength == ClassStatBoosts::Hunter::STRENGTH, 'wrong hunter strength'
-    );
-    assert(
-        new_adventurer.stats.dexterity == ClassStatBoosts::Hunter::DEXTERITY,
-        'wrong hunter dexterity'
-    );
-    assert(
-        new_adventurer.stats.vitality == ClassStatBoosts::Hunter::VITALITY, 'wrong hunter vitality'
-    );
-    assert(
-        new_adventurer.stats.intelligence == ClassStatBoosts::Hunter::INTELLIGENCE,
-        'wrong hunter intelligence'
-    );
-    assert(new_adventurer.stats.wisdom == ClassStatBoosts::Hunter::WISDOM, 'wrong hunter wisdom');
-    assert(
-        new_adventurer.stats.charisma == ClassStatBoosts::Hunter::CHARISMA, 'wrong hunter charisma'
-    );
-}
-#[test]
-#[available_gas(2000000)]
-fn test_new_warrior() {
-    let new_adventurer = ImplAdventurer::new(1, AdventurerClass::Warrior(()), 1);
-    assert(
-        new_adventurer.stats.strength == ClassStatBoosts::Warrior::STRENGTH,
-        'wrong warrior strength'
-    );
-    assert(
-        new_adventurer.stats.dexterity == ClassStatBoosts::Warrior::DEXTERITY,
-        'wrong warrior dexterity'
-    );
-    assert(
-        new_adventurer.stats.vitality == ClassStatBoosts::Warrior::VITALITY,
-        'wrong warrior vitality'
-    );
-    assert(
-        new_adventurer.stats.intelligence == ClassStatBoosts::Warrior::INTELLIGENCE,
-        'wrong warrior intelligence'
-    );
-    assert(new_adventurer.stats.wisdom == ClassStatBoosts::Warrior::WISDOM, 'wrong warrior wisdom');
-    assert(
-        new_adventurer.stats.charisma == ClassStatBoosts::Warrior::CHARISMA,
-        'wrong warrior charisma'
-    );
-}
-
 
 #[test]
 #[available_gas(200000)]
 fn test_increase_health() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // test stock max health is 100
     adventurer.increase_health(5);
@@ -1736,7 +1625,7 @@ fn test_increase_health() {
 #[test]
 #[available_gas(200000)]
 fn test_get_max_health() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // assert starting state
     assert(adventurer.get_max_health() == STARTING_HEALTH, 'advntr should have max health');
@@ -1757,14 +1646,14 @@ fn test_get_max_health() {
 #[test]
 #[available_gas(200000)]
 fn test_has_full_health() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // adventurers should start with full health
     assert(adventurer.has_full_health() == true, 'should start with full health');
 
     // increase max health via vitality boost
     // health is no longer technically full
-    adventurer.stats.vitality = 1;
+    adventurer.stats.vitality = 2;
     assert(adventurer.has_full_health() == false, 'vitality increased max');
 
     // fill up health
@@ -1779,7 +1668,7 @@ fn test_has_full_health() {
 #[test]
 #[available_gas(3000000)]
 fn test_add_gold() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // assert starting state
     assert(adventurer.gold == STARTING_GOLD, 'wrong advntr starting gold');
@@ -1805,7 +1694,7 @@ fn test_add_gold() {
 #[test]
 #[available_gas(90000)]
 fn test_deduct_health() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     let starting_health = adventurer.health;
     let deduct_amount = 5;
 
@@ -1821,7 +1710,7 @@ fn test_deduct_health() {
 #[test]
 #[available_gas(90000)]
 fn test_deduct_gold() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     let starting_gold = adventurer.gold;
     let deduct_amount = 5;
 
@@ -1837,7 +1726,7 @@ fn test_deduct_gold() {
 #[test]
 #[available_gas(200000)]
 fn test_increase_adventurer_xp() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // base case level increase
     let (previous_level, new_level) = adventurer.increase_adventurer_xp(4);
     assert(adventurer.xp == 4, 'xp should be 4');
@@ -1865,7 +1754,7 @@ fn test_increase_adventurer_xp() {
 #[available_gas(3000000)]
 fn test_add_stat_upgrade_points() {
     // get new adventurer
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     let original_stat_points = adventurer.stat_points_available;
 
     // zero case
@@ -1897,7 +1786,7 @@ fn test_add_stat_upgrade_points() {
 #[test]
 #[available_gas(90000)]
 fn test_add_strength() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // basic case
     adventurer.increase_strength(1);
     assert(adventurer.stats.strength == 1, 'strength should be 1');
@@ -1909,7 +1798,7 @@ fn test_add_strength() {
 #[test]
 #[available_gas(90000)]
 fn test_add_dexterity() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // basic case
     adventurer.increase_dexterity(1);
     assert(adventurer.stats.dexterity == 1, 'dexterity should be 1');
@@ -1921,7 +1810,7 @@ fn test_add_dexterity() {
 #[test]
 #[available_gas(90000)]
 fn test_add_vitality() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // basic case
     adventurer.increase_vitality(1);
     assert(adventurer.stats.vitality == 1, 'vitality should be 1');
@@ -1933,7 +1822,7 @@ fn test_add_vitality() {
 #[test]
 #[available_gas(90000)]
 fn test_add_intelligence() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // basic case
     adventurer.increase_intelligence(1);
     assert(adventurer.stats.intelligence == 1, 'intelligence should be 1');
@@ -1945,7 +1834,7 @@ fn test_add_intelligence() {
 #[test]
 #[available_gas(90000)]
 fn test_add_wisdom() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // basic case
     adventurer.increase_wisdom(1);
     assert(adventurer.stats.wisdom == 1, 'wisdom should be 1');
@@ -1957,7 +1846,7 @@ fn test_add_wisdom() {
 #[test]
 #[available_gas(90000)]
 fn test_add_charisma() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // basic case
     adventurer.increase_charisma(1);
     assert(adventurer.stats.charisma == 1, 'charisma should be 1');
@@ -1969,7 +1858,7 @@ fn test_add_charisma() {
 #[test]
 #[available_gas(90000)]
 fn test_deduct_strength() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // basic case
     adventurer.increase_strength(2);
     adventurer.deduct_strength(1);
@@ -1983,7 +1872,7 @@ fn test_deduct_strength() {
 #[test]
 #[available_gas(90000)]
 fn test_deduct_dexterity() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // basic case
     adventurer.increase_dexterity(2);
     adventurer.deduct_dexterity(1);
@@ -1997,7 +1886,7 @@ fn test_deduct_dexterity() {
 #[test]
 #[available_gas(90000)]
 fn test_deduct_vitality() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // basic case
     adventurer.increase_vitality(2);
     adventurer.deduct_vitality(1);
@@ -2011,7 +1900,7 @@ fn test_deduct_vitality() {
 #[test]
 #[available_gas(90000)]
 fn test_deduct_intelligence() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // basic case
     adventurer.increase_intelligence(2);
     adventurer.deduct_intelligence(1);
@@ -2025,7 +1914,7 @@ fn test_deduct_intelligence() {
 #[test]
 #[available_gas(90000)]
 fn test_deduct_wisdom() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // basic case
     adventurer.increase_wisdom(2);
     adventurer.deduct_wisdom(1);
@@ -2039,7 +1928,7 @@ fn test_deduct_wisdom() {
 #[test]
 #[available_gas(90000)]
 fn test_deduct_charisma() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // basic case
     adventurer.increase_charisma(2);
     adventurer.deduct_charisma(1);
@@ -2055,7 +1944,7 @@ fn test_deduct_charisma() {
 #[should_panic(expected: ('Item is not weapon', ))]
 #[available_gas(90000)]
 fn test_equip_invalid_weapon() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // create demon crown item
     let item = ItemPrimitive { id: constants::ItemId::DemonCrown, xp: 1, metadata: 0 };
     // try to equip it to adventurer as a weapon
@@ -2069,7 +1958,7 @@ fn test_equip_invalid_weapon() {
 #[test]
 #[available_gas(90000)]
 fn test_equip_valid_weapon() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // Create Katana item
     let item = ItemPrimitive { id: constants::ItemId::Katana, xp: 1, metadata: 0 };
@@ -2087,7 +1976,7 @@ fn test_equip_valid_weapon() {
 #[should_panic(expected: ('Item is not chest armor', ))]
 #[available_gas(90000)]
 fn test_equip_invalid_chest() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // try to equip a Demon Crown as chest item
     let item = ItemPrimitive { id: constants::ItemId::DemonCrown, xp: 1, metadata: 0 };
     adventurer.equip_chest_armor(item);
@@ -2100,7 +1989,7 @@ fn test_equip_invalid_chest() {
 #[test]
 #[available_gas(90000)]
 fn test_equip_valid_chest() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // equip Divine Robe as chest item
     let item = ItemPrimitive { id: constants::ItemId::DivineRobe, xp: 1, metadata: 0 };
     adventurer.equip_chest_armor(item);
@@ -2116,7 +2005,7 @@ fn test_equip_valid_chest() {
 #[should_panic(expected: ('Item is not head armor', ))]
 #[available_gas(90000)]
 fn test_equip_invalid_head() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // try to equip a Katana as head item
     let item = ItemPrimitive { id: constants::ItemId::Katana, xp: 1, metadata: 0 };
     adventurer.equip_head_armor(item);
@@ -2126,7 +2015,7 @@ fn test_equip_invalid_head() {
 #[test]
 #[available_gas(90000)]
 fn test_equip_valid_head() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // equip Crown as head item
     let item = ItemPrimitive { id: constants::ItemId::Crown, xp: 1, metadata: 0 };
     adventurer.equip_head_armor(item);
@@ -2141,7 +2030,7 @@ fn test_equip_valid_head() {
 #[should_panic(expected: ('Item is not waist armor', ))]
 #[available_gas(90000)]
 fn test_equip_invalid_waist() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // try to equip a Demon Crown as waist item
     let item = ItemPrimitive { id: constants::ItemId::DemonCrown, xp: 1, metadata: 0 };
     adventurer.equip_waist_armor(item);
@@ -2151,7 +2040,7 @@ fn test_equip_invalid_waist() {
 #[test]
 #[available_gas(90000)]
 fn test_equip_valid_waist() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // equip Wool Sash as waist item
     let item = ItemPrimitive { id: constants::ItemId::WoolSash, xp: 1, metadata: 0 };
@@ -2168,7 +2057,7 @@ fn test_equip_valid_waist() {
 #[should_panic(expected: ('Item is not foot armor', ))]
 #[available_gas(90000)]
 fn test_equip_invalid_foot() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // try to equip a Demon Crown as foot item
     let item = ItemPrimitive { id: constants::ItemId::DemonCrown, xp: 1, metadata: 0 };
     adventurer.equip_foot_armor(item);
@@ -2178,7 +2067,7 @@ fn test_equip_invalid_foot() {
 #[test]
 #[available_gas(90000)]
 fn test_equip_valid_foot() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // equip Silk Slippers as foot item
     let item = ItemPrimitive { id: constants::ItemId::SilkSlippers, xp: 1, metadata: 0 };
@@ -2195,7 +2084,7 @@ fn test_equip_valid_foot() {
 #[should_panic(expected: ('Item is not hand armor', ))]
 #[available_gas(90000)]
 fn test_equip_invalid_hand() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // try to equip a Demon Crown as hand item
     let item = ItemPrimitive { id: constants::ItemId::DemonCrown, xp: 1, metadata: 0 };
@@ -2206,7 +2095,7 @@ fn test_equip_invalid_hand() {
 #[test]
 #[available_gas(90000)]
 fn test_equip_valid_hand() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // equip Divine Gloves as hand item
     let item = ItemPrimitive { id: constants::ItemId::DivineGloves, xp: 1, metadata: 0 };
@@ -2223,7 +2112,7 @@ fn test_equip_valid_hand() {
 #[should_panic(expected: ('Item is not necklace', ))]
 #[available_gas(90000)]
 fn test_equip_invalid_neck() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // try to equip a Demon Crown as necklace
     let item = ItemPrimitive { id: constants::ItemId::DemonCrown, xp: 1, metadata: 0 };
@@ -2234,7 +2123,7 @@ fn test_equip_invalid_neck() {
 #[test]
 #[available_gas(90000)]
 fn test_equip_valid_neck() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // equip Pendant as necklace
     let item = ItemPrimitive { id: constants::ItemId::Pendant, xp: 1, metadata: 0 };
@@ -2251,7 +2140,7 @@ fn test_equip_valid_neck() {
 #[should_panic(expected: ('Item is not a ring', ))]
 #[available_gas(90000)]
 fn test_equip_invalid_ring() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // try to equip a Demon Crown as ring
     let item = ItemPrimitive { id: constants::ItemId::DemonCrown, xp: 1, metadata: 0 };
@@ -2262,7 +2151,7 @@ fn test_equip_invalid_ring() {
 #[test]
 #[available_gas(90000)]
 fn test_equip_valid_ring() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     let item = ItemPrimitive { id: constants::ItemId::PlatinumRing, xp: 1, metadata: 0 };
     adventurer.equip_ring(item);
     assert(adventurer.ring.id == constants::ItemId::PlatinumRing, 'did not equip ring');
@@ -2273,7 +2162,7 @@ fn test_equip_valid_ring() {
 #[test]
 #[available_gas(6000000)]
 fn test_increase_item_xp() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     let entropy = 1;
     let item_ghost_wand = ItemPrimitive { id: constants::ItemId::GhostWand, xp: 1, metadata: 1 };
     adventurer.equip_item(item_ghost_wand);
@@ -2468,7 +2357,7 @@ fn test_increase_item_xp() {
 #[test]
 #[available_gas(60000)]
 fn test_set_beast_health() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // base case
     adventurer.set_beast_health(100);
@@ -2482,7 +2371,7 @@ fn test_set_beast_health() {
 #[test]
 #[available_gas(90000)]
 fn test_deduct_beast_health() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // stage beast with 100
     adventurer.set_beast_health(100);
@@ -2514,7 +2403,7 @@ fn test_explore_xp_discovery() { // TODO: test xp discovery
 #[test]
 #[available_gas(220000)]
 fn test_increment_stat_valid() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     adventurer.increment_stat(StatisticIndex::STRENGTH);
     assert(adventurer.stats.strength == 1, 'strength');
@@ -2569,7 +2458,7 @@ fn test_increment_stat_valid() {
 #[should_panic(expected: ('Valid stat range is 0-5', ))]
 #[available_gas(90000)]
 fn test_increment_stat_invalid() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // invalid stat index should cause panic
     // which this test is annotated to expect
@@ -2579,7 +2468,7 @@ fn test_increment_stat_invalid() {
 #[test]
 #[available_gas(600000)]
 fn test_get_item_at_slot() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // stage items
     let weapon = ItemPrimitive { id: constants::ItemId::Katana, xp: 1, metadata: 1 };
@@ -2615,7 +2504,7 @@ fn test_get_item_at_slot() {
 #[test]
 #[available_gas(600000)]
 fn test_is_slot_free() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // stage items
     let weapon = ItemPrimitive { id: constants::ItemId::Katana, xp: 1, metadata: 1 };
@@ -2647,7 +2536,7 @@ fn test_is_slot_free() {
 #[test]
 #[available_gas(600000)]
 fn test_get_level() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     assert(adventurer.get_level() == 1, 'level should be 1');
 
     adventurer.xp = 4;
@@ -2671,7 +2560,7 @@ fn test_get_level() {
 #[test]
 #[available_gas(200000)]
 fn test_charisma_health_discount_overflow() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // max charisma
     adventurer.stats.charisma = 255;
@@ -2687,7 +2576,7 @@ fn test_charisma_health_discount_overflow() {
 #[test]
 #[available_gas(200000)]
 fn test_charisma_item_discount_overflow() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     let item_price = 15;
 
     // no charisma case
@@ -2720,7 +2609,7 @@ fn test_charisma_item_discount_overflow() {
 #[available_gas(100000)]
 fn test_increase_xp() {
     // initialize lvl 1 adventurer with no stat points available
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // increase adventurer xp by 3 which should level up the adventurer
     adventurer.increase_adventurer_xp(4);
@@ -2734,7 +2623,7 @@ fn test_increase_xp() {
 #[test]
 #[available_gas(600000)]
 fn test_add_suffix_boost() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     adventurer.add_suffix_boost(ItemSuffix::of_Power);
     assert(adventurer.stats.strength == 3, 'strength should be 3');
@@ -2780,7 +2669,7 @@ fn test_add_suffix_boost() {
 #[test]
 #[available_gas(1900000)]
 fn test_remove_suffix_boost() {
-    let mut adventurer = ImplAdventurer::new(12, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // verify starting state
     assert(adventurer.stats.strength == 0, 'strength should be 0');
@@ -2916,7 +2805,7 @@ fn test_get_market_entropy() {
 #[test]
 #[available_gas(390000)]
 fn test_discover_treasure() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // give vitality so we can discover health
     adventurer.stats.vitality = 1;
@@ -2941,7 +2830,7 @@ fn test_discover_treasure() {
 #[test]
 #[available_gas(200000)]
 fn test_get_luck() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     assert(adventurer.get_luck() == 0, 'start with no luck');
 
     // equip a greatness 1 necklace
@@ -2963,7 +2852,7 @@ fn test_get_luck() {
 #[test]
 #[available_gas(200000)]
 fn test_in_battle() {
-    let mut adventurer = ImplAdventurer::new(1, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     assert(adventurer.in_battle() == true, 'new advntr start in battle');
 
     adventurer.beast_health = 0;
@@ -2977,7 +2866,7 @@ fn test_in_battle() {
 #[test]
 #[available_gas(900000)]
 fn test_equip_item() {
-    let mut adventurer = ImplAdventurer::new(12, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // assert starting conditions
     assert(adventurer.weapon.id == 12, 'weapon should be 12');
@@ -3022,7 +2911,7 @@ fn test_equip_item() {
 #[test]
 #[available_gas(2000000)]
 fn test_grant_xp_and_check_for_greatness_increase() {
-    let mut adventurer = ImplAdventurer::new(12, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // stage items
     let mut weapon = ItemPrimitive { id: constants::ItemId::Katana, xp: 1, metadata: 1 };
@@ -3142,7 +3031,7 @@ fn test_grant_xp_and_check_for_greatness_increase() {
 fn test_is_equipped() {
     let wand = ItemPrimitive { id: constants::ItemId::Wand, xp: 1, metadata: 1 };
     let demon_crown = ItemPrimitive { id: constants::ItemId::DemonCrown, xp: 1, metadata: 2 };
-    let mut adventurer = ImplAdventurer::new(wand.id, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // assert starting state
     assert(adventurer.weapon.id == wand.id, 'weapon should be wand');
@@ -3263,7 +3152,7 @@ fn test_is_equipped() {
 #[available_gas(1100000)]
 fn test_drop_item_not_equipped() {
     // instantiate adventurer
-    let mut adventurer = ImplAdventurer::new(12, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
     // try to drop an item that isn't equipped
     // this should panic with 'item is not equipped'
     // the test is annotated to expect this panic
@@ -3273,7 +3162,7 @@ fn test_drop_item_not_equipped() {
 #[test]
 #[available_gas(1100000)]
 fn test_drop_item() {
-    let mut adventurer = ImplAdventurer::new(12, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12, 0, 0, 0, 0, 0, 0, 0);
 
     // assert starting conditions
     assert(adventurer.weapon.id == constants::ItemId::Wand, 'weapon should be wand');

--- a/contracts/adventurer/src/adventurer_meta.cairo
+++ b/contracts/adventurer/src/adventurer_meta.cairo
@@ -4,48 +4,11 @@ use traits::{TryInto, Into};
 use pack::constants::pow;
 use pack::pack::{Packing, rshift_split};
 
-#[derive(Drop, Copy, PartialEq, Serde)]
-enum AdventurerClass {
-    None: (),
-    Cleric: (),
-    Scout: (),
-    Hunter: (),
-    Warrior: ()
-}
-
-#[generate_trait]
-impl ImplAdventurerClass of IAdventurerClass {
-    fn to_u8(self: AdventurerClass) -> u8 {
-        match self {
-            AdventurerClass::None(()) => 0,
-            AdventurerClass::Cleric(()) => 1,
-            AdventurerClass::Scout(()) => 2,
-            AdventurerClass::Hunter(()) => 3,
-            AdventurerClass::Warrior(()) => 4,
-        }
-    }
-    fn u8_to_slot(item_type: u8) -> AdventurerClass {
-        if item_type == 0 {
-            AdventurerClass::None(())
-        } else if item_type == 1 {
-            AdventurerClass::Cleric(())
-        } else if item_type == 2 {
-            AdventurerClass::Scout(())
-        } else if item_type == 3 {
-            AdventurerClass::Hunter(())
-        } else if item_type == 4 {
-            AdventurerClass::Warrior(())
-        } else {
-            panic_with_felt252('unknown adventurer class')
-        }
-    }
-}
-
 #[derive(Drop, Copy, Serde)]
 struct AdventurerMetadata {
     name: u128,
     home_realm: u16,
-    class: AdventurerClass,
+    class: u8,
     entropy: u128,
 }
 
@@ -53,7 +16,7 @@ impl PackingAdventurerMetadata of Packing<AdventurerMetadata> {
     fn pack(self: AdventurerMetadata) -> felt252 {
         (self.entropy.into()
             + self.home_realm.into() * pow::TWO_POW_128
-            + self.class.to_u8().into() * pow::TWO_POW_141
+            + self.class.into() * pow::TWO_POW_141
             + self.name.into() * pow::TWO_POW_145)
             .try_into()
             .expect('pack AdventurerMetadata')
@@ -67,9 +30,7 @@ impl PackingAdventurerMetadata of Packing<AdventurerMetadata> {
         AdventurerMetadata {
             name: name.try_into().expect('unpack AdvMetadata name'),
             home_realm: home_realm.try_into().expect('unpack AdvMetadata home_realm'),
-            class: ImplAdventurerClass::u8_to_slot(
-                class.try_into().expect('unpack AdvMetadata class')
-            ),
+            class: class.try_into().expect('unpack AdvMetadata class'),
             entropy: entropy.try_into().expect('unpack AdvMetadata entropy')
         }
     }
@@ -87,7 +48,7 @@ fn test_meta() {
     let meta = AdventurerMetadata {
         name: 'abcdefghijklm',
         home_realm: 8000,
-        class: AdventurerClass::Warrior(()),
+        class: 1,
         entropy: 340282366920938463463374607431768211455
     };
 

--- a/contracts/adventurer/src/adventurer_utils.cairo
+++ b/contracts/adventurer/src/adventurer_utils.cairo
@@ -9,7 +9,7 @@ use super::{
         adventurer_constants::{MAX_STAT_VALUE, U128_MAX, ClassStatBoosts},
         discovery_constants::DiscoveryEnums::{ExploreResult, TreasureDiscovery}
     },
-    adventurer_meta::AdventurerClass, adventurer_stats::Stats
+    adventurer_stats::Stats
 };
 use lootitems::statistics::constants::{
     NUM_ITEMS,
@@ -100,59 +100,6 @@ impl AdventurerUtils of IAdventurer {
         let poseidon: felt252 = poseidon_hash_span(hash_span.span()).into();
         let (d, r) = rshift_split(poseidon.into(), U128_MAX.into());
         (r.try_into().unwrap(), d.try_into().unwrap())
-    }
-
-    // @notice Retrieves the stats for an adventurer class
-    // @param adventurer_class The class of the adventurer to retrieve the stats for
-    // @return A Stats object which represents the stats of the given adventurer class
-    fn get_class_stats(adventurer_class: AdventurerClass) -> Stats {
-        match adventurer_class {
-            AdventurerClass::None(()) => {
-                Stats {
-                    strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 0
-                }
-            },
-            AdventurerClass::Cleric(()) => {
-                Stats {
-                    strength: ClassStatBoosts::Cleric::STRENGTH,
-                    dexterity: ClassStatBoosts::Cleric::DEXTERITY,
-                    vitality: ClassStatBoosts::Cleric::VITALITY,
-                    intelligence: ClassStatBoosts::Cleric::INTELLIGENCE,
-                    wisdom: ClassStatBoosts::Cleric::WISDOM,
-                    charisma: ClassStatBoosts::Cleric::VITALITY
-                }
-            },
-            AdventurerClass::Scout(()) => {
-                Stats {
-                    strength: ClassStatBoosts::Scout::STRENGTH,
-                    dexterity: ClassStatBoosts::Scout::DEXTERITY,
-                    vitality: ClassStatBoosts::Scout::VITALITY,
-                    intelligence: ClassStatBoosts::Scout::INTELLIGENCE,
-                    wisdom: ClassStatBoosts::Scout::WISDOM,
-                    charisma: ClassStatBoosts::Scout::VITALITY
-                }
-            },
-            AdventurerClass::Hunter(()) => {
-                Stats {
-                    strength: ClassStatBoosts::Hunter::STRENGTH,
-                    dexterity: ClassStatBoosts::Hunter::DEXTERITY,
-                    vitality: ClassStatBoosts::Hunter::VITALITY,
-                    intelligence: ClassStatBoosts::Hunter::INTELLIGENCE,
-                    wisdom: ClassStatBoosts::Hunter::WISDOM,
-                    charisma: ClassStatBoosts::Hunter::VITALITY
-                }
-            },
-            AdventurerClass::Warrior(()) => {
-                Stats {
-                    strength: ClassStatBoosts::Warrior::STRENGTH,
-                    dexterity: ClassStatBoosts::Warrior::DEXTERITY,
-                    vitality: ClassStatBoosts::Warrior::VITALITY,
-                    intelligence: ClassStatBoosts::Warrior::INTELLIGENCE,
-                    wisdom: ClassStatBoosts::Warrior::WISDOM,
-                    charisma: ClassStatBoosts::Warrior::VITALITY
-                }
-            },
-        }
     }
 
     // TODO: Need to refactor this and add_suffix_boost to ensure they

--- a/contracts/adventurer/src/item_meta.cairo
+++ b/contracts/adventurer/src/item_meta.cairo
@@ -6,7 +6,7 @@ use pack::pack::{Packing, rshift_split};
 use pack::constants::pow;
 use lootitems::statistics::constants::{ItemId, ItemSuffix};
 
-use super::{adventurer::{Adventurer, IAdventurer, ImplAdventurer}, item_primitive::ItemPrimitive, adventurer_meta::AdventurerClass};
+use super::{adventurer::{Adventurer, IAdventurer, ImplAdventurer}, item_primitive::ItemPrimitive};
 use super::bag::{Bag, IBag};
 
 mod STORAGE {
@@ -456,7 +456,7 @@ fn test_item_meta_packing() {
 #[available_gas(3000000)]
 fn test_set_metadata_id() {
     // start test with a new adventurer wielding a wand
-    let mut adventurer = ImplAdventurer::new(12, AdventurerClass::None(()), 1);
+    let mut adventurer = ImplAdventurer::new(12,1,1,1,1,1,1,1);
 
     // assert adventurer starter weapon has meta data id 1
     assert(adventurer.weapon.metadata == 1, 'advntr wpn meta data shld be 1');
@@ -477,7 +477,7 @@ fn test_set_metadata_id() {
             }, item_5: ItemPrimitive {
             id: 0, xp: 0, metadata: 0, 
             }, item_6: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0,
+            id: 0, xp: 0, metadata: 0, 
             }, item_7: ItemPrimitive {
             id: 0, xp: 0, metadata: 0, 
             }, item_8: ItemPrimitive {

--- a/contracts/beasts/src/beast.cairo
+++ b/contracts/beasts/src/beast.cairo
@@ -56,7 +56,7 @@ impl ImplBeast of IBeast {
                 combat_spec: CombatSpec {
                     tier: ImplBeast::get_tier(beast_id),
                     item_type: ImplBeast::get_type(beast_id),
-                    level: U8IntoU16::into(ImplBeast::get_level(adventurer_level, seed)),
+                    level: ImplBeast::get_level(adventurer_level, seed),
                     specials: special_names
                 }
             }
@@ -157,13 +157,7 @@ impl ImplBeast of IBeast {
     fn get_starting_health(adventurer_level: u8, entropy: u128, ) -> u16 {
         // Delete this function to combat system but pass in difficulty parameters
         // which control when and how quickly beasts health increases
-        let beast_health = ImplCombat::get_enemy_starting_health(
-            adventurer_level,
-            MINIMUM_HEALTH,
-            CombatSettings::DIFFICULTY_INCREASE_RATE::NORMAL,
-            CombatSettings::HEALTH_MULTIPLIER::NORMAL,
-            entropy
-        );
+        let beast_health = ImplCombat::get_enemy_starting_health(adventurer_level, entropy);
 
         // if the beast health provdied by combat library
         // is higher than the max allowed for a beast
@@ -192,17 +186,12 @@ impl ImplBeast of IBeast {
             }
         }
     }
-    fn get_level(adventurer_level: u8, seed: u128) -> u8 {
+    fn get_level(adventurer_level: u8, seed: u128) -> u16 {
         // Delegate level generation to combat system but pass in difficulty parameters
         // which control when and how quickly beasts level increases
         // For the purposes of beasts, we pass in a seed instead of entropy which will
         // result in deterministic beasts
-        ImplCombat::get_random_level(
-            adventurer_level,
-            seed,
-            CombatSettings::DIFFICULTY_INCREASE_RATE::NORMAL,
-            CombatSettings::LEVEL_MULTIPLIER::NORMAL,
-        )
+        ImplCombat::get_random_level(adventurer_level, seed)
     }
 
     // attack is used to calculate the damage dealt to a beast
@@ -705,16 +694,8 @@ fn test_get_level() {
 
     // beast level and adventurer level will be same up to the difficulty cliff
     let entity_level = ImplBeast::get_level(adventurer_level, 0);
-    assert(entity_level == adventurer_level, 'lvl should eql advr lvl');
+    assert(entity_level == adventurer_level.into(), 'lvl should eql advr lvl');
 
-    // test at just before the difficult level cliff
-    adventurer_level = CombatSettings::DIFFICULTY_INCREASE_RATE::NORMAL - 1;
-    let entity_level = ImplBeast::get_level(adventurer_level, 0);
-    // entity level should still be the same as adventurer level
-    assert(entity_level == adventurer_level, 'lvl should eql advr lvl');
-
-    // As we exceed difficult cliff, beast level will start to range
-    // based on entropy
     adventurer_level = CombatSettings::DIFFICULTY_INCREASE_RATE::NORMAL + 1;
     let entity_level = ImplBeast::get_level(adventurer_level, 0);
     assert(entity_level == 3, 'beast lvl should be 3');

--- a/contracts/game/src/game/constants.cairo
+++ b/contracts/game/src/game/constants.cairo
@@ -19,10 +19,13 @@ mod messages {
     const TOO_MANY_ITEMS: felt252 = 'Too many items';
     const ITEM_ALREADY_OWNED: felt252 = 'Item already owned';
     const ADVENTURER_DOESNT_OWN_ITEM: felt252 = 'Adventurer doesnt own item';
+    const ZERO_DEXTERITY: felt252 = 'Cant flee, no dexterity';
+    const WRONG_STARTING_STATS: felt252 = 'Wrong starting stat count';
 }
 
 const BLOCKS_IN_A_WEEK: u64 = 3360;
 const COST_TO_PLAY: u256 = 25;
+const STARTING_STATS: u8 = 6;
 
 const U64_MAX: u64 = 18446744073709551615;
 const U128_MAX: u128 = 340282366920938463463374607431768211455;

--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -14,7 +14,13 @@ trait IGame<TContractState> {
         ref self: TContractState,
         interface_id: ContractAddress,
         starting_weapon: u8,
-        adventurer_meta: AdventurerMetadata
+        adventurer_meta: AdventurerMetadata,
+        starting_strength: u8,
+        starting_dexterity: u8,
+        starting_vitality: u8,
+        starting_intelligence: u8,
+        starting_wisdom: u8,
+        starting_charsima: u8
     );
     fn explore(ref self: TContractState, adventurer_id: u256);
     fn attack(ref self: TContractState, adventurer_id: u256);

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -23,7 +23,7 @@ mod tests {
     };
     use combat::constants::CombatEnums::{Slot, Tier};
     use survivor::{
-        adventurer_meta::{AdventurerMetadata, AdventurerClass},
+        adventurer_meta::{AdventurerMetadata},
         constants::adventurer_constants::{
             STARTING_GOLD, POTION_HEALTH_AMOUNT, POTION_PRICE, STARTING_HEALTH, ClassStatBoosts
         },
@@ -66,13 +66,10 @@ mod tests {
         let mut game = setup();
 
         let adventurer_meta = AdventurerMetadata {
-            name: 'Loaf'.try_into().unwrap(),
-            home_realm: 1,
-            class: AdventurerClass::Scout(()),
-            entropy: 1
+            name: 'Loaf'.try_into().unwrap(), home_realm: 1, class: 1, entropy: 1
         };
 
-        game.start(INTERFACE_ID(), ItemId::Wand, adventurer_meta);
+        game.start(INTERFACE_ID(), ItemId::Wand, adventurer_meta, 0, 2, 0, 2, 2, 0);
 
         let original_adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(original_adventurer.xp == 0, 'wrong starting xp');
@@ -97,11 +94,14 @@ mod tests {
                 INTERFACE_ID(),
                 ItemId::Wand,
                 AdventurerMetadata {
-                    name: 'loothero'.try_into().unwrap(),
-                    home_realm: 1,
-                    class: AdventurerClass::Cleric(()),
-                    entropy: 1
-                }
+                    name: 'loothero'.try_into().unwrap(), home_realm: 1, class: 1, entropy: 1
+                },
+                0,
+                1,
+                0,
+                1,
+                1,
+                3,
             );
 
         game
@@ -121,60 +121,6 @@ mod tests {
         assert(adventurer.stat_points_available == 1, 'should have 1 stat available');
 
         // return game
-        game
-    }
-
-    fn new_adventurer_scout() -> IGameDispatcher {
-        let mut game = setup();
-
-        game
-            .start(
-                INTERFACE_ID(),
-                ItemId::Wand,
-                AdventurerMetadata {
-                    name: 'spag'.try_into().unwrap(),
-                    home_realm: 1,
-                    class: AdventurerClass::Scout(()),
-                    entropy: 1
-                }
-            );
-
-        game
-    }
-
-    fn new_adventurer_hunter() -> IGameDispatcher {
-        let mut game = setup();
-
-        game
-            .start(
-                INTERFACE_ID(),
-                ItemId::Wand,
-                AdventurerMetadata {
-                    name: 'dev'.try_into().unwrap(),
-                    home_realm: 1,
-                    class: AdventurerClass::Hunter(()),
-                    entropy: 1
-                }
-            );
-
-        game
-    }
-
-    fn new_adventurer_warrior() -> IGameDispatcher {
-        let mut game = setup();
-
-        game
-            .start(
-                INTERFACE_ID(),
-                ItemId::Wand,
-                AdventurerMetadata {
-                    name: 'ethereum'.try_into().unwrap(),
-                    home_realm: 1,
-                    class: AdventurerClass::Warrior(()),
-                    entropy: 1
-                }
-            );
-
         game
     }
 
@@ -426,38 +372,9 @@ mod tests {
         // check meta
         assert(adventurer_meta_1.name == 'Loaf', 'name');
         assert(adventurer_meta_1.home_realm == 1, 'home_realm');
-        assert(adventurer_meta_1.class == AdventurerClass::Scout(()), 'class');
+        assert(adventurer_meta_1.class == 1, 'class');
 
         adventurer_meta_1.entropy;
-    }
-
-    #[test]
-    #[available_gas(3000000000000)]
-    fn test_start_cleric() {
-        let mut game = new_adventurer_cleric();
-
-        let adventurer = game.get_adventurer(ADVENTURER_ID);
-        let adventurer_meta = game.get_adventurer_meta(ADVENTURER_ID);
-
-        // check adventurer
-        assert(
-            adventurer.stats.strength == ClassStatBoosts::Cleric::STRENGTH, 'wrong cleric strength'
-        );
-        assert(
-            adventurer.stats.dexterity == ClassStatBoosts::Cleric::DEXTERITY,
-            'wrong cleric dexterity'
-        );
-        assert(
-            adventurer.stats.vitality == ClassStatBoosts::Cleric::VITALITY, 'wrong cleric vitality'
-        );
-        assert(
-            adventurer.stats.intelligence == ClassStatBoosts::Cleric::INTELLIGENCE,
-            'wrong cleric intelligence'
-        );
-        assert(adventurer.stats.wisdom == ClassStatBoosts::Cleric::WISDOM, 'wrong cleric wisdom');
-        assert(
-            adventurer.stats.charisma == ClassStatBoosts::Cleric::CHARISMA, 'wrong cleric charisma'
-        );
     }
 
     #[test]
@@ -573,11 +490,11 @@ mod tests {
 
         // explore till we find a beast
         // TODO: use cheat codes to make this less fragile
-        testing::set_block_number(1004);
+        testing::set_block_number(1006);
         game.explore(ADVENTURER_ID);
         // use stat upgrade
         game.upgrade_stat(ADVENTURER_ID, 1, 1);
-        testing::set_block_number(1005);
+        testing::set_block_number(1007);
         game.explore(ADVENTURER_ID);
 
         let updated_adventurer = game.get_adventurer(ADVENTURER_ID);

--- a/contracts/obstacles/src/obstacle.cairo
+++ b/contracts/obstacles/src/obstacle.cairo
@@ -44,13 +44,13 @@ impl ImplObstacle of IObstacle {
     }
     // get_obstacle returns an obstacle based on the provided obstacle id and level
     // @param id: u8 - the obstacle id
-    // @param level: u8 - the obstacle level
+    // @param level: u16 - the obstacle level
     // @return Obstacle - the obstacle
-    fn get_obstacle(id: u8, level: u8) -> Obstacle {
+    fn get_obstacle(id: u8, _level: u16) -> Obstacle {
         let combat_specs = CombatSpec {
             tier: ImplObstacle::get_tier(id),
             item_type: ImplObstacle::get_type(id),
-            level: U8IntoU16::into(level),
+            level: _level,
             specials: SpecialPowers {
                 special1: 0, special2: 0, special3: 0, 
             }
@@ -63,13 +63,8 @@ impl ImplObstacle of IObstacle {
     // @param adventurer_level: the level of adventurer ()
     // @param entropy: entropy for random level generation
     // @return u8 - the obstacle level
-    fn get_random_level(adventurer_level: u8, entropy: u128) -> u8 {
-        ImplCombat::get_random_level(
-            adventurer_level,
-            entropy,
-            CombatSettings::DIFFICULTY_INCREASE_RATE::NORMAL,
-            CombatSettings::LEVEL_MULTIPLIER::NORMAL,
-        )
+    fn get_random_level(adventurer_level: u8, entropy: u128) -> u16 {
+        ImplCombat::get_random_level(adventurer_level, entropy)
     }
 
     // get_tier returns the tier of the obstacle based on the provided obstacle id


### PR DESCRIPTION
This is a relatively significant change to the game that involves three primary changes:

1. Contract now accepts any combination of 6 starting stats
2. The calculation used to determine if adventurer was able to flee and avoid ambush/obstacles was altered from `(1+relevant_stat) / level` to `relevant_stat/level`. The result is that if the adventurer has no dexterity, they have a 0% chance of fleeing. The contract will not allow adventurers to call flee with 0 dex to prevent this mistake - better for them to battle to the death
3. Simplified beast and obstacle scaling. 
-- The maximum Beast and Obstacle level is now 1 - `2 * adventurer_level`. At level 20 we add 10, making the minimum 11, and maximum 50. At level 30 we add 20, making the minimum 21 and the max 80. At level 40 we add 40 and finally at level 50 we add 80.
-- We use a similar approach for beast health scaling

From a game balance, these changes are intended to accomplish:
1. Remove concerns around OP starting classes. Frontends can now create any classes they want
2. Not using any of your stats for DEX, INTEL, WISDOM will be immediately consequential. If you discover a beast with no DEX, you will not be able to flee
3. Make the beast and obstacle leveling more continuous and intuitive. Furthermore, the goal is to have beasts/obstacles do smaller amounts of damage more frequently instead of large amounts of damage less frequently
