### PR TITLE
adds unique abilities for Loot Rings

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -15,7 +15,7 @@ use super::{
             MAX_STAT_VALUE, MAX_STAT_UPGRADES, MAX_XP, MAX_ADVENTURER_BLOCKS, ITEM_MAX_GREATNESS,
             ITEM_MAX_XP, MAX_ADVENTURER_HEALTH, CHARISMA_ITEM_DISCOUNT, ClassStatBoosts,
             MAX_BLOCK_COUNT, STAT_UPGRADE_POINTS_PER_LEVEL, PENDENT_G20_STAT_BONUS,
-            BEAST_SPECIAL_NAME_LEVEL_UNLOCK
+            SILVER_RING_G20_LUCK_BONUS, BEAST_SPECIAL_NAME_LEVEL_UNLOCK
         },
         discovery_constants::DiscoveryEnums::{ExploreResult, TreasureDiscovery}
     }
@@ -359,7 +359,12 @@ impl ImplAdventurer of IAdventurer {
             necklace_greatness = 0;
         }
 
-        let mut ring_greatness = self.ring.get_greatness();
+        // @dev: the ring's luck bonus is only applied if the ring is a silver ring
+        //       if gas weren't a concern, we would have item_luck_bonus take in adventurer
+        //       and call it at the end of this function to make it more generalizable
+        //       but since for LS we know silver ring is only ring with luck bonus, we can
+        //       just hardcode it here
+        let mut ring_greatness = self.ring.get_greatness() + self.ring.item_luck_bonus();
         if (self.ring.id == 0) {
             ring_greatness = 0;
         }
@@ -1292,11 +1297,54 @@ impl ImplAdventurer of IAdventurer {
         self.neck.id == ItemId::Necklace && self.neck.get_greatness() == 20
     }
 
-    // @notice check if 
+    // @notice checks if adventurer has double gold from beasts ability unlocked
+    // @dev unlock is the gold ring with greatness 20
+    // @param adventurer the Adventurer to check if double gold from beasts is unlocked
+    // @return bool: true if double gold from beasts is unlocked, false otherwise
+    #[inline(always)]
+    fn double_gold_from_beasts_unlocked(self: Adventurer) -> bool {
+        self.ring.id == ItemId::GoldRing && self.ring.get_greatness() == 20
+    }
+
+    // @notice checks if adventurer has double critical hit ability unlocked
+    // @dev unlock is the platinum ring with greatness 20
+    // @param adventurer the Adventurer to check if double critical hit is unlocked
+    // @return bool: true if double critical hit is unlocked, false otherwise
+    #[inline(always)]
+    fn double_critical_hit_unlocked(self: Adventurer) -> bool {
+        self.ring.id == ItemId::PlatinumRing && self.ring.get_greatness() == 20
+    }
+
+    // @notice checks if adventurer has double special name damage ability unlocked
+    // @dev unlock is the titanium ring with greatness 20
+    // @param adventurer the Adventurer to check if double special name damage is unlocked
+    // @return bool: true if double special name damage is unlocked, false otherwise
+    #[inline(always)]
+    fn double_special_name_damage_unlocked(self: Adventurer) -> bool {
+        self.ring.id == ItemId::TitaniumRing && self.ring.get_greatness() == 20
+    }
+
+    // @notice gets stat bonus for an item
+    // @dev this is currently used for the pendant which grants +1 stat point at greatness 20
+    // @param item the ItemPrimitive to check if it qualifies for bonus stat points
+    // @return u8: the stat bonus, 0 if none 
     #[inline(always)]
     fn item_stat_bonus(self: ItemPrimitive) -> u8 {
         if self.id == ItemId::Pendant {
             PENDENT_G20_STAT_BONUS
+        } else {
+            0
+        }
+    }
+
+    // @notice gets luck bonus for an item
+    // @dev this is currently used for the silver ring which grants +20 luck at greatness 20
+    // @param item the ItemPrimitive to check if it qualifies for double luck
+    // @return u8 the luck bonus, 0 if none
+    #[inline(always)]
+    fn item_luck_bonus(self: ItemPrimitive) -> u8 {
+        if (self.id == ItemId::SilverRing && self.get_greatness() == 20) {
+            SILVER_RING_G20_LUCK_BONUS
         } else {
             0
         }
@@ -1334,12 +1382,224 @@ mod tests {
                 CHARISMA_POTION_DISCOUNT, MINIMUM_ITEM_PRICE, MINIMUM_POTION_PRICE,
                 HEALTH_INCREASE_PER_VITALITY, MAX_GOLD, MAX_STAT_VALUE, MAX_STAT_UPGRADES, MAX_XP,
                 MAX_ADVENTURER_BLOCKS, ITEM_MAX_GREATNESS, ITEM_MAX_XP, MAX_ADVENTURER_HEALTH,
-                CHARISMA_ITEM_DISCOUNT, ClassStatBoosts, MAX_BLOCK_COUNT
+                CHARISMA_ITEM_DISCOUNT, ClassStatBoosts, MAX_BLOCK_COUNT, SILVER_RING_G20_LUCK_BONUS
             },
             discovery_constants::DiscoveryEnums::{ExploreResult, TreasureDiscovery}
         }
     };
     use pack::{pack::{Packing, rshift_split}, constants::{MASK_16, pow, MASK_8, MASK_BOOL, mask}};
+
+    #[test]
+    #[available_gas(28390)]
+    fn test_double_gold_from_beasts_unlocked_gas() {
+        let adventurer = ImplAdventurer::new(
+            12,
+            0,
+            Stats {
+                strength: 1, dexterity: 1, vitality: 1, intelligence: 1, wisdom: 1, charisma: 1,
+            }
+        );
+        ImplAdventurer::double_gold_from_beasts_unlocked(adventurer);
+    }
+
+    #[test]
+    #[available_gas(74050)]
+    fn test_double_gold_from_beasts_unlocked() {
+        let mut adventurer = ImplAdventurer::new(
+            12,
+            0,
+            Stats {
+                strength: 1, dexterity: 1, vitality: 1, intelligence: 1, wisdom: 1, charisma: 1,
+            }
+        );
+
+        // verify new adventurers don't have double gold discovery unlocked
+        assert(
+            !ImplAdventurer::double_gold_from_beasts_unlocked(adventurer),
+            'double beast gold not unlocked'
+        );
+
+        // equip an amulet and verify result doesn't change
+        adventurer.neck = ItemPrimitive { id: ItemId::Amulet, xp: 400, metadata: 1 };
+        assert(
+            !ImplAdventurer::double_gold_from_beasts_unlocked(adventurer),
+            'amulet not unlock beast 2xgold'
+        );
+
+        // equip a pendant and verify result doesn't change
+        adventurer.neck = ItemPrimitive { id: ItemId::Pendant, xp: 400, metadata: 2 };
+        assert(
+            !ImplAdventurer::double_gold_from_beasts_unlocked(adventurer),
+            'pendant not unlock beast 2xgold'
+        );
+
+        // equip a necklace and verify result doesn't change
+        adventurer.neck = ItemPrimitive { id: ItemId::Necklace, xp: 400, metadata: 3 };
+        assert(
+            !ImplAdventurer::double_gold_from_beasts_unlocked(adventurer),
+            'necklace not beast 2xgold'
+        );
+
+        // equip a bronze ring and verify result doesn't change
+        adventurer.ring = ItemPrimitive { id: ItemId::BronzeRing, xp: 400, metadata: 4 };
+        assert(
+            !ImplAdventurer::double_gold_from_beasts_unlocked(adventurer),
+            'brnze ring ! unlck beast 2xgold'
+        );
+
+        // equip a gold ring with 399 xp (greatness 19) and verifyh result doesn't change
+        adventurer.ring = ItemPrimitive { id: ItemId::GoldRing, xp: 399, metadata: 5 };
+        assert(
+            !ImplAdventurer::double_gold_from_beasts_unlocked(adventurer),
+            'G19 gold ring ! beast 2xgold'
+        );
+
+        // equip a gold ring with 400 xp (greatness 20) and verify result is true
+        adventurer.ring = ItemPrimitive { id: ItemId::GoldRing, xp: 400, metadata: 6 };
+        assert(
+            ImplAdventurer::double_gold_from_beasts_unlocked(adventurer),
+            'G20 gold ring ! beast 2xgold'
+        );
+    }
+
+    #[test]
+    #[available_gas(29090)]
+    fn test_double_critical_hit_unlocked_gas() {
+        let mut adventurer = ImplAdventurer::new(
+            12,
+            0,
+            Stats {
+                strength: 1, dexterity: 1, vitality: 1, intelligence: 1, wisdom: 1, charisma: 1,
+            }
+        );
+
+        // equip a Platinum Ring ring with 400xp (greatness 20)
+        adventurer.ring = ItemPrimitive { id: ItemId::PlatinumRing, xp: 400, metadata: 6 };
+        ImplAdventurer::double_critical_hit_unlocked(adventurer);
+    }
+
+    #[test]
+    #[available_gas(67690)]
+    fn test_double_critical_hit_unlocked() {
+        let mut adventurer = ImplAdventurer::new(
+            12,
+            0,
+            Stats {
+                strength: 1, dexterity: 1, vitality: 1, intelligence: 1, wisdom: 1, charisma: 1,
+            }
+        );
+
+        // verify starting state (no ring)
+        assert(adventurer.ring.id == 0, 'start without a ring');
+
+        // verify no double critical hit unlocked without a ring
+        assert(
+            !ImplAdventurer::double_critical_hit_unlocked(adventurer), 'no crit hit without ring'
+        );
+
+        // equip a bronze ring and verify result doesn't change
+        adventurer.ring = ItemPrimitive { id: ItemId::BronzeRing, xp: 400, metadata: 4 };
+        assert(
+            !ImplAdventurer::double_critical_hit_unlocked(adventurer), 'brnze ring ! 2x crit dmg'
+        );
+
+        // equip a silver ring with 400 xp (greatness 20) and verify result is false
+        adventurer.ring = ItemPrimitive { id: ItemId::SilverRing, xp: 400, metadata: 6 };
+        assert(
+            !ImplAdventurer::double_critical_hit_unlocked(adventurer), 'silver ring ! 2x crit dmg'
+        );
+
+        // equip a gold ring with 400 xp (greatness 20) and verify result is false
+        adventurer.ring = ItemPrimitive { id: ItemId::GoldRing, xp: 400, metadata: 6 };
+        assert(
+            !ImplAdventurer::double_critical_hit_unlocked(adventurer), 'gold ring ! 2x crit dmg'
+        );
+
+        // equip a titanium ring with 400xp (greatness 20) and verify result is false
+        adventurer.ring = ItemPrimitive { id: ItemId::TitaniumRing, xp: 400, metadata: 6 };
+        assert(
+            !ImplAdventurer::double_critical_hit_unlocked(adventurer), 'titanium ring ! unlck 2xdmg'
+        );
+
+        // equip a platiniun ring with 400xp (greatness 20) and verify result is true
+        adventurer.ring = ItemPrimitive { id: ItemId::PlatinumRing, xp: 400, metadata: 6 };
+        assert(
+            ImplAdventurer::double_critical_hit_unlocked(adventurer), 'platinum ring ! unlck 2xdmg'
+        );
+    }
+
+    // gas baseline
+    #[test]
+    #[available_gas(29090)]
+    fn test_double_special_name_damage_unlocked_gas() {
+        let mut adventurer = ImplAdventurer::new(
+            12,
+            0,
+            Stats {
+                strength: 1, dexterity: 1, vitality: 1, intelligence: 1, wisdom: 1, charisma: 1,
+            }
+        );
+
+        // equip a titanium ring with 400xp (greatness 20)
+        adventurer.ring = ItemPrimitive { id: ItemId::TitaniumRing, xp: 400, metadata: 6 };
+        ImplAdventurer::double_special_name_damage_unlocked(adventurer);
+    }
+
+    #[test]
+    #[available_gas(67690)]
+    fn test_double_special_name_damage_unlocked() {
+        let mut adventurer = ImplAdventurer::new(
+            12,
+            0,
+            Stats {
+                strength: 1, dexterity: 1, vitality: 1, intelligence: 1, wisdom: 1, charisma: 1,
+            }
+        );
+
+        // verify starting state (no ring)
+        assert(adventurer.ring.id == 0, 'start without a ring');
+
+        // verify no double critical hit unlocked without a ring
+        assert(
+            !ImplAdventurer::double_special_name_damage_unlocked(adventurer),
+            'no double name dmg without ring'
+        );
+
+        // equip a bronze ring and verify result doesn't change
+        adventurer.ring = ItemPrimitive { id: ItemId::BronzeRing, xp: 400, metadata: 4 };
+        assert(
+            !ImplAdventurer::double_special_name_damage_unlocked(adventurer),
+            'brnze ring ! 2x name dmg'
+        );
+
+        // equip a silver ring with 400 xp (greatness 20) and verify result is false
+        adventurer.ring = ItemPrimitive { id: ItemId::SilverRing, xp: 400, metadata: 6 };
+        assert(
+            !ImplAdventurer::double_special_name_damage_unlocked(adventurer),
+            'silver ring ! 2x name dmg'
+        );
+
+        // equip a gold ring with 400 xp (greatness 20) and verify result is false
+        adventurer.ring = ItemPrimitive { id: ItemId::GoldRing, xp: 400, metadata: 6 };
+        assert(
+            !ImplAdventurer::double_special_name_damage_unlocked(adventurer),
+            'gold ring ! 2x name dmg'
+        );
+
+        // equip a platiniun ring with 400xp (greatness 20) and verify result is false
+        adventurer.ring = ItemPrimitive { id: ItemId::PlatinumRing, xp: 400, metadata: 6 };
+        assert(
+            !ImplAdventurer::double_special_name_damage_unlocked(adventurer),
+            'platinum ring ! 2x name dmg'
+        );
+
+        // equip a titanium ring with 400xp (greatness 20) and verify result is true
+        adventurer.ring = ItemPrimitive { id: ItemId::TitaniumRing, xp: 400, metadata: 6 };
+        assert(
+            ImplAdventurer::double_special_name_damage_unlocked(adventurer),
+            'g20 titanium ring unlcks 2xdmg'
+        );
+    }
 
     #[test]
     #[available_gas(3300)]
@@ -3373,7 +3633,7 @@ mod tests {
     }
 
     #[test]
-    #[available_gas(140000)]
+    #[available_gas(240000)]
     fn test_get_luck() {
         let mut adventurer = ImplAdventurer::new(
             12,
@@ -3385,19 +3645,34 @@ mod tests {
         assert(adventurer.get_luck() == 0, 'start with no luck');
 
         // equip a greatness 1 necklace
-        let mut neck = ItemPrimitive { id: constants::ItemId::Amulet, xp: 1, metadata: 7 };
+        let neck = ItemPrimitive { id: constants::ItemId::Amulet, xp: 1, metadata: 7 };
         adventurer.equip_necklace(neck);
         assert(adventurer.get_luck() == 1, 'should be 1 luck');
 
         // equip a greatness 1 ring
-        let mut ring = ItemPrimitive { id: constants::ItemId::GoldRing, xp: 1, metadata: 8 };
+        let ring = ItemPrimitive { id: constants::ItemId::GoldRing, xp: 1, metadata: 8 };
         adventurer.equip_ring(ring);
         assert(adventurer.get_luck() == 2, 'should be 2 luck');
+
+        // equip a greatness 19 silver ring
+        let mut silver_ring = ItemPrimitive {
+            id: constants::ItemId::SilverRing, xp: 399, metadata: 8
+        };
+        adventurer.equip_ring(silver_ring);
+        assert(adventurer.get_luck() == 20, 'should be 20 luck');
+
+        // increase silver ring to greatness 20 to unlock extra 20 luck
+        adventurer.ring.xp = 400;
+        assert(adventurer.get_luck() == 41, 'should be 41 luck');
 
         // overflow case
         adventurer.ring.xp = 65535;
         adventurer.neck.xp = 65535;
-        assert(adventurer.get_luck() == ITEM_MAX_GREATNESS * 2, 'should be 40 luck');
+        let luck = adventurer.get_luck();
+        assert(
+            adventurer.get_luck() == (ITEM_MAX_GREATNESS * 2) + SILVER_RING_G20_LUCK_BONUS,
+            'should be 60 luck'
+        );
     }
 
     #[test]

--- a/contracts/adventurer/src/constants/adventurer_constants.cairo
+++ b/contracts/adventurer/src/constants/adventurer_constants.cairo
@@ -18,6 +18,7 @@ const ITEM_MAX_GREATNESS: u8 = 20;
 const ITEM_MAX_XP: u16 = 400;
 const MAX_GREATNESS_STAT_BONUS: u8 = 1;
 const PENDENT_G20_STAT_BONUS: u8 = 1;
+const SILVER_RING_G20_LUCK_BONUS: u8 = 20;
 
 // Stat Settings
 const MAX_STAT_VALUE: u8 = 31; // 2^5 - 1

--- a/contracts/combat/src/constants.cairo
+++ b/contracts/combat/src/constants.cairo
@@ -50,7 +50,7 @@ mod CombatSettings {
 
     // controls the minimum damage bonus for elemental damage
     const STRONG_ELEMENTAL_BONUS_MIN: u16 = 10; // u16 because this is used with other u16s
-    const MAX_CRITICAL_HIT_LUCK: u8 = 40; // max luck for critical hit. Will produce 50% chance
+    const MAX_CRITICAL_HIT_LUCK: u8 = 100; // max luck for critical hit. Will produce 50% chance
 
     enum Difficulty {
         Easy: (),

--- a/contracts/obstacles/src/constants.cairo
+++ b/contracts/obstacles/src/constants.cairo
@@ -2,7 +2,7 @@ use combat::constants::{CombatEnums, CombatSettings};
 
 mod ObstacleSettings {
     // Determines the minimum damage an obstacle can do
-    const MINIMUM_DAMAGE: u16 = 1;
+    const MINIMUM_DAMAGE: u16 = 4;
     const DAMAGE_BOOST: u16 = 0;
     const MINIMUM_XP_REWARD: u16 = 4;
 }

--- a/contracts/obstacles/src/obstacle.cairo
+++ b/contracts/obstacles/src/obstacle.cairo
@@ -390,8 +390,10 @@ impl ImplObstacle of IObstacle {
     // @return The calculated damage as a 16-bit unsigned integer.
     // @dev Note that critical hits are not considered for obstacles in this calculation.
     fn get_damage(obstacle: Obstacle, armor_combat_spec: CombatSpec, entropy: u128) -> u16 {
-        // no critical hits for obstacles
-        let is_critical_hit = false;
+        // obstacle critical hit is always 1/6
+        let is_critical_hit = (entropy % 6) == 0;
+        let double_critical_hit_damage = false;
+        let double_name_damage = false;
 
         ImplCombat::calculate_damage(
             obstacle.combat_specs,
@@ -399,6 +401,8 @@ impl ImplObstacle of IObstacle {
             ObstacleSettings::MINIMUM_DAMAGE,
             ObstacleSettings::DAMAGE_BOOST,
             is_critical_hit,
+            double_critical_hit_damage,
+            double_name_damage,
             entropy
         )
     }
@@ -407,7 +411,7 @@ impl ImplObstacle of IObstacle {
     // @param obstacle: Obstacle - the obstacle
     // @return u16 - the xp reward
     fn get_xp_reward(self: Obstacle) -> u16 {
-        let xp_reward = self.combat_specs.get_xp_reward();
+        let xp_reward = self.combat_specs.get_base_reward();
         if (xp_reward < ObstacleSettings::MINIMUM_XP_REWARD) {
             ObstacleSettings::MINIMUM_XP_REWARD
         } else {


### PR DESCRIPTION
* Abilities are unlocked at Greatness 20
* (T3) Bronze Ring: no special ability (economy option)
* (T2) Silver Ring: bonus +20 luck
* (T1) Gold Ring: 2x gold reward from defeating beasts
* (T1) Platinum Ring: 2x critical hit damage
* (T1) Titanium Ring: 2x special name damage