### PR TITLE
Significant changes to adventurer upgrade handling

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -292,13 +292,6 @@ impl ImplAdventurer of IAdventurer {
         }
     }
 
-    // @notice Checks if the adventurer has at least a specified amount of gold.
-    // @param value The amount of gold to check for.
-    // @return True if the adventurer has at least `value` amount of gold, false otherwise.
-    fn check_gold(self: Adventurer, value: u16) -> bool {
-        self.gold >= value
-    }
-
     // get_item_at_slot returns the item at a given item slot
     // @param self: Adventurer to check
     // @param slot: Slot to check

--- a/contracts/game/src/game/constants.cairo
+++ b/contracts/game/src/game/constants.cairo
@@ -21,6 +21,7 @@ mod messages {
     const ADVENTURER_DOESNT_OWN_ITEM: felt252 = 'Adventurer doesnt own item';
     const ZERO_DEXTERITY: felt252 = 'Cant flee, no dexterity';
     const WRONG_STARTING_STATS: felt252 = 'Wrong starting stat count';
+    const MUST_USE_ALL_STATS: felt252 = 'Must use all stats';
 }
 
 const BLOCKS_IN_A_WEEK: u64 = 3360;

--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -27,14 +27,11 @@ trait IGame<TContractState> {
     fn attack_till_death(ref self: TContractState, adventurer_id: u256);
     fn flee(ref self: TContractState, adventurer_id: u256);
     fn equip(ref self: TContractState, adventurer_id: u256, items: Array<u8>);
-    fn drop(ref self: TContractState, adventurer_id: u256, items: Array<u8>);
+    fn drop_items(ref self: TContractState, adventurer_id: u256, items: Array<u8>);
     fn buy_items(ref self: TContractState, adventurer_id: u256, items: Array<ItemPurchase>);
-    fn buy_item(ref self: TContractState, adventurer_id: u256, item_id: u8, equip: bool);
-    fn buy_potion(ref self: TContractState, adventurer_id: u256);
     fn buy_potions(ref self: TContractState, adventurer_id: u256, amount: u8);
-    fn upgrade_stat(ref self: TContractState, adventurer_id: u256, stat: u8, amount: u8);
     fn upgrade_stats(ref self: TContractState, adventurer_id: u256, stats: Array<u8>);
-    fn buy_items_and_upgrade_stats(
+    fn upgrade_adventurer(
         ref self: TContractState,
         adventurer_id: u256,
         potion_quantity: u8,

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -80,7 +80,7 @@ mod Game {
     #[derive(Drop, starknet::Event)]
     enum Event {
         StartGame: StartGame,
-        StatUpgradesAvailable: StatUpgradesAvailable,
+        UpgradeAvailable: UpgradeAvailable,
         StrengthIncreased: StrengthIncreased,
         DexterityIncreased: DexterityIncreased,
         VitalityIncreased: VitalityIncreased,
@@ -1977,7 +1977,7 @@ mod Game {
                 adventurer.add_stat_upgrade_points(MAX_GREATNESS_STAT_BONUS);
 
                 // emit stat upgrades available event
-                __event_StatUpgradesAvailable(
+                __event_UpgradeAvailable(
                     ref self,
                     AdventurerState {
                         owner: get_caller_address(),
@@ -2027,7 +2027,7 @@ mod Game {
                 adventurer.add_stat_upgrade_points(MAX_GREATNESS_STAT_BONUS);
 
                 // emit stat upgrades available event
-                __event_StatUpgradesAvailable(
+                __event_UpgradeAvailable(
                     ref self,
                     AdventurerState {
                         owner: get_caller_address(),
@@ -2883,7 +2883,7 @@ mod Game {
         stat_id: u8,
         amount: u8
     ) {
-        // assert adventurer has stat StatUpgradesAvailable available
+        // assert adventurer has stat UpgradeAvailable available
         _assert_has_required_stat_points(@self, adventurer, amount);
 
         //deduct upgrades from adventurer available stat points
@@ -3036,7 +3036,7 @@ mod Game {
         );
 
         // emit stat upgrades available event
-        __event_StatUpgradesAvailable(
+        __event_UpgradeAvailable(
             ref self,
             adventurer_state: AdventurerState {
                 owner: get_caller_address(), adventurer_id, adventurer
@@ -3711,7 +3711,7 @@ mod Game {
     }
 
     #[derive(Drop, starknet::Event)]
-    struct StatUpgradesAvailable {
+    struct UpgradeAvailable {
         adventurer_state: AdventurerState, 
     }
 
@@ -4008,7 +4008,7 @@ mod Game {
             );
     }
 
-    fn __event_StatUpgradesAvailable(ref self: ContractState, adventurer_state: AdventurerState) {
-        self.emit(Event::StatUpgradesAvailable(StatUpgradesAvailable { adventurer_state }));
+    fn __event_UpgradeAvailable(ref self: ContractState, adventurer_state: AdventurerState) {
+        self.emit(Event::UpgradeAvailable(UpgradeAvailable { adventurer_state }));
     }
 }

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -110,6 +110,7 @@ mod Game {
         AdventurerLeveledUp: AdventurerLeveledUp,
         NewItemsAvailable: NewItemsAvailable,
         IdleDamagePenalty: IdleDamagePenalty,
+        AdventurerUpgraded: AdventurerUpgraded
     }
 
     #[constructor]
@@ -497,7 +498,7 @@ mod Game {
         // @param adventurer_id The ID of the adventurer dropping the items.
         // @param items A Array of item IDs to be dropped. The length of this Array must be less than or equal to the maximum item capacity.
         // @notice This function does not handle adding dropped items to any form of external inventory or the ground. This must be handled separately. It does however emit an event for each dropped item.
-        fn drop(ref self: ContractState, adventurer_id: u256, items: Array<u8>) {
+        fn drop_items(ref self: ContractState, adventurer_id: u256, items: Array<u8>) {
             // assert caller owns adventurer
             _assert_ownership(@self, adventurer_id);
 
@@ -565,20 +566,24 @@ mod Game {
             let mut adventurer = _unpack_adventurer_apply_stat_boost(
                 @self, adventurer_id, name_storage1, name_storage2
             );
+            let original_adventurer = adventurer.clone();
+
             // unpack Loot bag from storage
             let mut bag = _bag_unpacked(@self, adventurer_id);
 
             // assert adventurer is not dead
-            _assert_not_dead(@self, adventurer);
+            _assert_not_dead(@self, original_adventurer);
 
             // assert adventurer is not in battle
-            _assert_not_in_battle(@self, adventurer);
+            _assert_not_in_battle(@self, original_adventurer);
 
             // assert market is open
-            _assert_market_is_open(@self, adventurer);
+            _assert_market_is_open(@self, original_adventurer);
 
             // buy the provided items
-            let bag_mutated = _buy_items(ref self, ref adventurer, ref bag, adventurer_id, items);
+            let bag_mutated = _buy_items(
+                ref self, ref adventurer, original_adventurer, ref bag, adventurer_id, items
+            );
 
             // if the purchases mutated the adventurer's bag
             if (bag_mutated) {
@@ -593,130 +598,6 @@ mod Game {
                 ref adventurer,
                 original_name_storage1,
                 original_name_storage2
-            );
-        }
-
-        // @notice This function allows an adventurer to purchase a single item from the market.
-        // @dev This function assumes that the adventurer is alive, not in battle, and that the market is open.
-        // @param adventurer_id The unique identifier of the adventurer.
-        // @param item_id The identifier of the item to be purchased.
-        // @param equip Boolean representing whether the item is to be equipped or not.
-        fn buy_item(ref self: ContractState, adventurer_id: u256, item_id: u8, equip: bool) {
-            // assert caller owns adventurer
-            _assert_ownership(@self, adventurer_id);
-
-            // get item names from storage
-            let mut name_storage1 = _loot_special_names_storage_unpacked(
-                @self, adventurer_id, LOOT_NAME_STORAGE_INDEX_1
-            );
-            let mut name_storage2 = _loot_special_names_storage_unpacked(
-                @self, adventurer_id, LOOT_NAME_STORAGE_INDEX_2
-            );
-
-            // store the unmodified storages so we can use these
-            // to remove the same stat boosts when we pack and save the adventurer
-            let orginal_name_storage1 = name_storage1;
-            let orginal_name_storage2 = name_storage2;
-
-            // unpack adventurer from storage
-            let mut adventurer = _unpack_adventurer_apply_stat_boost(
-                @self, adventurer_id, name_storage1, name_storage2
-            );
-            // unpack Loot bag from storage
-            let mut bag = _bag_unpacked(@self, adventurer_id);
-
-            // assert adventurer is not dead
-            _assert_not_dead(@self, adventurer);
-
-            // assert adventurer is not in battle
-            _assert_not_in_battle(@self, adventurer);
-
-            // assert market is open
-            _assert_market_is_open(@self, adventurer);
-
-            // get adventurer entropy
-            let adventurer_entropy: u128 = _adventurer_meta_unpacked(@self, adventurer_id)
-                .entropy
-                .into();
-
-            // check item is available on market
-            _assert_item_is_available(
-                @self, adventurer, adventurer_id, adventurer_entropy, item_id
-            );
-
-            // buy item
-            let bag_mutated = _buy_item(
-                ref self, ref adventurer, ref bag, adventurer_id, adventurer_entropy, item_id, equip
-            );
-
-            // if buying item mutated bag
-            if (bag_mutated) {
-                // pack and save updated bag
-                _pack_bag(ref self, adventurer_id, bag);
-            }
-
-            // remove stat boosts, pack, and save adventurer
-            _pack_adventurer_remove_stat_boost(
-                ref self,
-                adventurer_id,
-                ref adventurer,
-                orginal_name_storage1,
-                orginal_name_storage2
-            );
-        }
-
-        // @notice This function allows an adventurer to purchase a health potion.
-        // @dev This function assumes that the adventurer is alive, not in battle, and that the market is open.
-        // @param adventurer_id The unique identifier of the adventurer.
-        fn buy_potion(ref self: ContractState, adventurer_id: u256) {
-            // assert caller owns adventurer
-            _assert_ownership(@self, adventurer_id);
-
-            // get item names from storage
-            let mut name_storage1 = _loot_special_names_storage_unpacked(
-                @self, adventurer_id, LOOT_NAME_STORAGE_INDEX_1
-            );
-            let mut name_storage2 = _loot_special_names_storage_unpacked(
-                @self, adventurer_id, LOOT_NAME_STORAGE_INDEX_2
-            );
-
-            let orginal_name_storage1 = name_storage1;
-            let orginal_name_storage2 = name_storage2;
-
-            // unpack adventurer from storage (stat boosts applied on unpacking)
-            let mut adventurer = _unpack_adventurer_apply_stat_boost(
-                @self, adventurer_id, name_storage1, name_storage2
-            );
-
-            // assert adventurer is not dead
-            _assert_not_dead(@self, adventurer);
-
-            // assert adventurer is not in a battle
-            _assert_not_in_battle(@self, adventurer);
-
-            // assert market is open
-            _assert_market_is_open(@self, adventurer);
-
-            // purchase health
-            _buy_potion(ref self, adventurer_id, ref adventurer);
-
-            // emit purchase potion event
-            __event_PurchasedPotion(
-                ref self,
-                AdventurerState {
-                    owner: get_caller_address(), adventurer_id, adventurer: adventurer
-                },
-                1,
-                POTION_HEALTH_AMOUNT
-            );
-
-            // pack and save adventurer
-            _pack_adventurer_remove_stat_boost(
-                ref self,
-                adventurer_id,
-                ref adventurer,
-                orginal_name_storage1,
-                orginal_name_storage2
             );
         }
 
@@ -754,7 +635,20 @@ mod Game {
             _assert_market_is_open(@self, adventurer);
 
             // buy potions
-            _buy_potions(ref self, ref adventurer, adventurer_id, amount);
+            let (cost, health_increase) = _buy_potions(
+                ref self, ref adventurer, adventurer_id, amount
+            );
+
+            // emit purchase potion event
+            __event_PurchasedPotion(
+                ref self,
+                AdventurerState {
+                    owner: get_caller_address(), adventurer_id, adventurer: adventurer
+                },
+                amount,
+                cost,
+                health_increase,
+            );
 
             // pack and save adventurer
             _pack_adventurer_remove_stat_boost(
@@ -766,62 +660,7 @@ mod Game {
             );
         }
 
-        // @notice This function allows an adventurer to upgrade their stats.
-        // @dev This function assumes that the adventurer is alive and has enough stat points available.
-        // @param adventurer_id The unique identifier of the adventurer.
-        // @param stat The stat to be upgraded.
-        // @param amount The amount to upgrade the stat by.
-        fn upgrade_stat(ref self: ContractState, adventurer_id: u256, stat: u8, amount: u8) {
-            // assert caller owns adventurer
-            _assert_ownership(@self, adventurer_id);
-
-            // get item names from storage
-            let mut name_storage1 = _loot_special_names_storage_unpacked(
-                @self, adventurer_id, LOOT_NAME_STORAGE_INDEX_1
-            );
-            let mut name_storage2 = _loot_special_names_storage_unpacked(
-                @self, adventurer_id, LOOT_NAME_STORAGE_INDEX_2
-            );
-
-            // maintain copy of originals so we can remove same stats
-            // when we pack and save the adventurer
-            let original_name_storage1 = name_storage1;
-            let original_name_storage2 = name_storage2;
-
-            // unpack adventurer from storage (stat boosts applied on unpacking)
-            let mut adventurer = _unpack_adventurer_apply_stat_boost(
-                @self, adventurer_id, name_storage1, name_storage2
-            );
-
-            // assert adventurer is not dead
-            _assert_not_dead(@self, adventurer);
-
-            // upgrade adventurer's stat
-            _upgrade_stat(ref self, adventurer_id, ref adventurer, stat, amount);
-
-            // if adventurer has more stats available
-            if (adventurer.stat_points_available > 0) {
-                // emit new market items
-                __event_NewItemsAvailable(
-                    ref self,
-                    adventurer_state: AdventurerState {
-                        owner: get_caller_address(), adventurer_id, adventurer
-                    },
-                    items: _get_items_on_market(@self, adventurer_id, adventurer)
-                );
-            }
-
-            // remove stat boosts, pack, and save adventurer
-            _pack_adventurer_remove_stat_boost(
-                ref self,
-                adventurer_id,
-                ref adventurer,
-                original_name_storage1,
-                original_name_storage2
-            );
-        }
-
-        fn buy_items_and_upgrade_stats(
+        fn upgrade_adventurer(
             ref self: ContractState,
             adventurer_id: u256,
             potion_quantity: u8,
@@ -846,27 +685,35 @@ mod Game {
             let mut adventurer = _unpack_adventurer_apply_stat_boost(
                 @self, adventurer_id, name_storage1, name_storage2
             );
+            let original_adventurer = adventurer.clone();
 
-            // unpack Loot bag from storage
-            let mut bag = _bag_unpacked(@self, adventurer_id);
+            // assert all available stats are being used
+            _assert_using_all_stats(@self, original_adventurer, stats.len());
 
             // assert adventurer is not dead
-            _assert_not_dead(@self, adventurer);
+            _assert_not_dead(@self, original_adventurer);
 
             // assert adventurer is not in battle
-            _assert_not_in_battle(@self, adventurer);
+            _assert_not_in_battle(@self, original_adventurer);
 
             // assert market is open
-            _assert_market_is_open(@self, adventurer);
+            _assert_market_is_open(@self, original_adventurer);
 
             // upgrade stats
             _upgrade_stats(ref self, ref adventurer, adventurer_id, stats);
 
             // buy potions
-            _buy_potions(ref self, ref adventurer, adventurer_id, potion_quantity);
+            let (potion_cost, health_from_potions) = _buy_potions(
+                ref self, ref adventurer, adventurer_id, potion_quantity
+            );
 
-            // buy items
-            let bag_mutated = _buy_items(ref self, ref adventurer, ref bag, adventurer_id, items);
+            // unpack Loot bag from storage
+            let mut bag = _bag_unpacked(@self, adventurer_id);
+
+            // buy items, pass it items clone so we retain ownership for using it in the event
+            let bag_mutated = _buy_items(
+                ref self, ref adventurer, original_adventurer, ref bag, adventurer_id, items.clone()
+            );
 
             // if the purchases mutated the adventurer's bag
             if (bag_mutated) {
@@ -881,6 +728,33 @@ mod Game {
                 ref adventurer,
                 original_name_storage1,
                 original_name_storage2
+            );
+
+            // emit adventurer upgraded event
+            __event_AdventurerUpgraded(
+                ref self,
+                AdventurerUpgraded {
+                    adventurer_state_with_bag: AdventurerStateWithBag {
+                        adventurer_state: AdventurerState {
+                            owner: get_caller_address(), adventurer_id, adventurer
+                        }, bag: bag
+                    },
+                    strength_increase: adventurer.stats.strength
+                        - original_adventurer.stats.strength,
+                    dexterity_increase: adventurer.stats.dexterity
+                        - original_adventurer.stats.dexterity,
+                    vitality_increase: adventurer.stats.vitality
+                        - original_adventurer.stats.vitality,
+                    intelligence_increase: adventurer.stats.intelligence
+                        - original_adventurer.stats.intelligence,
+                    wisdom_increase: adventurer.stats.wisdom - original_adventurer.stats.wisdom,
+                    charisma_increase: adventurer.stats.charisma
+                        - original_adventurer.stats.charisma,
+                    potions_purchased: potion_quantity,
+                    cost_of_potions: potion_cost,
+                    health_from_potions: health_from_potions,
+                    items_purchased: items
+                }
             );
         }
 
@@ -2763,29 +2637,6 @@ mod Game {
         );
     }
 
-    // @dev Drops a single item from the adventurer's possessions, either from equipment or bag.
-    // @param self The contract state
-    // @param adventurer The adventurer from which the item will be dropped
-    // @param bag The bag containing the adventurer's items
-    // @param item_id The identifier of the item to be dropped
-    // @return A tuple containing two boolean values. The first indicates if the adventurer was mutated, the second indicates if the bag was mutated
-    fn _drop_item(
-        ref self: ContractState, ref adventurer: Adventurer, ref bag: Bag, item_id: u8
-    ) -> (bool, bool) {
-        // if the adventurer has the item equipped
-        if adventurer.is_equipped(item_id) {
-            // remove it from the adventurer
-            adventurer.drop_item(item_id);
-            // return (true, false) to indicate the adventurer was mutated but not bag
-            (true, false)
-        } else {
-            // otherwise, it's in their bag so remove it from there
-            bag.remove_item(item_id);
-            // return (false, true) to indicate the adventurer was not mutated but the bag was
-            (false, true)
-        }
-    }
-
     // @dev Drops multiple items from the adventurer's possessions, either from equipment or bag.
     // It tracks if the adventurer or the bag was mutated (updated).
     // @param self The contract state
@@ -2812,15 +2663,18 @@ mod Game {
             if i >= items.len() {
                 break ();
             }
-            // assert the adventurer owns the item
-            _assert_adventurer_owns_item(@self, adventurer, bag, *items.at(i));
 
-            // drop it and track whether the adventurer or bag was mutated
-            let (_adventurer_mutated, _bag_mutated) = _drop_item(
-                ref self, ref adventurer, ref bag, *items.at(i)
-            );
-            adventurer_mutated = adventurer_mutated || _adventurer_mutated;
-            bag_mutated = bag_mutated || _bag_mutated;
+            // get and drop item
+            let item_id = *items.at(i);
+            if adventurer.is_equipped(item_id) {
+                adventurer.drop_item(item_id);
+                adventurer_mutated = true;
+            } else if bag.contains(item_id) {
+                bag.remove_item(item_id);
+                bag_mutated = true;
+            } else {
+                panic_with_felt252('Item not owned by adventurer');
+            }
 
             i += 1;
         };
@@ -2838,6 +2692,7 @@ mod Game {
     fn _buy_items(
         ref self: ContractState,
         ref adventurer: Adventurer,
+        original_adventurer: Adventurer,
         ref bag: Bag,
         adventurer_id: u256,
         items: Array<ItemPurchase>
@@ -2862,6 +2717,7 @@ mod Game {
             let inner_bag_mutated = _buy_item(
                 ref self,
                 ref adventurer,
+                original_adventurer,
                 ref bag,
                 adventurer_id,
                 adventurer_entropy,
@@ -2883,29 +2739,30 @@ mod Game {
 
     fn _buy_potions(
         ref self: ContractState, ref adventurer: Adventurer, adventurer_id: u256, amount: u8
-    ) {
-        // buy potions
-        let mut i: u8 = 0;
-        loop {
-            if i >= amount {
-                break ();
-            }
-            _buy_potion(ref self, adventurer_id, ref adventurer);
-            i += 1;
-        };
+    ) -> (u16, u16) {
+        let cost_of_potions = adventurer.charisma_adjusted_potion_price() * amount.into();
+        let health_from_potions = POTION_HEALTH_AMOUNT * amount.into();
 
-        // emit purchase potion event
-        __event_PurchasedPotion(
-            ref self,
-            AdventurerState { owner: get_caller_address(), adventurer_id, adventurer: adventurer },
-            amount,
-            POTION_HEALTH_AMOUNT * amount.into(),
-        );
+        // assert adventurer has enough gold to buy the potions
+        _assert_has_enough_gold(@self, adventurer, cost_of_potions);
+
+        // assert adventurer is not buying more health than they can use
+        _assert_not_buying_excess_health(@self, adventurer, health_from_potions);
+
+        // calculate cost of potion based on the adventurer's level
+        adventurer.deduct_gold(cost_of_potions);
+
+        // add health to adventurer
+        adventurer.increase_health(health_from_potions);
+
+        // return cost of potions and amount of health purchased
+        (cost_of_potions, health_from_potions)
     }
 
     fn _upgrade_stats(
         ref self: ContractState, ref adventurer: Adventurer, adventurer_id: u256, stats: Array<u8>
     ) {
+        internal::revoke_ap_tracking();
         // assert adventurer has the required stat upgrades
         _assert_has_required_stat_points(@self, adventurer, stats.len().try_into().unwrap());
 
@@ -2918,18 +2775,6 @@ mod Game {
             _upgrade_stat(ref self, adventurer_id, ref adventurer, *stats.at(i), 1);
             i += 1;
         };
-
-        // if adventurer still has more stats available
-        if (adventurer.stat_points_available > 0) {
-            // emit new market items
-            __event_NewItemsAvailable(
-                ref self,
-                adventurer_state: AdventurerState {
-                    owner: get_caller_address(), adventurer_id, adventurer
-                },
-                items: _get_items_on_market(@self, adventurer_id, adventurer)
-            );
-        }
     }
 
     // @dev This function allows the adventurer to purchase an item from the market.
@@ -2944,6 +2789,7 @@ mod Game {
     fn _buy_item(
         ref self: ContractState,
         ref adventurer: Adventurer,
+        original_adventurer: Adventurer,
         ref bag: Bag,
         adventurer_id: u256,
         adventurer_entropy: u128,
@@ -2953,6 +2799,11 @@ mod Game {
         // https://github.com/starkware-libs/cairo/issues/2942
         // internal::revoke_ap_tracking();
         // TODO: Remove after testing
+
+        // check item is available on market
+        _assert_item_is_available(
+            @self, original_adventurer, adventurer_id, adventurer_entropy, item_id
+        );
 
         // assert adventurer does not already own the item
         _assert_item_not_owned(@self, adventurer, bag, item_id);
@@ -2964,7 +2815,7 @@ mod Game {
         let charisma_adjusted_price = adventurer.charisma_adjusted_item_price(base_item_price);
 
         // check adventurer has enough gold
-        assert(adventurer.check_gold(charisma_adjusted_price) == true, messages::NOT_ENOUGH_GOLD);
+        assert(adventurer.gold > charisma_adjusted_price, messages::NOT_ENOUGH_GOLD);
 
         // get item from id
         let mut item = ImplItemPrimitive::new_item(item_id);
@@ -3041,79 +2892,18 @@ mod Game {
         // increase relevant stat and emit stat specific event
         if (stat_id == StatisticIndex::STRENGTH) {
             adventurer.increase_strength(amount);
-            __event__StrengthIncreased(
-                ref self,
-                AdventurerState {
-                    owner: get_caller_address(), adventurer_id, adventurer: adventurer
-                },
-                amount
-            );
         } else if (stat_id == StatisticIndex::DEXTERITY) {
             adventurer.increase_dexterity(amount);
-            __event__DexterityIncreased(
-                ref self,
-                AdventurerState {
-                    owner: get_caller_address(), adventurer_id, adventurer: adventurer
-                },
-                amount
-            );
         } else if (stat_id == StatisticIndex::VITALITY) {
             adventurer.increase_vitality(amount);
             adventurer.increase_health(VITALITY_INSTANT_HEALTH_BONUS);
-            __event__VitalityIncreased(
-                ref self,
-                AdventurerState {
-                    owner: get_caller_address(), adventurer_id, adventurer: adventurer
-                },
-                amount
-            );
         } else if (stat_id == StatisticIndex::INTELLIGENCE) {
             adventurer.increase_intelligence(amount);
-            __event__IntelligenceIncreased(
-                ref self,
-                AdventurerState {
-                    owner: get_caller_address(), adventurer_id, adventurer: adventurer
-                },
-                amount
-            );
         } else if (stat_id == StatisticIndex::WISDOM) {
             adventurer.increase_wisdom(amount);
-            __event__WisdomIncreased(
-                ref self,
-                AdventurerState {
-                    owner: get_caller_address(), adventurer_id, adventurer: adventurer
-                },
-                amount
-            );
         } else if (stat_id == StatisticIndex::CHARISMA) {
             adventurer.increase_charisma(amount);
-            __event__CharismaIncreased(
-                ref self,
-                AdventurerState {
-                    owner: get_caller_address(), adventurer_id, adventurer: adventurer
-                },
-                amount
-            );
         }
-    }
-
-    fn _buy_potion(ref self: ContractState, adventurer_id: u256, ref adventurer: Adventurer) {
-        internal::revoke_ap_tracking();
-
-        // check gold balance
-        assert(
-            adventurer.check_gold(adventurer.charisma_adjusted_potion_price()) == true,
-            messages::NOT_ENOUGH_GOLD
-        );
-
-        // verify adventurer isn't already at max health
-        assert(adventurer.get_max_health() != adventurer.health, messages::HEALTH_FULL);
-
-        // calculate cost of potion based on the adventurer's level
-        adventurer.deduct_gold(adventurer.charisma_adjusted_potion_price());
-
-        // add health to adventurer
-        adventurer.increase_health(POTION_HEALTH_AMOUNT);
     }
 
     // _get_live_entropy generates entropy for exploration
@@ -3344,15 +3134,6 @@ mod Game {
             messages::ITEM_ALREADY_OWNED
         );
     }
-    fn _assert_adventurer_owns_item(
-        self: @ContractState, adventurer: Adventurer, bag: Bag, item_id: u8
-    ) {
-        // assert item is equipped or in bag
-        assert(
-            adventurer.is_equipped(item_id) == true || bag.contains(item_id) == true,
-            messages::ADVENTURER_DOESNT_OWN_ITEM
-        );
-    }
     fn _assert_item_is_available(
         self: @ContractState,
         adventurer: Adventurer,
@@ -3391,6 +3172,22 @@ mod Game {
             .get_idle_blocks(starknet::get_block_info().unbox().block_number);
 
         assert(idle_blocks >= IDLE_DEATH_PENALTY_BLOCKS, messages::ADVENTURER_NOT_IDLE);
+    }
+    fn _assert_has_enough_gold(self: @ContractState, adventurer: Adventurer, cost: u16) {
+        assert(adventurer.gold > cost, messages::NOT_ENOUGH_GOLD);
+    }
+    fn _assert_not_buying_excess_health(
+        self: @ContractState, adventurer: Adventurer, purchased_health: u16
+    ) {
+        let adventurer_health_after_potions = adventurer.health + purchased_health;
+        // assert adventurer is not buying more health than needed
+        assert(
+            adventurer_health_after_potions < adventurer.get_max_health() + POTION_HEALTH_AMOUNT,
+            messages::HEALTH_FULL
+        );
+    }
+    fn _assert_using_all_stats(self: @ContractState, adventurer: Adventurer, stat_count: u32) {
+        assert(adventurer.stat_points_available.into() == stat_count, messages::MUST_USE_ALL_STATS);
     }
     fn _idle_longer_than_penalty_threshold(
         self: @ContractState, adventurer: Adventurer
@@ -3870,7 +3667,8 @@ mod Game {
     struct PurchasedPotion {
         adventurer_state: AdventurerState,
         quantity: u8,
-        health_amount: u16,
+        cost: u16,
+        health_gained: u16,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -3915,6 +3713,27 @@ mod Game {
     #[derive(Drop, starknet::Event)]
     struct StatUpgradesAvailable {
         adventurer_state: AdventurerState, 
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct AdventurerUpgraded {
+        adventurer_state_with_bag: AdventurerStateWithBag,
+        strength_increase: u8,
+        dexterity_increase: u8,
+        vitality_increase: u8,
+        intelligence_increase: u8,
+        wisdom_increase: u8,
+        charisma_increase: u8,
+        potions_purchased: u8,
+        cost_of_potions: u16,
+        health_from_potions: u16,
+        items_purchased: Array<ItemPurchase>
+    }
+
+    fn __event_AdventurerUpgraded(
+        ref self: ContractState, adventurer_upgraded_event: AdventurerUpgraded
+    ) {
+        self.emit(Event::AdventurerUpgraded(adventurer_upgraded_event));
     }
 
     fn __event__StartGame(
@@ -4119,12 +3938,16 @@ mod Game {
     }
 
     fn __event_PurchasedPotion(
-        ref self: ContractState, adventurer_state: AdventurerState, quantity: u8, health_amount: u16
+        ref self: ContractState,
+        adventurer_state: AdventurerState,
+        quantity: u8,
+        cost: u16,
+        health_gained: u16
     ) {
         self
             .emit(
                 Event::PurchasedPotion(
-                    PurchasedPotion { adventurer_state, quantity, health_amount }
+                    PurchasedPotion { adventurer_state, quantity, cost, health_gained }
                 )
             );
     }

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -166,8 +166,9 @@ mod tests {
         // start game on lvl 2
         let mut game = new_adventurer_lvl2();
 
-        // upgrade charisma
-        game.upgrade_stat(ADVENTURER_ID, stat, 1);
+        let mut stat_upgrades = ArrayTrait::<u8>::new();
+        stat_upgrades.append(stat);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades);
 
         // go explore
         game.explore(ADVENTURER_ID);
@@ -192,7 +193,9 @@ mod tests {
         let mut game = new_adventurer_lvl3(stat);
 
         // upgrade charisma
-        game.upgrade_stat(ADVENTURER_ID, stat, 1);
+        let mut stat_upgrades = ArrayTrait::<u8>::new();
+        stat_upgrades.append(stat);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades);
 
         // go explore
         game.explore(ADVENTURER_ID);
@@ -211,7 +214,9 @@ mod tests {
         let mut game = new_adventurer_lvl4(stat);
 
         // upgrade charisma
-        game.upgrade_stat(ADVENTURER_ID, stat, 1);
+        let mut stat_upgrades = ArrayTrait::<u8>::new();
+        stat_upgrades.append(stat);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades);
 
         // go explore
         game.explore(ADVENTURER_ID);
@@ -244,15 +249,16 @@ mod tests {
         let purchase_foot_id = *foot_inventory.at(0);
         let purchase_hand_id = *hand_inventory.at(0);
 
-        game.buy_item(ADVENTURER_ID, purchase_weapon_id, true);
-        game.buy_item(ADVENTURER_ID, purchase_chest_id, true);
-        game.buy_item(ADVENTURER_ID, purchase_head_id, true);
-        game.buy_item(ADVENTURER_ID, purchase_waist_id, true);
-        game.buy_item(ADVENTURER_ID, purchase_foot_id, true);
-        game.buy_item(ADVENTURER_ID, purchase_hand_id, true);
+        let mut shopping_cart = ArrayTrait::<ItemPurchase>::new();
+        shopping_cart.append(ItemPurchase { item_id: purchase_weapon_id, equip: true });
+        shopping_cart.append(ItemPurchase { item_id: purchase_chest_id, equip: true });
+        shopping_cart.append(ItemPurchase { item_id: purchase_head_id, equip: true });
+        shopping_cart.append(ItemPurchase { item_id: purchase_waist_id, equip: true });
+        shopping_cart.append(ItemPurchase { item_id: purchase_foot_id, equip: true });
+        shopping_cart.append(ItemPurchase { item_id: purchase_hand_id, equip: true });
+        game.buy_items(ADVENTURER_ID, shopping_cart);
 
         let adventurer = game.get_adventurer(ADVENTURER_ID);
-
         assert(adventurer.weapon.id == purchase_weapon_id, 'new weapon should be equipped');
         assert(adventurer.chest.id == purchase_chest_id, 'new chest should be equipped');
         assert(adventurer.head.id == purchase_head_id, 'new head should be equipped');
@@ -261,8 +267,10 @@ mod tests {
         assert(adventurer.hand.id == purchase_hand_id, 'new hand should be equipped');
         assert(adventurer.gold < STARTING_GOLD, 'items should not be free');
 
-        // upgrade charisma
-        game.upgrade_stat(ADVENTURER_ID, stat, 1);
+        // upgrade stats
+        let mut stat_upgrades = ArrayTrait::<u8>::new();
+        stat_upgrades.append(stat);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades);
 
         // go explore
         game.explore(ADVENTURER_ID);
@@ -277,7 +285,9 @@ mod tests {
     fn new_adventurer_lvl7_equipped(stat: u8) -> IGameDispatcher {
         let mut game = new_adventurer_lvl6_equipped(stat);
         let STRENGTH: u8 = 0;
-        game.upgrade_stat(ADVENTURER_ID, STRENGTH, 1);
+        let mut stat_upgrades = ArrayTrait::<u8>::new();
+        stat_upgrades.append(STRENGTH);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades);
 
         // go explore
         game.explore(ADVENTURER_ID);
@@ -291,7 +301,9 @@ mod tests {
     fn new_adventurer_lvl8_equipped(stat: u8) -> IGameDispatcher {
         let mut game = new_adventurer_lvl7_equipped(stat);
         let STRENGTH: u8 = 0;
-        game.upgrade_stat(ADVENTURER_ID, STRENGTH, 1);
+        let mut stat_upgrades = ArrayTrait::<u8>::new();
+        stat_upgrades.append(STRENGTH);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades);
 
         // go explore
         game.explore(ADVENTURER_ID);
@@ -305,7 +317,9 @@ mod tests {
     fn new_adventurer_lvl9_equipped(stat: u8) -> IGameDispatcher {
         let mut game = new_adventurer_lvl8_equipped(stat);
         let STRENGTH: u8 = 0;
-        game.upgrade_stat(ADVENTURER_ID, STRENGTH, 1);
+        let mut stat_upgrades = ArrayTrait::<u8>::new();
+        stat_upgrades.append(STRENGTH);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades);
 
         // go explore
         game.explore(ADVENTURER_ID);
@@ -319,7 +333,9 @@ mod tests {
     fn new_adventurer_lvl10_equipped(stat: u8) -> IGameDispatcher {
         let mut game = new_adventurer_lvl9_equipped(stat);
         let STRENGTH: u8 = 0;
-        game.upgrade_stat(ADVENTURER_ID, STRENGTH, 1);
+        let mut stat_upgrades = ArrayTrait::<u8>::new();
+        stat_upgrades.append(STRENGTH);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades);
 
         // go explore
         game.explore(ADVENTURER_ID);
@@ -336,7 +352,9 @@ mod tests {
     fn new_adventurer_lvl11_equipped(stat: u8) -> IGameDispatcher {
         let mut game = new_adventurer_lvl10_equipped(stat);
         let STRENGTH: u8 = 0;
-        game.upgrade_stat(ADVENTURER_ID, STRENGTH, 1);
+        let mut stat_upgrades = ArrayTrait::<u8>::new();
+        stat_upgrades.append(STRENGTH);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades);
 
         // go explore
         game.explore(ADVENTURER_ID);
@@ -486,10 +504,13 @@ mod tests {
 
         // explore till we find a beast
         // TODO: use cheat codes to make this less fragile
-        game.upgrade_stat(ADVENTURER_ID, 1, 1);
+        let mut stat_upgrades = ArrayTrait::<u8>::new();
+        stat_upgrades.append(1);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades.clone());
+
         testing::set_block_number(1006);
         game.explore(ADVENTURER_ID);
-        game.upgrade_stat(ADVENTURER_ID, 1, 1);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades);
         testing::set_block_number(1007);
         game.explore(ADVENTURER_ID);
 
@@ -536,9 +557,12 @@ mod tests {
         let item_id = *market_items.at(0).item.id;
         let item_price = *market_items.at(0).price.into();
 
+        let mut shopping_cart = ArrayTrait::<ItemPurchase>::new();
+        shopping_cart.append(ItemPurchase { item_id: item_id, equip: true });
+
         // attempt to buy item during battle - should_panic with message 'Action not allowed in battle'
         // this test is annotated to expect a panic so if it doesn't, this test will fail
-        game.buy_item(ADVENTURER_ID, item_id, true);
+        game.buy_items(ADVENTURER_ID, shopping_cart);
     }
 
     #[test]
@@ -548,17 +572,20 @@ mod tests {
         // mint adventurer and advance to level 2
         let mut game = new_adventurer_lvl2();
 
-        // use the adventurers available stat
-        game.upgrade_stat(ADVENTURER_ID, 1, 1);
+        let mut stat_upgrades = ArrayTrait::<u8>::new();
+        stat_upgrades.append(1);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades);
 
         // get valid item from market
         let market_items = @game.get_items_on_market(ADVENTURER_ID);
         let item_id = *market_items.at(0).item.id;
+        let mut shoppping_cart = ArrayTrait::<ItemPurchase>::new();
+        shoppping_cart.append(ItemPurchase { item_id: item_id, equip: true });
 
         // attempt to buy item butince we have already used our stat upgrade 
         // the market should be closed resulting in a 'Market is closed' panic
         // this test is annotated to expect that specific panic so if it doesn't, this test will fail
-        game.buy_item(ADVENTURER_ID, item_id, true);
+        game.buy_items(ADVENTURER_ID, shoppping_cart);
     }
 
     #[test]
@@ -573,13 +600,15 @@ mod tests {
 
         // get first item on the market
         let item_id = *market_items.at(0).item.id;
+        let mut shopping_cart = ArrayTrait::<ItemPurchase>::new();
+        shopping_cart.append(ItemPurchase { item_id: item_id, equip: true });
 
         // buy first item on market and equip it
-        game.buy_item(ADVENTURER_ID, item_id, true);
+        game.buy_items(ADVENTURER_ID, shopping_cart.clone());
 
         // try to buy the same item again which should result in a panic
         // 'Item already owned' which is annotated in the test
-        game.buy_item(ADVENTURER_ID, item_id, true);
+        game.buy_items(ADVENTURER_ID, shopping_cart);
     }
 
     #[test]
@@ -592,15 +621,14 @@ mod tests {
         // get items from market
         let market_items = @game.get_items_on_market(ADVENTURER_ID);
 
-        // get first item on the market
+        // try to buy same item but equip one and put one in bag
         let item_id = *market_items.at(0).item.id;
+        let mut shopping_cart = ArrayTrait::<ItemPurchase>::new();
+        shopping_cart.append(ItemPurchase { item_id: item_id, equip: false });
+        shopping_cart.append(ItemPurchase { item_id: item_id, equip: true });
 
-        // buy first item on market and put it into bag
-        game.buy_item(ADVENTURER_ID, item_id, false);
-
-        // try to buy the same item again which should result in a panic
-        // 'Item already owned' which is annotated in the test
-        game.buy_item(ADVENTURER_ID, item_id, true);
+        // should throw 'Item already owned' panic
+        game.buy_items(ADVENTURER_ID, shopping_cart);
     }
 
     #[test]
@@ -608,7 +636,9 @@ mod tests {
     #[available_gas(65000000)]
     fn test_buy_item_not_on_market() {
         let mut game = new_adventurer_lvl2();
-        game.buy_item(ADVENTURER_ID, 200, true);
+        let mut shopping_cart = ArrayTrait::<ItemPurchase>::new();
+        shopping_cart.append(ItemPurchase { item_id: 255, equip: false });
+        game.buy_items(ADVENTURER_ID, shopping_cart);
     }
 
     #[test]
@@ -618,8 +648,10 @@ mod tests {
         let market_items = @game.get_items_on_market(ADVENTURER_ID);
         let item_id = *market_items.at(0).item.id;
         let item_price = *market_items.at(0).price.into();
+        let mut shopping_cart = ArrayTrait::<ItemPurchase>::new();
+        shopping_cart.append(ItemPurchase { item_id: item_id, equip: true });
 
-        game.buy_item(ADVENTURER_ID, item_id, true);
+        game.buy_items(ADVENTURER_ID, shopping_cart);
 
         let adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(adventurer.gold == (STARTING_GOLD + 4 - item_price), 'wrong gold amount');
@@ -630,12 +662,12 @@ mod tests {
     fn test_buy_and_bag_item() {
         let mut game = new_adventurer_lvl2();
         let market_items = @game.get_items_on_market(ADVENTURER_ID);
-
-        game.buy_item(ADVENTURER_ID, *market_items.at(0).item.id, false);
-
+        let item_id = *market_items.at(0).item.id;
+        let mut shopping_cart = ArrayTrait::<ItemPurchase>::new();
+        shopping_cart.append(ItemPurchase { item_id: item_id, equip: false });
+        game.buy_items(ADVENTURER_ID, shopping_cart);
         let bag = game.get_bag(ADVENTURER_ID);
-
-        assert(bag.item_1.id == *market_items.at(0).item.id, 'sash in bag');
+        assert(bag.item_1.id == *market_items.at(0).item.id, 'item should be in bag');
     }
 
     #[test]
@@ -802,6 +834,7 @@ mod tests {
         let mut purchased_ring: u8 = 0;
         let mut purchased_necklace: u8 = 0;
         let mut purchased_items = ArrayTrait::<Loot>::new();
+        let mut shopping_cart = ArrayTrait::<ItemPurchase>::new();
 
         let mut i: u32 = 0;
         loop {
@@ -818,46 +851,47 @@ mod tests {
                 && (market_item.tier == Tier::T5(()))
                 && market_item.id != 12) {
                 purchased_items.append(market_item);
-                game.buy_item(ADVENTURER_ID, market_item.id, false);
+                shopping_cart.append(ItemPurchase { item_id: market_item.id, equip: false });
                 purchased_weapon = market_item.id;
             } else if (market_item.slot == Slot::Chest(())
                 && purchased_chest == 0
                 && market_item.tier == Tier::T5(())) {
                 purchased_items.append(market_item);
-                game.buy_item(ADVENTURER_ID, market_item.id, false);
+                shopping_cart.append(ItemPurchase { item_id: market_item.id, equip: false });
                 purchased_chest = market_item.id;
             } else if (market_item.slot == Slot::Head(())
                 && purchased_head == 0
                 && market_item.tier == Tier::T5(())) {
                 purchased_items.append(market_item);
-                game.buy_item(ADVENTURER_ID, market_item.id, false);
+                shopping_cart.append(ItemPurchase { item_id: market_item.id, equip: false });
                 purchased_head = market_item.id;
             } else if (market_item.slot == Slot::Waist(())
                 && purchased_waist == 0
                 && market_item.tier == Tier::T5(())) {
                 purchased_items.append(market_item);
-                game.buy_item(ADVENTURER_ID, market_item.id, false);
+                shopping_cart.append(ItemPurchase { item_id: market_item.id, equip: false });
                 purchased_waist = market_item.id;
             } else if (market_item.slot == Slot::Foot(())
                 && purchased_foot == 0
                 && market_item.tier == Tier::T5(())) {
                 purchased_items.append(market_item);
-                game.buy_item(ADVENTURER_ID, market_item.id, false);
+                shopping_cart.append(ItemPurchase { item_id: market_item.id, equip: false });
                 purchased_foot = market_item.id;
             } else if (market_item.slot == Slot::Hand(())
                 && purchased_hand == 0
                 && market_item.tier == Tier::T5(())) {
                 purchased_items.append(market_item);
-                game.buy_item(ADVENTURER_ID, market_item.id, false);
+                shopping_cart.append(ItemPurchase { item_id: market_item.id, equip: false });
                 purchased_hand = market_item.id;
             } else if (market_item.slot == Slot::Ring(())
                 && purchased_ring == 0
                 && market_item.tier == Tier::T3(())) {
                 purchased_items.append(market_item);
+                shopping_cart.append(ItemPurchase { item_id: market_item.id, equip: false });
                 purchased_ring = market_item.id;
             } else if (market_item.slot == Slot::Neck(()) && purchased_necklace == 0) {
                 purchased_items.append(market_item);
-                game.buy_item(ADVENTURER_ID, market_item.id, false);
+                shopping_cart.append(ItemPurchase { item_id: market_item.id, equip: false });
                 purchased_necklace = market_item.id;
             }
             i += 1;
@@ -865,8 +899,10 @@ mod tests {
 
         let purchased_items_span = purchased_items.span();
 
-        // verify we were able to buy at least 2 items
-        assert(purchased_items_span.len() > 1, 'need more items to equip');
+        // verify we have at least 2 items in our shopping cart
+        assert(shopping_cart.len() >= 2, 'insufficient item purchase');
+        // buy items
+        game.buy_items(ADVENTURER_ID, shopping_cart.clone());
 
         // get bag from storage
         let bag = game.get_bag(ADVENTURER_ID);
@@ -911,38 +947,6 @@ mod tests {
 
     #[test]
     #[available_gas(100000000)]
-    fn test_buy_potion() {
-        let mut game = new_adventurer_lvl2_with_idle_penalty();
-
-        // get updated adventurer state
-        let adventurer = game.get_adventurer(ADVENTURER_ID);
-
-        // get adventurer health and gold before buying potion
-        let adventurer_health_pre_potion = adventurer.health;
-        let adventurer_gold_pre_potion = adventurer.gold;
-
-        // buy potion
-        game.buy_potion(ADVENTURER_ID);
-
-        // get updated adventurer state
-        let adventurer = game.get_adventurer(ADVENTURER_ID);
-
-        // verify potion increased health by POTION_HEALTH_AMOUNT or adventurer health is full
-        assert(
-            adventurer.health == adventurer_health_pre_potion + POTION_HEALTH_AMOUNT,
-            'potion did not give health'
-        );
-
-        // verify potion cost reduced adventurers gold balance by POTION_PRICE * adventurer level (no charisma discount here)
-        assert(
-            adventurer.gold == adventurer_gold_pre_potion
-                - (POTION_PRICE * adventurer.get_level().into()),
-            'potion cost is wrong'
-        );
-    }
-
-    #[test]
-    #[available_gas(100000000)]
     fn test_buy_potions() {
         let mut game = new_adventurer_lvl2_with_idle_penalty();
 
@@ -976,33 +980,6 @@ mod tests {
 
     #[test]
     #[should_panic(expected: ('Health already full', 'ENTRYPOINT_FAILED'))]
-    // we don't care about gas for this test so setting it high so this test
-    // is more resilient to changes in game settings like starting health, potion health amount, etc
-    #[available_gas(100000000)]
-    fn test_buy_potion_exceed_max_health() {
-        let mut game = new_adventurer_lvl2();
-        // get updated adventurer state
-        let adventurer = game.get_adventurer(ADVENTURER_ID);
-
-        // get number of potions required to reach full health
-        let potions_to_full_health = POTION_HEALTH_AMOUNT
-            / (adventurer.get_max_health() - adventurer.health);
-
-        let mut i: u16 = 0;
-        loop {
-            // buy one more health than is required to reach full health
-            // this should throw a panic 'Health already full'
-            // this test is annotated to expect that panic
-            if i > potions_to_full_health {
-                break;
-            }
-            game.buy_potion(ADVENTURER_ID);
-            i += 1;
-        }
-    }
-
-    #[test]
-    #[should_panic(expected: ('Health already full', 'ENTRYPOINT_FAILED'))]
     #[available_gas(450000000)]
     fn test_buy_potions_exceed_max_health() {
         let mut game = new_adventurer_lvl2();
@@ -1015,7 +992,7 @@ mod tests {
             / (adventurer.get_max_health() - adventurer.health))
             .try_into()
             .unwrap();
-
+        
         // attempt to buy one more potion than is required to reach full health
         // this should result in a panic 'Health already full'
         // this test is annotated to expect that panic
@@ -1029,13 +1006,16 @@ mod tests {
         // deploy and start new game
         let mut game = new_adventurer_lvl2();
 
+        let mut stat_upgrades = ArrayTrait::<u8>::new();
+        stat_upgrades.append(1);
+
         // use stat upgrade
-        game.upgrade_stat(ADVENTURER_ID, 0, 1);
+        game.upgrade_stats(ADVENTURER_ID, stat_upgrades);
 
         // attempt to buy potion
         // should panic with 'Market is closed'
         // this test is annotated to expect that panic
-        game.buy_potion(ADVENTURER_ID);
+        game.buy_potions(ADVENTURER_ID, 1);
     }
 
     #[test]
@@ -1048,7 +1028,7 @@ mod tests {
         // attempt to immediately buy health before clearing starter beast
         // this should result in contract throwing a panic 'Action not allowed in battle'
         // This test is annotated to expect that panic
-        game.buy_potion(ADVENTURER_ID);
+        game.buy_potions(ADVENTURER_ID, 1);
     }
 
     #[test]
@@ -1545,9 +1525,11 @@ mod tests {
 
         // get first item on the market
         let purchased_item_id = *market_items.at(0).item.id;
+        let mut shopping_cart = ArrayTrait::<ItemPurchase>::new();
+        shopping_cart.append(ItemPurchase { item_id: purchased_item_id, equip: false });
 
         // buy first item on market and bag it
-        game.buy_item(ADVENTURER_ID, purchased_item_id, false);
+        game.buy_items(ADVENTURER_ID, shopping_cart);
 
         // get adventurer state
         let adventurer = game.get_adventurer(ADVENTURER_ID);
@@ -1565,7 +1547,7 @@ mod tests {
         drop_list.append(purchased_item_id);
 
         // call contract drop
-        game.drop(ADVENTURER_ID, drop_list);
+        game.drop_items(ADVENTURER_ID, drop_list);
 
         // get adventurer state
         let adventurer = game.get_adventurer(ADVENTURER_ID);
@@ -1581,7 +1563,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Adventurer doesnt own item', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Item not owned by adventurer', 'ENTRYPOINT_FAILED'))]
     #[available_gas(90000000)]
     fn test_drop_item_without_ownership() {
         // start new game on level 2 so we have access to the market
@@ -1592,9 +1574,9 @@ mod tests {
         drop_list.append(255);
 
         // try to drop an item the adventurer doesn't own
-        // this should result in a panic 'Adventurer doesnt own item'
+        // this should result in a panic 'Item not owned by adventurer'
         // this test is annotated to expect that panic
-        game.drop(ADVENTURER_ID, drop_list);
+        game.drop_items(ADVENTURER_ID, drop_list);
     }
 
     #[test]
@@ -1652,7 +1634,7 @@ mod tests {
 
     #[test]
     #[available_gas(100000000)]
-    fn test_buy_items_and_upgrade_stats() {
+    fn test_upgrade_adventurer() {
         // deploy and start new game
         let mut game = new_adventurer_lvl2();
 
@@ -1677,17 +1659,13 @@ mod tests {
         stat_upgrades.append(5);
 
         // purchase potions, items, and upgrade stat in single call
-        game
-            .buy_items_and_upgrade_stats(
-                ADVENTURER_ID, potion_quantity, items_to_purchase, stat_upgrades
-            );
+        game.upgrade_adventurer(ADVENTURER_ID, potion_quantity, items_to_purchase, stat_upgrades);
 
         // get updated adventurer state
         let adventurer = game.get_adventurer(ADVENTURER_ID);
 
         // assert health was increased by one potion
         assert(adventurer.health == original_health + POTION_HEALTH_AMOUNT, 'health not increased');
-
         // assert charisma was increased
         assert(adventurer.stats.charisma == original_charisma + 1, 'charisma not increased');
         // assert stat point was used


### PR DESCRIPTION
* changes endpoint from buy_items_and_upgrade_stats() to upgrade_adventurer()
* requires all available stat upgrades be used when called
* emits an AdventurerUpgraded event instead of the barrage of individual events: {ItemPurchased, PotionPurchased, [Stat]Increased]}
* AdventuerUpgraded event includes all of the upgrade relevant informationsssssssssssssssssssssssssssssssss
* removes individual operation endpoints: {buy_item, buy_potion, upgrade_stat} as these are inefficient and should not be used
* renames public drop to drop_items to be more descriptive
* updates PurchasedPotion event to include {amount, cost, health_increase}
* fixes bug where buy_items wasn't validated item was available
* Change StatUpgradesAvailable event to UpgradeAvailable