### PR TITLE
Jewlery ability changes

### DIFF
--- a/contracts/adventurer/src/adventurer_stats.cairo
+++ b/contracts/adventurer/src/adventurer_stats.cairo
@@ -18,16 +18,8 @@ struct Stats { // 5 bits each
 #[generate_trait]
 impl StatUtils of IStat {
     fn new() -> Stats {
-        Stats {
-            strength: 0,
-            dexterity: 0,
-            vitality: 0,
-            intelligence: 0,
-            wisdom: 0,
-            charisma: 0
-        }
+        Stats { strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 0 }
     }
-
 }
 
 impl StatsPacking of Packing<Stats> {
@@ -89,50 +81,63 @@ impl StatsPacking of Packing<Stats> {
     }
 }
 
-#[test]
-#[available_gas(1500000)]
-fn test_stats_packing() {
-    // zero case
-    let stats = Stats {
-        strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 0
-    };
+// ---------------------------
+// ---------- Tests ----------
+// ---------------------------
+#[cfg(test)]
+mod tests {
+    use survivor::{constants::adventurer_constants::MAX_STAT_VALUE, adventurer_stats::{Stats, StatsPacking}};
+    
+    #[test]
+    #[available_gas(1500000)]
+    fn test_stats_packing() {
+        // zero case
+        let stats = Stats {
+            strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 0
+        };
 
-    let packed = stats.pack();
-    let unpacked = StatsPacking::unpack(packed);
-    assert(stats.strength == unpacked.strength, 'strength zero case');
-    assert(stats.dexterity == unpacked.dexterity, 'dexterity zero case');
-    assert(stats.vitality == unpacked.vitality, 'vitality zero case');
-    assert(stats.intelligence == unpacked.intelligence, 'intelligence zero case');
-    assert(stats.wisdom == unpacked.wisdom, 'wisdom zero case');
-    assert(stats.charisma == unpacked.charisma, 'charisma zero case');
+        let packed = stats.pack();
+        let unpacked = StatsPacking::unpack(packed);
+        assert(stats.strength == unpacked.strength, 'strength zero case');
+        assert(stats.dexterity == unpacked.dexterity, 'dexterity zero case');
+        assert(stats.vitality == unpacked.vitality, 'vitality zero case');
+        assert(stats.intelligence == unpacked.intelligence, 'intelligence zero case');
+        assert(stats.wisdom == unpacked.wisdom, 'wisdom zero case');
+        assert(stats.charisma == unpacked.charisma, 'charisma zero case');
 
-    // storage limit test (2^5 - 1 = 31)
-    let stats = Stats {
-        strength: 31, dexterity: 31, vitality: 31, intelligence: 31, wisdom: 31, charisma: 31
-    };
+        // storage limit test (2^5 - 1 = 31)
+        let stats = Stats {
+            strength: 31, dexterity: 31, vitality: 31, intelligence: 31, wisdom: 31, charisma: 31
+        };
 
-    let packed = stats.pack();
-    let unpacked = StatsPacking::unpack(packed);
-    assert(stats.strength == unpacked.strength, 'strength storage limit');
-    assert(stats.dexterity == unpacked.dexterity, 'dexterity storage limit');
-    assert(stats.vitality == unpacked.vitality, 'vitality storage limit');
-    assert(stats.intelligence == unpacked.intelligence, 'intelligence storage limit');
-    assert(stats.wisdom == unpacked.wisdom, 'wisdom storage limit');
-    assert(stats.charisma == unpacked.charisma, 'charisma storage limit');
+        let packed = stats.pack();
+        let unpacked = StatsPacking::unpack(packed);
+        assert(stats.strength == unpacked.strength, 'strength storage limit');
+        assert(stats.dexterity == unpacked.dexterity, 'dexterity storage limit');
+        assert(stats.vitality == unpacked.vitality, 'vitality storage limit');
+        assert(stats.intelligence == unpacked.intelligence, 'intelligence storage limit');
+        assert(stats.wisdom == unpacked.wisdom, 'wisdom storage limit');
+        assert(stats.charisma == unpacked.charisma, 'charisma storage limit');
 
-    // overflow storage limit using max u8
-    let stats = Stats {
-        strength: 255, dexterity: 255, vitality: 255, intelligence: 255, wisdom: 255, charisma: 255
-    };
+        // overflow storage limit using max u8
+        let stats = Stats {
+            strength: 255,
+            dexterity: 255,
+            vitality: 255,
+            intelligence: 255,
+            wisdom: 255,
+            charisma: 255
+        };
 
-    let packed = stats.pack();
-    let unpacked = StatsPacking::unpack(packed);
+        let packed = stats.pack();
+        let unpacked = StatsPacking::unpack(packed);
 
-    // assert packing function prevented overflow
-    assert(unpacked.strength == MAX_STAT_VALUE, 'strength pack overflow');
-    assert(unpacked.dexterity == MAX_STAT_VALUE, 'dexterity pack overflow');
-    assert(unpacked.vitality == MAX_STAT_VALUE, 'vitality pack overflow');
-    assert(unpacked.intelligence == MAX_STAT_VALUE, 'intelligence pack overflow');
-    assert(unpacked.wisdom == MAX_STAT_VALUE, 'wisdom pack overflow');
-    assert(unpacked.charisma == MAX_STAT_VALUE, 'charisma pack overflow');
+        // assert packing function prevented overflow
+        assert(unpacked.strength == MAX_STAT_VALUE, 'strength pack overflow');
+        assert(unpacked.dexterity == MAX_STAT_VALUE, 'dexterity pack overflow');
+        assert(unpacked.vitality == MAX_STAT_VALUE, 'vitality pack overflow');
+        assert(unpacked.intelligence == MAX_STAT_VALUE, 'intelligence pack overflow');
+        assert(unpacked.wisdom == MAX_STAT_VALUE, 'wisdom pack overflow');
+        assert(unpacked.charisma == MAX_STAT_VALUE, 'charisma pack overflow');
+    }
 }

--- a/contracts/adventurer/src/adventurer_utils.cairo
+++ b/contracts/adventurer/src/adventurer_utils.cairo
@@ -223,7 +223,7 @@ mod tests {
         );
 
         // deduct 1 health
-        adventurer.health.decrease_health(1);
+        adventurer.decrease_health(1);
         assert(
             AdventurerUtils::is_health_full(adventurer.health, adventurer.stats.vitality) == false,
             'health should not be full'

--- a/contracts/adventurer/src/bag.cairo
+++ b/contracts/adventurer/src/bag.cairo
@@ -81,6 +81,25 @@ impl BagPacking of Packing<Bag> {
 
 #[generate_trait]
 impl ImplBag of IBag {
+    // @notice Creates a new instance of the Bag
+    // @return The instance of the Bag
+    fn new() -> Bag {
+        Bag {
+            item_1: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_2: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_3: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_4: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_5: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_6: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_7: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_8: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_9: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_10: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_11: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            mutated: false
+        }
+    }
+
     // @notice Retrieves an item from the bag by its id
     // @dev If the item with the specified id is not in the bag, it throws an error
     // @param self The instance of the Bag
@@ -261,519 +280,686 @@ impl ImplBag of IBag {
     // @param item The id of the item to search for
     // @return A bool indicating whether the item is present in the bag
     #[inline(always)]
-    fn contains(self: Bag, item: u8) -> bool {
-        if self.item_1.id == item {
-            true
-        } else if self.item_2.id == item {
-            true
-        } else if self.item_3.id == item {
-            true
-        } else if self.item_4.id == item {
-            true
-        } else if self.item_5.id == item {
-            true
-        } else if self.item_6.id == item {
-            true
-        } else if self.item_7.id == item {
-            true
-        } else if self.item_8.id == item {
-            true
-        } else if self.item_9.id == item {
-            true
-        } else if self.item_10.id == item {
-            true
-        } else if self.item_11.id == item {
-            true
+    fn contains(self: Bag, item_id: u8) -> (bool, ItemPrimitive) {
+        assert(item_id != 0, 'Item ID cannot be 0');
+        if self.item_1.id == item_id {
+            return (true, self.item_1);
+        } else if self.item_2.id == item_id {
+            return (true, self.item_2);
+        } else if self.item_3.id == item_id {
+            return (true, self.item_3);
+        } else if self.item_4.id == item_id {
+            return (true, self.item_4);
+        } else if self.item_5.id == item_id {
+            return (true, self.item_5);
+        } else if self.item_6.id == item_id {
+            return (true, self.item_6);
+        } else if self.item_7.id == item_id {
+            return (true, self.item_7);
+        } else if self.item_8.id == item_id {
+            return (true, self.item_8);
+        } else if self.item_9.id == item_id {
+            return (true, self.item_9);
+        } else if self.item_10.id == item_id {
+            return (true, self.item_10);
+        } else if self.item_11.id == item_id {
+            return (true, self.item_11);
         } else {
-            false
+            return (false, ItemPrimitive { id: 0, xp: 0, metadata: 0 });
         }
+    }
+
+    // @notice Gets all the jewelry items in the bag
+    // @param self The instance of the Bag
+    // @return An array of all the jewelry items in the bag
+    fn get_jewelry(self: Bag) -> Array<ItemPrimitive> {
+        let mut jewlery = ArrayTrait::<ItemPrimitive>::new();
+        if ImplItemPrimitive::is_jewlery(self.item_1) {
+            jewlery.append(self.item_1);
+        }
+        if ImplItemPrimitive::is_jewlery(self.item_2) {
+            jewlery.append(self.item_2);
+        }
+        if ImplItemPrimitive::is_jewlery(self.item_3) {
+            jewlery.append(self.item_3);
+        }
+        if ImplItemPrimitive::is_jewlery(self.item_4) {
+            jewlery.append(self.item_4);
+        }
+        if ImplItemPrimitive::is_jewlery(self.item_5) {
+            jewlery.append(self.item_5);
+        }
+        if ImplItemPrimitive::is_jewlery(self.item_6) {
+            jewlery.append(self.item_6);
+        }
+        if ImplItemPrimitive::is_jewlery(self.item_7) {
+            jewlery.append(self.item_7);
+        }
+        if ImplItemPrimitive::is_jewlery(self.item_8) {
+            jewlery.append(self.item_8);
+        }
+        if ImplItemPrimitive::is_jewlery(self.item_9) {
+            jewlery.append(self.item_9);
+        }
+        if ImplItemPrimitive::is_jewlery(self.item_10) {
+            jewlery.append(self.item_10);
+        }
+        if ImplItemPrimitive::is_jewlery(self.item_11) {
+            jewlery.append(self.item_11);
+        }
+        jewlery
+    }
+
+    // @notice Gets the total greatness of all jewelry items in the bag
+    // @param self The instance of the Bag
+    // @return The total greatness of all jewelry items in the bag
+    fn get_jewelry_greatness(self: Bag) -> u8 {
+        let jewelry_items = self.get_jewelry();
+        let mut total_greatness = 0;
+        let mut item_index = 0;
+        loop {
+            if item_index == jewelry_items.len() {
+                break;
+            }
+            let jewelry_item = *jewelry_items.at(item_index);
+            total_greatness += jewelry_item.get_greatness();
+            item_index += 1;
+        };
+        total_greatness
     }
 }
 
-#[test]
-#[available_gas(88000)]
-fn test_contains() {
-    let bag = Bag {
-        item_1: ItemPrimitive {
-            id: 0, xp: 511, metadata: 1
-            }, item_2: ItemPrimitive {
-            id: 2, xp: 511, metadata: 2
-            }, item_3: ItemPrimitive {
-            id: 3, xp: 511, metadata: 3
-            }, item_4: ItemPrimitive {
-            id: 4, xp: 511, metadata: 4
-            }, item_5: ItemPrimitive {
-            id: 5, xp: 511, metadata: 5
-            }, item_6: ItemPrimitive {
-            id: 6, xp: 511, metadata: 6
-            }, item_7: ItemPrimitive {
-            id: 7, xp: 511, metadata: 7
-            }, item_8: ItemPrimitive {
-            id: 8, xp: 511, metadata: 8
-            }, item_9: ItemPrimitive {
-            id: 9, xp: 511, metadata: 9
-            }, item_10: ItemPrimitive {
-            id: 10, xp: 511, metadata: 10
-            }, item_11: ItemPrimitive {
-            id: 255, xp: 511, metadata: 11, 
-        }, mutated: false
-    };
+// ---------------------------
+// ---------- Tests ----------
+// ---------------------------
+#[cfg(test)]
+mod tests {
+    use survivor::{bag::{Bag, ImplBag, IBag}, item_primitive::{ItemPrimitive}};
+    use lootitems::{constants::ItemId};
+    use pack::{pack::{Packing}};
 
-    assert(bag.contains(0) == true, 'Item 0 should be in bag');
-    assert(bag.contains(2) == true, 'Item 2 should be in bag');
-    assert(bag.contains(3) == true, 'Item 3 should be in bag');
-    assert(bag.contains(4) == true, 'Item 4 should be in bag');
-    assert(bag.contains(5) == true, 'Item 5 should be in bag');
-    assert(bag.contains(6) == true, 'Item 6 should be in bag');
-    assert(bag.contains(7) == true, 'Item 7 should be in bag');
-    assert(bag.contains(8) == true, 'Item 8 should be in bag');
-    assert(bag.contains(9) == true, 'Item 9 should be in bag');
-    assert(bag.contains(10) == true, 'Item 10 should be in bag');
-    assert(bag.contains(255) == true, 'Item 255 should be in bag');
-    assert(bag.contains(100) == false, 'Item 100 not in bag');
-}
+    #[test]
+    #[available_gas(94030)]
+    fn test_get_jewelry_greatness() {
+        let katana = ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 1 };
+        let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 2, metadata: 2 };
+        let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 3, metadata: 3 };
+        let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 4, metadata: 4 };
+        let ghost_wand = ItemPrimitive { id: ItemId::GhostWand, xp: 5, metadata: 5 };
+        let leather_gloves = ItemPrimitive { id: ItemId::LeatherGloves, xp: 6, metadata: 6 };
+        let silk_gloves = ItemPrimitive { id: ItemId::SilkGloves, xp: 7, metadata: 7 };
+        let linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 8, metadata: 8 };
+        let crown = ItemPrimitive { id: ItemId::Crown, xp: 10, metadata: 9 };
+        let amulet = ItemPrimitive { id: ItemId::Amulet, xp: 9, metadata: 10 };
+        let pendant = ItemPrimitive { id: ItemId::Pendant, xp: 16, metadata: 11 };
+        let bag = Bag {
+            item_1: katana,
+            item_2: demon_crown,
+            item_3: silk_robe,
+            item_4: silver_ring,
+            item_5: ghost_wand,
+            item_6: leather_gloves,
+            item_7: silk_gloves,
+            item_8: linen_gloves,
+            item_9: crown,
+            item_10: amulet,
+            item_11: pendant,
+            mutated: false
+        };
 
-#[test]
-#[available_gas(2390000)]
-fn test_pack_bag() {
-    let mut bag = Bag {
-        item_1: ItemPrimitive {
-            id: 127, xp: 511, metadata: 31
-            }, item_2: ItemPrimitive {
-            id: 127, xp: 511, metadata: 31
-            }, item_3: ItemPrimitive {
-            id: 127, xp: 511, metadata: 31
-            }, item_4: ItemPrimitive {
-            id: 127, xp: 511, metadata: 31
-            }, item_5: ItemPrimitive {
-            id: 127, xp: 511, metadata: 31
-            }, item_6: ItemPrimitive {
-            id: 127, xp: 511, metadata: 31
-            }, item_7: ItemPrimitive {
-            id: 127, xp: 511, metadata: 31
-            }, item_8: ItemPrimitive {
-            id: 127, xp: 511, metadata: 31
-            }, item_9: ItemPrimitive {
-            id: 127, xp: 511, metadata: 31
-            }, item_10: ItemPrimitive {
-            id: 127, xp: 511, metadata: 31
-            }, item_11: ItemPrimitive {
-            id: 127, xp: 511, metadata: 31
-        }, mutated: false,
-    };
+        let jewelry_greatness = bag.get_jewelry_greatness();
+        assert(jewelry_greatness == 9, 'bagged jewlwery greatness is 9');
+    }
+    #[test]
+    #[available_gas(107010)]
+    fn test_get_jewelry_gas() {
+        let katana = ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 1 };
+        let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 2, metadata: 2 };
+        let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 3, metadata: 3 };
+        let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 4, metadata: 4 };
+        let ghost_wand = ItemPrimitive { id: ItemId::GhostWand, xp: 5, metadata: 5 };
+        let leather_gloves = ItemPrimitive { id: ItemId::LeatherGloves, xp: 6, metadata: 6 };
+        let silk_gloves = ItemPrimitive { id: ItemId::SilkGloves, xp: 7, metadata: 7 };
+        let linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 8, metadata: 8 };
+        let crown = ItemPrimitive { id: ItemId::Crown, xp: 10, metadata: 9 };
+        let amulet = ItemPrimitive { id: ItemId::Amulet, xp: 10, metadata: 10 };
+        let pendant = ItemPrimitive { id: ItemId::Pendant, xp: 10, metadata: 11 };
+        let bag = Bag {
+            item_1: katana,
+            item_2: demon_crown,
+            item_3: silk_robe,
+            item_4: silver_ring,
+            item_5: ghost_wand,
+            item_6: leather_gloves,
+            item_7: silk_gloves,
+            item_8: linen_gloves,
+            item_9: crown,
+            item_10: amulet,
+            item_11: pendant,
+            mutated: false
+        };
 
-    let packed_bag: Bag = Packing::unpack(bag.pack());
+        bag.get_jewelry();
+    }
 
-    assert(packed_bag.item_1.id == 127, 'Loot 1 ID is not 127');
-    assert(packed_bag.item_1.xp == 511, 'Loot 1 XP is not 511');
-    assert(packed_bag.item_1.metadata == 31, ' metadata is not 31');
+    #[test]
+    #[available_gas(41710)]
+    fn test_get_jewelry() {
+        let katana = ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 1 };
+        let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 2, metadata: 2 };
+        let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 3, metadata: 3 };
+        let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 4, metadata: 4 };
+        let ghost_wand = ItemPrimitive { id: ItemId::GhostWand, xp: 5, metadata: 5 };
+        let leather_gloves = ItemPrimitive { id: ItemId::LeatherGloves, xp: 6, metadata: 6 };
+        let silk_gloves = ItemPrimitive { id: ItemId::SilkGloves, xp: 7, metadata: 7 };
+        let linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 8, metadata: 8 };
+        let crown = ItemPrimitive { id: ItemId::Crown, xp: 10, metadata: 9 };
+        let amulet = ItemPrimitive { id: ItemId::Amulet, xp: 10, metadata: 10 };
+        let pendant = ItemPrimitive { id: ItemId::Pendant, xp: 10, metadata: 11 };
+        let bag = Bag {
+            item_1: katana,
+            item_2: demon_crown,
+            item_3: silk_robe,
+            item_4: silver_ring,
+            item_5: ghost_wand,
+            item_6: leather_gloves,
+            item_7: silk_gloves,
+            item_8: linen_gloves,
+            item_9: crown,
+            item_10: amulet,
+            item_11: pendant,
+            mutated: false
+        };
 
-    assert(packed_bag.item_2.id == 127, 'Loot 2 ID is not 127');
-    assert(packed_bag.item_2.xp == 511, 'Loot 2 XP is not 511');
-    assert(packed_bag.item_2.metadata == 31, ' 2 metadata is not 31');
+        let jewelry = bag.get_jewelry();
+        assert(jewelry.len() == 3, 'bag should have 3 jewlery items');
+        assert(*jewelry.at(0).id == silver_ring.id, 'silver ring in bag');
+        assert(*jewelry.at(1).id == amulet.id, 'amulet in bag');
+        assert(*jewelry.at(2).id == pendant.id, 'pendant in bag');
+    }
 
-    assert(packed_bag.item_3.id == 127, 'Loot 3 ID is not 127');
-    assert(packed_bag.item_3.xp == 511, 'Loot 3 XP is not 511');
-    assert(packed_bag.item_3.metadata == 31, ' 3 metadata is not 31');
+    #[test]
+    #[should_panic(expected: ('Item ID cannot be 0',))]
+    #[available_gas(6900)]
+    fn test_contains_invalid_zero() {
+        let katana = ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 1 };
+        let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 2, metadata: 2 };
+        let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 3, metadata: 3 };
+        let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 4, metadata: 4 };
+        let ghost_wand = ItemPrimitive { id: ItemId::GhostWand, xp: 5, metadata: 5 };
+        let leather_gloves = ItemPrimitive { id: ItemId::LeatherGloves, xp: 6, metadata: 6 };
+        let silk_gloves = ItemPrimitive { id: ItemId::SilkGloves, xp: 7, metadata: 7 };
+        let linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 8, metadata: 8 };
+        let crown = ItemPrimitive { id: ItemId::Crown, xp: 10, metadata: 9 };
+        let bag = Bag {
+            item_1: katana,
+            item_2: demon_crown,
+            item_3: silk_robe,
+            item_4: silver_ring,
+            item_5: ghost_wand,
+            item_6: leather_gloves,
+            item_7: silk_gloves,
+            item_8: linen_gloves,
+            item_9: crown,
+            item_10: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_11: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            mutated: false
+        };
+        bag.contains(0);
+    }
 
-    assert(packed_bag.item_4.id == 127, 'Loot 4 ID is not 127');
-    assert(packed_bag.item_4.xp == 511, 'Loot 4 XP is not 511');
-    assert(packed_bag.item_4.metadata == 31, ' 4 metadata is not 31');
+    #[test]
+    #[available_gas(56400)]
+    fn test_contains() {
+        let katana = ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 1 };
+        let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 2, metadata: 2 };
+        let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 3, metadata: 3 };
+        let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 4, metadata: 4 };
+        let ghost_wand = ItemPrimitive { id: ItemId::GhostWand, xp: 5, metadata: 5 };
+        let leather_gloves = ItemPrimitive { id: ItemId::LeatherGloves, xp: 6, metadata: 6 };
+        let silk_gloves = ItemPrimitive { id: ItemId::SilkGloves, xp: 7, metadata: 7 };
+        let linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 8, metadata: 8 };
+        let crown = ItemPrimitive { id: ItemId::Crown, xp: 10, metadata: 9 };
+        let bag = Bag {
+            item_1: katana,
+            item_2: demon_crown,
+            item_3: silk_robe,
+            item_4: silver_ring,
+            item_5: ghost_wand,
+            item_6: leather_gloves,
+            item_7: silk_gloves,
+            item_8: linen_gloves,
+            item_9: crown,
+            item_10: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_11: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            mutated: false
+        };
 
-    assert(packed_bag.item_5.id == 127, 'Loot 5 ID is not 127');
-    assert(packed_bag.item_5.xp == 511, 'Loot 5 XP is not 511');
-    assert(packed_bag.item_5.metadata == 31, ' 5 metadata is not 31');
+        let (contains, item) = bag.contains(katana.id);
+        assert(contains == true, 'katans should be in bag');
+        assert(item.id == katana.id, 'item id should be katana');
+        assert(item.xp == katana.xp, 'item xp should be katana');
+        assert(item.metadata == katana.metadata, 'item metadata should be katana');
 
-    assert(packed_bag.item_6.id == 127, 'Loot 6 ID is not 127');
-    assert(packed_bag.item_6.xp == 511, 'Loot 6 XP is not 511');
-    assert(packed_bag.item_6.metadata == 31, ' 6 metadata is not 31');
+        let (contains, item) = bag.contains(demon_crown.id);
+        assert(contains == true, 'demon crown should be in bag');
+        assert(item.id == demon_crown.id, 'item id should be demon crown');
+        assert(item.xp == demon_crown.xp, 'item xp should be demon crown');
+        assert(item.metadata == demon_crown.metadata, 'demon crown metadata');
 
-    assert(packed_bag.item_7.id == 127, 'Loot 7 ID is not 127');
-    assert(packed_bag.item_7.xp == 511, 'Loot 7 XP is not 511');
-    assert(packed_bag.item_7.metadata == 31, ' 7 metadata is not 31');
+        let (contains, item) = bag.contains(silk_robe.id);
+        assert(contains == true, 'silk robe should be in bag');
+        assert(item.id == silk_robe.id, 'item id should be silk robe');
+        assert(item.xp == silk_robe.xp, 'item xp should be silk robe');
+        assert(item.metadata == silk_robe.metadata, 'silk robe metadata');
 
-    assert(packed_bag.item_8.id == 127, 'Loot 8 ID is not 127');
-    assert(packed_bag.item_8.xp == 511, 'Loot 8 XP is not 511');
-    assert(packed_bag.item_8.metadata == 31, ' 8 metadata is not 31');
+        let (contains, item) = bag.contains(silver_ring.id);
+        assert(contains == true, 'silver ring should be in bag');
+        assert(item.id == silver_ring.id, 'item id should be silver ring');
+        assert(item.xp == silver_ring.xp, 'item xp should be silver ring');
+        assert(item.metadata == silver_ring.metadata, 'silver ring metadata');
 
-    assert(packed_bag.item_9.id == 127, 'Loot 9 ID is not 127');
-    assert(packed_bag.item_9.xp == 511, 'Loot 9 XP is not 511');
-    assert(packed_bag.item_9.metadata == 31, ' 9 metadata is not 31');
+        let (contains, item) = bag.contains(ghost_wand.id);
+        assert(contains == true, 'ghost wand should be in bag');
+        assert(item.id == ghost_wand.id, 'item id should be ghost wand');
+        assert(item.xp == ghost_wand.xp, 'item xp should be ghost wand');
+        assert(item.metadata == ghost_wand.metadata, 'ghost wand metadata');
 
-    assert(packed_bag.item_10.id == 127, 'Loot 10 ID is not 127');
-    assert(packed_bag.item_10.xp == 511, 'Loot 10 XP is not 511');
-    assert(packed_bag.item_10.metadata == 31, ' 10 metadata is not 31');
+        let (contains, item) = bag.contains(leather_gloves.id);
+        assert(contains == true, 'leather gloves should be in bag');
+        assert(item.id == leather_gloves.id, 'leather gloves id');
+        assert(item.xp == leather_gloves.xp, 'leather gloves xp');
+        assert(item.metadata == leather_gloves.metadata, 'leather gloves metadata');
 
-    assert(packed_bag.item_11.id == 127, 'Loot 11 ID is not 127');
-    assert(packed_bag.item_11.xp == 511, 'Loot 11 XP is not 511');
-    assert(packed_bag.item_11.metadata == 31, ' 11 metadata is not 31');
-}
+        let (contains, item) = bag.contains(silk_gloves.id);
+        assert(contains == true, 'silk gloves should be in bag');
+        assert(item.id == silk_gloves.id, 'item id should be silk gloves');
+        assert(item.xp == silk_gloves.xp, 'item xp should be silk gloves');
+        assert(item.metadata == silk_gloves.metadata, 'silk gloves metadata');
 
-#[test]
-#[should_panic(expected: ('Item ID cannot be 0', ))]
-#[available_gas(20000)]
-fn test_add_item_blank_item() {
-    // start with full bag
-    let mut bag = Bag {
-        item_1: ItemPrimitive {
-            id: 1, xp: 1, metadata: 1
-            }, item_2: ItemPrimitive {
-            id: 2, xp: 1, metadata: 2
-            }, item_3: ItemPrimitive {
-            id: 3, xp: 1, metadata: 3
-            }, item_4: ItemPrimitive {
-            id: 4, xp: 1, metadata: 4
-            }, item_5: ItemPrimitive {
-            id: 5, xp: 1, metadata: 5
-            }, item_6: ItemPrimitive {
-            id: 6, xp: 1, metadata: 6
-            }, item_7: ItemPrimitive {
-            id: 7, xp: 1, metadata: 7
-            }, item_8: ItemPrimitive {
-            id: 8, xp: 1, metadata: 8
-            }, item_9: ItemPrimitive {
-            id: 9, xp: 1, metadata: 9
-            }, item_10: ItemPrimitive {
-            id: 10, xp: 1, metadata: 10
-            }, item_11: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0
-        }, mutated: false
-    };
+        let (contains, item) = bag.contains(linen_gloves.id);
+        assert(contains == true, 'linen gloves should be in bag');
+        assert(item.id == linen_gloves.id, 'item id should be linen gloves');
+        assert(item.xp == linen_gloves.xp, 'item xp should be linen gloves');
+        assert(item.metadata == linen_gloves.metadata, 'linen gloves metadata');
 
-    // try adding an empty item to the bag
-    // this should panic with 'Item ID cannot be 0'
-    // which this test is annotated to expect
-    bag.add_item(ItemPrimitive { id: 0, xp: 1, metadata: 1 });
-}
+        let (contains, item) = bag.contains(crown.id);
+        assert(contains == true, 'crown should be in bag');
+        assert(item.id == crown.id, 'item id should be crown');
+        assert(item.xp == crown.xp, 'item xp should be crown');
+        assert(item.metadata == crown.metadata, 'item metadata should be crown');
 
-#[test]
-#[should_panic(expected: ('Bag is full', ))]
-#[available_gas(15000)]
-fn test_add_item_full_bag() {
-    // start with full bag
-    let mut bag = Bag {
-        item_1: ItemPrimitive {
-            id: 1, xp: 1, metadata: 1
-            }, item_2: ItemPrimitive {
-            id: 2, xp: 1, metadata: 2
-            }, item_3: ItemPrimitive {
-            id: 3, xp: 1, metadata: 3
-            }, item_4: ItemPrimitive {
-            id: 4, xp: 1, metadata: 4
-            }, item_5: ItemPrimitive {
-            id: 5, xp: 1, metadata: 5
-            }, item_6: ItemPrimitive {
-            id: 6, xp: 1, metadata: 6
-            }, item_7: ItemPrimitive {
-            id: 7, xp: 1, metadata: 7
-            }, item_8: ItemPrimitive {
-            id: 8, xp: 1, metadata: 8
-            }, item_9: ItemPrimitive {
-            id: 9, xp: 1, metadata: 9
-            }, item_10: ItemPrimitive {
-            id: 10, xp: 1, metadata: 10
-            }, item_11: ItemPrimitive {
-            id: 11, xp: 1, metadata: 11
-        }, mutated: false
-    };
+        let (contains, item) = bag.contains(ItemId::Maul);
+        assert(contains == false, 'maul should not be in bag');
+        assert(item.id == 0, 'id should be 0');
+        assert(item.xp == 0, 'xp should be 0');
+    }
 
-    // try adding an item to a full bag
-    // this should panic with 'Bag is full'
-    // which this test is annotated to expect
-    bag.add_item(ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 1 });
-}
+    #[test]
+    #[available_gas(2383150)]
+    fn test_pack_bag() {
+        let mut bag = Bag {
+            item_1: ItemPrimitive { id: 127, xp: 511, metadata: 31 },
+            item_2: ItemPrimitive { id: 127, xp: 511, metadata: 31 },
+            item_3: ItemPrimitive { id: 127, xp: 511, metadata: 31 },
+            item_4: ItemPrimitive { id: 127, xp: 511, metadata: 31 },
+            item_5: ItemPrimitive { id: 127, xp: 511, metadata: 31 },
+            item_6: ItemPrimitive { id: 127, xp: 511, metadata: 31 },
+            item_7: ItemPrimitive { id: 127, xp: 511, metadata: 31 },
+            item_8: ItemPrimitive { id: 127, xp: 511, metadata: 31 },
+            item_9: ItemPrimitive { id: 127, xp: 511, metadata: 31 },
+            item_10: ItemPrimitive { id: 127, xp: 511, metadata: 31 },
+            item_11: ItemPrimitive { id: 127, xp: 511, metadata: 31 },
+            mutated: false,
+        };
 
-#[test]
-#[available_gas(180000)]
-fn test_add_item() {
-    // start with empty bag
-    let mut bag = Bag {
-        item_1: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0
-            }, item_2: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0
-            }, item_3: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0
-            }, item_4: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0
-            }, item_5: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0
-            }, item_6: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0
-            }, item_7: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0
-            }, item_8: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0
-            }, item_9: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0
-            }, item_10: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0
-            }, item_11: ItemPrimitive {
-            id: 0, xp: 0, metadata: 0
-        }, mutated: false
-    };
+        let packed_bag: Bag = Packing::unpack(bag.pack());
 
-    // initialize items
-    let katana = ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 1 };
-    let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 1, metadata: 2 };
-    let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 1, metadata: 3 };
-    let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 1, metadata: 4 };
-    let ghost_wand = ItemPrimitive { id: ItemId::GhostWand, xp: 1, metadata: 5 };
-    let leather_gloves = ItemPrimitive { id: ItemId::LeatherGloves, xp: 1, metadata: 6 };
-    let silk_gloves = ItemPrimitive { id: ItemId::SilkGloves, xp: 1, metadata: 7 };
-    let linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 1, metadata: 8 };
-    let crown = ItemPrimitive { id: ItemId::Crown, xp: 1, metadata: 9 };
-    let divine_slippers = ItemPrimitive { id: ItemId::DivineSlippers, xp: 1, metadata: 10 };
-    let warhammer = ItemPrimitive { id: ItemId::Warhammer, xp: 1, metadata: 11 };
+        assert(packed_bag.item_1.id == 127, 'Loot 1 ID is not 127');
+        assert(packed_bag.item_1.xp == 511, 'Loot 1 XP is not 511');
+        assert(packed_bag.item_1.metadata == 31, ' metadata is not 31');
 
-    // add items to bag
-    bag.add_item(katana);
-    bag.add_item(demon_crown);
-    bag.add_item(silk_robe);
-    bag.add_item(silver_ring);
-    bag.add_item(ghost_wand);
-    bag.add_item(leather_gloves);
-    bag.add_item(silk_gloves);
-    bag.add_item(linen_gloves);
-    bag.add_item(crown);
-    bag.add_item(divine_slippers);
-    bag.add_item(warhammer);
+        assert(packed_bag.item_2.id == 127, 'Loot 2 ID is not 127');
+        assert(packed_bag.item_2.xp == 511, 'Loot 2 XP is not 511');
+        assert(packed_bag.item_2.metadata == 31, ' 2 metadata is not 31');
 
-    // assert items are in bag
-    assert(bag.item_1.id == ItemId::Katana, 'item 1 should be katana');
-    assert(bag.item_2.id == ItemId::DemonCrown, 'item 2 should be demon crown');
-    assert(bag.item_3.id == ItemId::SilkRobe, 'item 3 should be silk robe');
-    assert(bag.item_4.id == ItemId::SilverRing, 'item 4 should be silver ring');
-    assert(bag.item_5.id == ItemId::GhostWand, 'item 5 should be ghost wand');
-    assert(bag.item_6.id == ItemId::LeatherGloves, 'item 6 should be leather gloves');
-    assert(bag.item_7.id == ItemId::SilkGloves, 'item 7 should be silk gloves');
-    assert(bag.item_8.id == ItemId::LinenGloves, 'item 8 should be linen gloves');
-    assert(bag.item_9.id == ItemId::Crown, 'item 9 should be crown');
-    assert(bag.item_10.id == ItemId::DivineSlippers, 'should be divine slippers');
-    assert(bag.item_11.id == ItemId::Warhammer, 'item 11 should be warhammer');
-}
+        assert(packed_bag.item_3.id == 127, 'Loot 3 ID is not 127');
+        assert(packed_bag.item_3.xp == 511, 'Loot 3 XP is not 511');
+        assert(packed_bag.item_3.metadata == 31, ' 3 metadata is not 31');
 
-#[test]
-#[available_gas(59900)]
-fn test_is_full() {
-    // start with full bag
-    let mut bag = Bag {
-        item_1: ItemPrimitive {
-            id: 1, xp: 0, metadata: 0
-            }, item_2: ItemPrimitive {
-            id: 2, xp: 0, metadata: 0
-            }, item_3: ItemPrimitive {
-            id: 3, xp: 0, metadata: 0
-            }, item_4: ItemPrimitive {
-            id: 4, xp: 0, metadata: 0
-            }, item_5: ItemPrimitive {
-            id: 5, xp: 0, metadata: 0
-            }, item_6: ItemPrimitive {
-            id: 8, xp: 0, metadata: 0
-            }, item_7: ItemPrimitive {
-            id: 9, xp: 0, metadata: 0
-            }, item_8: ItemPrimitive {
-            id: 11, xp: 0, metadata: 0
-            }, item_9: ItemPrimitive {
-            id: 12, xp: 0, metadata: 0
-            }, item_10: ItemPrimitive {
-            id: 13, xp: 0, metadata: 0
-            }, item_11: ItemPrimitive {
-            id: 14, xp: 0, metadata: 0
-        }, mutated: false
-    };
+        assert(packed_bag.item_4.id == 127, 'Loot 4 ID is not 127');
+        assert(packed_bag.item_4.xp == 511, 'Loot 4 XP is not 511');
+        assert(packed_bag.item_4.metadata == 31, ' 4 metadata is not 31');
 
-    // assert bag is full
-    assert(bag.is_full() == true, 'Bag should be full');
+        assert(packed_bag.item_5.id == 127, 'Loot 5 ID is not 127');
+        assert(packed_bag.item_5.xp == 511, 'Loot 5 XP is not 511');
+        assert(packed_bag.item_5.metadata == 31, ' 5 metadata is not 31');
 
-    // remove an item
-    bag.remove_item(1);
+        assert(packed_bag.item_6.id == 127, 'Loot 6 ID is not 127');
+        assert(packed_bag.item_6.xp == 511, 'Loot 6 XP is not 511');
+        assert(packed_bag.item_6.metadata == 31, ' 6 metadata is not 31');
 
-    // assert bag is not full
-    assert(bag.is_full() == false, 'Bag should be not full');
+        assert(packed_bag.item_7.id == 127, 'Loot 7 ID is not 127');
+        assert(packed_bag.item_7.xp == 511, 'Loot 7 XP is not 511');
+        assert(packed_bag.item_7.metadata == 31, ' 7 metadata is not 31');
 
-    // add a new item
-    let mut warhammer = ItemPrimitive { id: ItemId::Warhammer, xp: 1, metadata: 11 };
-    bag.add_item(warhammer);
+        assert(packed_bag.item_8.id == 127, 'Loot 8 ID is not 127');
+        assert(packed_bag.item_8.xp == 511, 'Loot 8 XP is not 511');
+        assert(packed_bag.item_8.metadata == 31, ' 8 metadata is not 31');
 
-    // assert bag is full again
-    assert(bag.is_full() == true, 'Bag should be full again');
-}
+        assert(packed_bag.item_9.id == 127, 'Loot 9 ID is not 127');
+        assert(packed_bag.item_9.xp == 511, 'Loot 9 XP is not 511');
+        assert(packed_bag.item_9.metadata == 31, ' 9 metadata is not 31');
 
-#[test]
-#[should_panic(expected: ('Item not in bag', ))]
-#[available_gas(85000)]
-fn test_get_item_not_in_bag() {
-    let item_1 = ItemPrimitive { id: 11, xp: 0, metadata: 0 };
-    let item_2 = ItemPrimitive { id: 12, xp: 0, metadata: 0 };
-    let item_3 = ItemPrimitive { id: 13, xp: 0, metadata: 0 };
-    let item_4 = ItemPrimitive { id: 14, xp: 0, metadata: 0 };
-    let item_5 = ItemPrimitive { id: 15, xp: 0, metadata: 0 };
-    let item_6 = ItemPrimitive { id: 16, xp: 0, metadata: 0 };
-    let item_7 = ItemPrimitive { id: 17, xp: 0, metadata: 0 };
-    let item_8 = ItemPrimitive { id: 18, xp: 0, metadata: 0 };
-    let item_9 = ItemPrimitive { id: 19, xp: 0, metadata: 0 };
-    let item_10 = ItemPrimitive { id: 20, xp: 0, metadata: 0 };
-    let item_11 = ItemPrimitive { id: 21, xp: 0, metadata: 0 };
+        assert(packed_bag.item_10.id == 127, 'Loot 10 ID is not 127');
+        assert(packed_bag.item_10.xp == 511, 'Loot 10 XP is not 511');
+        assert(packed_bag.item_10.metadata == 31, ' 10 metadata is not 31');
 
-    let bag = Bag {
-        item_1: item_1,
-        item_2: item_2,
-        item_3: item_3,
-        item_4: item_4,
-        item_5: item_5,
-        item_6: item_6,
-        item_7: item_7,
-        item_8: item_8,
-        item_9: item_9,
-        item_10: item_10,
-        item_11: item_11,
-        mutated: false,
-    };
+        assert(packed_bag.item_11.id == 127, 'Loot 11 ID is not 127');
+        assert(packed_bag.item_11.xp == 511, 'Loot 11 XP is not 511');
+        assert(packed_bag.item_11.metadata == 31, ' 11 metadata is not 31');
+    }
 
-    // try to get an item that is not in bag
-    // should panic with 'Item not in bag'
-    // this test is annotated to expect this panic
-    // and will fail if it not thrown
-    bag.get_item(8);
-}
+    #[test]
+    #[should_panic(expected: ('Item ID cannot be 0',))]
+    #[available_gas(7920)]
+    fn test_add_item_blank_item() {
+        // start with full bag
+        let mut bag = Bag {
+            item_1: ItemPrimitive { id: 1, xp: 1, metadata: 1 },
+            item_2: ItemPrimitive { id: 2, xp: 1, metadata: 2 },
+            item_3: ItemPrimitive { id: 3, xp: 1, metadata: 3 },
+            item_4: ItemPrimitive { id: 4, xp: 1, metadata: 4 },
+            item_5: ItemPrimitive { id: 5, xp: 1, metadata: 5 },
+            item_6: ItemPrimitive { id: 6, xp: 1, metadata: 6 },
+            item_7: ItemPrimitive { id: 7, xp: 1, metadata: 7 },
+            item_8: ItemPrimitive { id: 8, xp: 1, metadata: 8 },
+            item_9: ItemPrimitive { id: 9, xp: 1, metadata: 9 },
+            item_10: ItemPrimitive { id: 10, xp: 1, metadata: 10 },
+            item_11: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            mutated: false
+        };
 
-#[test]
-#[available_gas(85000)]
-fn test_get_item() {
-    let item_1 = ItemPrimitive { id: 11, xp: 0, metadata: 0 };
-    let item_2 = ItemPrimitive { id: 12, xp: 0, metadata: 0 };
-    let item_3 = ItemPrimitive { id: 13, xp: 0, metadata: 0 };
-    let item_4 = ItemPrimitive { id: 14, xp: 0, metadata: 0 };
-    let item_5 = ItemPrimitive { id: 15, xp: 0, metadata: 0 };
-    let item_6 = ItemPrimitive { id: 16, xp: 0, metadata: 0 };
-    let item_7 = ItemPrimitive { id: 17, xp: 0, metadata: 0 };
-    let item_8 = ItemPrimitive { id: 18, xp: 0, metadata: 0 };
-    let item_9 = ItemPrimitive { id: 19, xp: 0, metadata: 0 };
-    let item_10 = ItemPrimitive { id: 20, xp: 0, metadata: 0 };
-    let item_11 = ItemPrimitive { id: 21, xp: 0, metadata: 0 };
+        // try adding an empty item to the bag
+        // this should panic with 'Item ID cannot be 0'
+        // which this test is annotated to expect
+        bag.add_item(ItemPrimitive { id: 0, xp: 1, metadata: 1 });
+    }
 
-    let bag = Bag {
-        item_1: item_1,
-        item_2: item_2,
-        item_3: item_3,
-        item_4: item_4,
-        item_5: item_5,
-        item_6: item_6,
-        item_7: item_7,
-        item_8: item_8,
-        item_9: item_9,
-        item_10: item_10,
-        item_11: item_11,
-        mutated: false,
-    };
+    #[test]
+    #[should_panic(expected: ('Bag is full',))]
+    #[available_gas(7920)]
+    fn test_add_item_full_bag() {
+        // start with full bag
+        let mut bag = Bag {
+            item_1: ItemPrimitive { id: 1, xp: 1, metadata: 1 },
+            item_2: ItemPrimitive { id: 2, xp: 1, metadata: 2 },
+            item_3: ItemPrimitive { id: 3, xp: 1, metadata: 3 },
+            item_4: ItemPrimitive { id: 4, xp: 1, metadata: 4 },
+            item_5: ItemPrimitive { id: 5, xp: 1, metadata: 5 },
+            item_6: ItemPrimitive { id: 6, xp: 1, metadata: 6 },
+            item_7: ItemPrimitive { id: 7, xp: 1, metadata: 7 },
+            item_8: ItemPrimitive { id: 8, xp: 1, metadata: 8 },
+            item_9: ItemPrimitive { id: 9, xp: 1, metadata: 9 },
+            item_10: ItemPrimitive { id: 10, xp: 1, metadata: 10 },
+            item_11: ItemPrimitive { id: 11, xp: 1, metadata: 11 },
+            mutated: false
+        };
 
-    let item1_from_bag = bag.get_item(11);
-    assert(item1_from_bag.id == item_1.id, 'Item id should be 11');
+        // try adding an item to a full bag
+        // this should panic with 'Bag is full'
+        // which this test is annotated to expect
+        bag.add_item(ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 1 });
+    }
 
-    let item2_from_bag = bag.get_item(12);
-    assert(item2_from_bag.id == item_2.id, 'Item id should be 12');
+    #[test]
+    #[available_gas(129100)]
+    fn test_add_item() {
+        // start with empty bag
+        let mut bag = Bag {
+            item_1: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_2: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_3: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_4: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_5: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_6: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_7: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_8: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_9: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_10: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            item_11: ItemPrimitive { id: 0, xp: 0, metadata: 0 },
+            mutated: false
+        };
 
-    let item3_from_bag = bag.get_item(13);
-    assert(item3_from_bag.id == item_3.id, 'Item id should be 13');
+        // initialize items
+        let katana = ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 1 };
+        let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 1, metadata: 2 };
+        let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 1, metadata: 3 };
+        let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 1, metadata: 4 };
+        let ghost_wand = ItemPrimitive { id: ItemId::GhostWand, xp: 1, metadata: 5 };
+        let leather_gloves = ItemPrimitive { id: ItemId::LeatherGloves, xp: 1, metadata: 6 };
+        let silk_gloves = ItemPrimitive { id: ItemId::SilkGloves, xp: 1, metadata: 7 };
+        let linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 1, metadata: 8 };
+        let crown = ItemPrimitive { id: ItemId::Crown, xp: 1, metadata: 9 };
+        let divine_slippers = ItemPrimitive { id: ItemId::DivineSlippers, xp: 1, metadata: 10 };
+        let warhammer = ItemPrimitive { id: ItemId::Warhammer, xp: 1, metadata: 11 };
 
-    let item4_from_bag = bag.get_item(14);
-    assert(item4_from_bag.id == item_4.id, 'Item id should be 14');
+        // add items to bag
+        bag.add_item(katana);
+        bag.add_item(demon_crown);
+        bag.add_item(silk_robe);
+        bag.add_item(silver_ring);
+        bag.add_item(ghost_wand);
+        bag.add_item(leather_gloves);
+        bag.add_item(silk_gloves);
+        bag.add_item(linen_gloves);
+        bag.add_item(crown);
+        bag.add_item(divine_slippers);
+        bag.add_item(warhammer);
 
-    let item5_from_bag = bag.get_item(15);
-    assert(item5_from_bag.id == item_5.id, 'Item id should be 15');
+        // assert items are in bag
+        assert(bag.item_1.id == ItemId::Katana, 'item 1 should be katana');
+        assert(bag.item_2.id == ItemId::DemonCrown, 'item 2 should be demon crown');
+        assert(bag.item_3.id == ItemId::SilkRobe, 'item 3 should be silk robe');
+        assert(bag.item_4.id == ItemId::SilverRing, 'item 4 should be silver ring');
+        assert(bag.item_5.id == ItemId::GhostWand, 'item 5 should be ghost wand');
+        assert(bag.item_6.id == ItemId::LeatherGloves, 'item 6 should be leather gloves');
+        assert(bag.item_7.id == ItemId::SilkGloves, 'item 7 should be silk gloves');
+        assert(bag.item_8.id == ItemId::LinenGloves, 'item 8 should be linen gloves');
+        assert(bag.item_9.id == ItemId::Crown, 'item 9 should be crown');
+        assert(bag.item_10.id == ItemId::DivineSlippers, 'should be divine slippers');
+        assert(bag.item_11.id == ItemId::Warhammer, 'item 11 should be warhammer');
+    }
 
-    let item6_from_bag = bag.get_item(16);
-    assert(item6_from_bag.id == item_6.id, 'Item id should be 16');
+    #[test]
+    #[available_gas(40300)]
+    fn test_is_full() {
+        // start with full bag
+        let mut bag = Bag {
+            item_1: ItemPrimitive { id: 1, xp: 0, metadata: 0 },
+            item_2: ItemPrimitive { id: 2, xp: 0, metadata: 0 },
+            item_3: ItemPrimitive { id: 3, xp: 0, metadata: 0 },
+            item_4: ItemPrimitive { id: 4, xp: 0, metadata: 0 },
+            item_5: ItemPrimitive { id: 5, xp: 0, metadata: 0 },
+            item_6: ItemPrimitive { id: 8, xp: 0, metadata: 0 },
+            item_7: ItemPrimitive { id: 9, xp: 0, metadata: 0 },
+            item_8: ItemPrimitive { id: 11, xp: 0, metadata: 0 },
+            item_9: ItemPrimitive { id: 12, xp: 0, metadata: 0 },
+            item_10: ItemPrimitive { id: 13, xp: 0, metadata: 0 },
+            item_11: ItemPrimitive { id: 14, xp: 0, metadata: 0 },
+            mutated: false
+        };
 
-    let item7_from_bag = bag.get_item(17);
-    assert(item7_from_bag.id == item_7.id, 'Item id should be 17');
+        // assert bag is full
+        assert(bag.is_full() == true, 'Bag should be full');
 
-    let item8_from_bag = bag.get_item(18);
-    assert(item8_from_bag.id == item_8.id, 'Item id should be 18');
+        // remove an item
+        bag.remove_item(1);
 
-    let item9_from_bag = bag.get_item(19);
-    assert(item9_from_bag.id == item_9.id, 'Item id should be 19');
+        // assert bag is not full
+        assert(bag.is_full() == false, 'Bag should be not full');
 
-    let item10_from_bag = bag.get_item(20);
-    assert(item10_from_bag.id == item_10.id, 'Item id should be 20');
+        // add a new item
+        let mut warhammer = ItemPrimitive { id: ItemId::Warhammer, xp: 1, metadata: 11 };
+        bag.add_item(warhammer);
 
-    let item11_from_bag = bag.get_item(21);
-    assert(item11_from_bag.id == item_11.id, 'Item id should be 21');
-}
+        // assert bag is full again
+        assert(bag.is_full() == true, 'Bag should be full again');
+    }
 
-#[test]
-#[available_gas(21900)]
-fn test_remove_item() {
-    let mut bag = Bag {
-        item_1: ItemPrimitive {
-            id: 1, xp: 0, metadata: 0
-            }, item_2: ItemPrimitive {
-            id: 2, xp: 0, metadata: 0
-            }, item_3: ItemPrimitive {
-            id: 3, xp: 0, metadata: 0
-            }, item_4: ItemPrimitive {
-            id: 4, xp: 0, metadata: 0
-            }, item_5: ItemPrimitive {
-            id: 5, xp: 0, metadata: 0
-            }, item_6: ItemPrimitive {
-            id: 6, xp: 0, metadata: 0
-            }, item_7: ItemPrimitive {
-            id: 7, xp: 0, metadata: 0
-            }, item_8: ItemPrimitive {
-            id: 8, xp: 1, metadata: 1
-            }, item_9: ItemPrimitive {
-            id: 9, xp: 0, metadata: 0
-            }, item_10: ItemPrimitive {
-            id: 10, xp: 0, metadata: 0
-            }, item_11: ItemPrimitive {
-            id: 11, xp: 0, metadata: 0
-        }, mutated: false
-    };
+    #[test]
+    #[should_panic(expected: ('Item not in bag',))]
+    #[available_gas(6820)]
+    fn test_get_item_not_in_bag() {
+        let item_1 = ItemPrimitive { id: 11, xp: 0, metadata: 0 };
+        let item_2 = ItemPrimitive { id: 12, xp: 0, metadata: 0 };
+        let item_3 = ItemPrimitive { id: 13, xp: 0, metadata: 0 };
+        let item_4 = ItemPrimitive { id: 14, xp: 0, metadata: 0 };
+        let item_5 = ItemPrimitive { id: 15, xp: 0, metadata: 0 };
+        let item_6 = ItemPrimitive { id: 16, xp: 0, metadata: 0 };
+        let item_7 = ItemPrimitive { id: 17, xp: 0, metadata: 0 };
+        let item_8 = ItemPrimitive { id: 18, xp: 0, metadata: 0 };
+        let item_9 = ItemPrimitive { id: 19, xp: 0, metadata: 0 };
+        let item_10 = ItemPrimitive { id: 20, xp: 0, metadata: 0 };
+        let item_11 = ItemPrimitive { id: 21, xp: 0, metadata: 0 };
 
-    // remove item from bag
-    let removed_item = bag.remove_item(6);
+        let bag = Bag {
+            item_1: item_1,
+            item_2: item_2,
+            item_3: item_3,
+            item_4: item_4,
+            item_5: item_5,
+            item_6: item_6,
+            item_7: item_7,
+            item_8: item_8,
+            item_9: item_9,
+            item_10: item_10,
+            item_11: item_11,
+            mutated: false,
+        };
 
-    // verify it has been removed
-    assert(bag.item_6.id == 0, 'id should be 0');
-    assert(bag.item_6.xp == 0, 'xp should be 0');
-    assert(bag.item_6.metadata == 0, 'metadata should be 0');
-    assert(removed_item.id == 6, 'removed item is wrong');
-}
+        // try to get an item that is not in bag
+        // should panic with 'Item not in bag'
+        // this test is annotated to expect this panic
+        // and will fail if it not thrown
+        bag.get_item(8);
+    }
 
-#[test]
-#[should_panic(expected: ('Item not in bag', ))]
-#[available_gas(21900)]
-fn test_remove_item_not_in_bag() {
-    // initialize bag
-    let mut bag = Bag {
-        item_1: ItemPrimitive {
-            id: 1, xp: 0, metadata: 0
-            }, item_2: ItemPrimitive {
-            id: 2, xp: 0, metadata: 0
-            }, item_3: ItemPrimitive {
-            id: 3, xp: 0, metadata: 0
-            }, item_4: ItemPrimitive {
-            id: 4, xp: 0, metadata: 0
-            }, item_5: ItemPrimitive {
-            id: 5, xp: 0, metadata: 0
-            }, item_6: ItemPrimitive {
-            id: 8, xp: 0, metadata: 0
-            }, item_7: ItemPrimitive {
-            id: 9, xp: 0, metadata: 0
-            }, item_8: ItemPrimitive {
-            id: 11, xp: 0, metadata: 0
-            }, item_9: ItemPrimitive {
-            id: 12, xp: 0, metadata: 0
-            }, item_10: ItemPrimitive {
-            id: 13, xp: 0, metadata: 0
-            }, item_11: ItemPrimitive {
-            id: 14, xp: 0, metadata: 0
-        }, mutated: false
-    };
+    #[test]
+    #[available_gas(50100)]
+    fn test_get_item() {
+        let item_1 = ItemPrimitive { id: 11, xp: 0, metadata: 0 };
+        let item_2 = ItemPrimitive { id: 12, xp: 0, metadata: 0 };
+        let item_3 = ItemPrimitive { id: 13, xp: 0, metadata: 0 };
+        let item_4 = ItemPrimitive { id: 14, xp: 0, metadata: 0 };
+        let item_5 = ItemPrimitive { id: 15, xp: 0, metadata: 0 };
+        let item_6 = ItemPrimitive { id: 16, xp: 0, metadata: 0 };
+        let item_7 = ItemPrimitive { id: 17, xp: 0, metadata: 0 };
+        let item_8 = ItemPrimitive { id: 18, xp: 0, metadata: 0 };
+        let item_9 = ItemPrimitive { id: 19, xp: 0, metadata: 0 };
+        let item_10 = ItemPrimitive { id: 20, xp: 0, metadata: 0 };
+        let item_11 = ItemPrimitive { id: 21, xp: 0, metadata: 0 };
 
-    // try to remove an item not in the bag
-    // this should panic with 'item not in bag'
-    // which this test is annotated to expect
-    bag.remove_item(255);
+        let bag = Bag {
+            item_1: item_1,
+            item_2: item_2,
+            item_3: item_3,
+            item_4: item_4,
+            item_5: item_5,
+            item_6: item_6,
+            item_7: item_7,
+            item_8: item_8,
+            item_9: item_9,
+            item_10: item_10,
+            item_11: item_11,
+            mutated: false,
+        };
+
+        let item1_from_bag = bag.get_item(11);
+        assert(item1_from_bag.id == item_1.id, 'Item id should be 11');
+
+        let item2_from_bag = bag.get_item(12);
+        assert(item2_from_bag.id == item_2.id, 'Item id should be 12');
+
+        let item3_from_bag = bag.get_item(13);
+        assert(item3_from_bag.id == item_3.id, 'Item id should be 13');
+
+        let item4_from_bag = bag.get_item(14);
+        assert(item4_from_bag.id == item_4.id, 'Item id should be 14');
+
+        let item5_from_bag = bag.get_item(15);
+        assert(item5_from_bag.id == item_5.id, 'Item id should be 15');
+
+        let item6_from_bag = bag.get_item(16);
+        assert(item6_from_bag.id == item_6.id, 'Item id should be 16');
+
+        let item7_from_bag = bag.get_item(17);
+        assert(item7_from_bag.id == item_7.id, 'Item id should be 17');
+
+        let item8_from_bag = bag.get_item(18);
+        assert(item8_from_bag.id == item_8.id, 'Item id should be 18');
+
+        let item9_from_bag = bag.get_item(19);
+        assert(item9_from_bag.id == item_9.id, 'Item id should be 19');
+
+        let item10_from_bag = bag.get_item(20);
+        assert(item10_from_bag.id == item_10.id, 'Item id should be 20');
+
+        let item11_from_bag = bag.get_item(21);
+        assert(item11_from_bag.id == item_11.id, 'Item id should be 21');
+    }
+
+    #[test]
+    #[available_gas(15700)]
+    fn test_remove_item() {
+        let mut bag = Bag {
+            item_1: ItemPrimitive { id: 1, xp: 0, metadata: 0 },
+            item_2: ItemPrimitive { id: 2, xp: 0, metadata: 0 },
+            item_3: ItemPrimitive { id: 3, xp: 0, metadata: 0 },
+            item_4: ItemPrimitive { id: 4, xp: 0, metadata: 0 },
+            item_5: ItemPrimitive { id: 5, xp: 0, metadata: 0 },
+            item_6: ItemPrimitive { id: 6, xp: 0, metadata: 0 },
+            item_7: ItemPrimitive { id: 7, xp: 0, metadata: 0 },
+            item_8: ItemPrimitive { id: 8, xp: 1, metadata: 1 },
+            item_9: ItemPrimitive { id: 9, xp: 0, metadata: 0 },
+            item_10: ItemPrimitive { id: 10, xp: 0, metadata: 0 },
+            item_11: ItemPrimitive { id: 11, xp: 0, metadata: 0 },
+            mutated: false
+        };
+
+        // remove item from bag
+        let removed_item = bag.remove_item(6);
+
+        // verify it has been removed
+        assert(bag.item_6.id == 0, 'id should be 0');
+        assert(bag.item_6.xp == 0, 'xp should be 0');
+        assert(bag.item_6.metadata == 0, 'metadata should be 0');
+        assert(removed_item.id == 6, 'removed item is wrong');
+    }
+
+    #[test]
+    #[should_panic(expected: ('Item not in bag',))]
+    #[available_gas(10420)]
+    fn test_remove_item_not_in_bag() {
+        // initialize bag
+        let mut bag = Bag {
+            item_1: ItemPrimitive { id: 1, xp: 0, metadata: 0 },
+            item_2: ItemPrimitive { id: 2, xp: 0, metadata: 0 },
+            item_3: ItemPrimitive { id: 3, xp: 0, metadata: 0 },
+            item_4: ItemPrimitive { id: 4, xp: 0, metadata: 0 },
+            item_5: ItemPrimitive { id: 5, xp: 0, metadata: 0 },
+            item_6: ItemPrimitive { id: 8, xp: 0, metadata: 0 },
+            item_7: ItemPrimitive { id: 9, xp: 0, metadata: 0 },
+            item_8: ItemPrimitive { id: 11, xp: 0, metadata: 0 },
+            item_9: ItemPrimitive { id: 12, xp: 0, metadata: 0 },
+            item_10: ItemPrimitive { id: 13, xp: 0, metadata: 0 },
+            item_11: ItemPrimitive { id: 14, xp: 0, metadata: 0 },
+            mutated: false
+        };
+
+        // try to remove an item not in the bag
+        // this should panic with 'item not in bag'
+        // which this test is annotated to expect
+        bag.remove_item(255);
+    }
 }

--- a/contracts/adventurer/src/exploration.cairo
+++ b/contracts/adventurer/src/exploration.cairo
@@ -42,12 +42,7 @@ impl ExploreUtils of Explore {
     // @param entropy: The entropy seed to use for random discovery amount
     // @return u16: the amount of gold discovered
     fn get_gold_discovery(adventurer: Adventurer, entropy: u128) -> u16 {
-        let base_gold = ExploreUtils::get_base_discovery_amount(adventurer.get_level(), entropy);
-        if adventurer.double_gold_discovery_unlocked() {
-            base_gold * 2
-        } else {
-            base_gold
-        }
+        ExploreUtils::get_base_discovery_amount(adventurer.get_level(), entropy)
     }
 
 
@@ -56,12 +51,7 @@ impl ExploreUtils of Explore {
     // @param entropy: The entropy seed to use for random discovery amount
     // @return u16: the amount of health discovered
     fn get_health_discovery(adventurer: Adventurer, entropy: u128) -> u16 {
-        let base_health = ExploreUtils::get_base_discovery_amount(adventurer.get_level(), entropy);
-        if adventurer.double_health_discovery_unlocked() {
-            base_health * 2
-        } else {
-            base_health
-        }
+        ExploreUtils::get_base_discovery_amount(adventurer.get_level(), entropy)
     }
 
     // @notice: generates a random xp discovery based on adventurer level and provided entropy
@@ -85,7 +75,7 @@ mod tests {
     use lootitems::constants::ItemId;
 
     #[test]
-    #[available_gas(69690)]
+    #[available_gas(55560)]
     fn test_get_gold_discovery_gas() {
         let adventurer = ImplAdventurer::new(
             12,
@@ -99,7 +89,7 @@ mod tests {
     }
 
     #[test]
-    #[available_gas(509690)]
+    #[available_gas(56060)]
     fn test_get_gold_discovery() {
         let mut adventurer = ImplAdventurer::new(
             12,
@@ -113,20 +103,10 @@ mod tests {
         let entropy = 0;
         let gold_discovery = ExploreUtils::get_gold_discovery(adventurer, entropy);
         assert(gold_discovery == 1, 'gold_discovery should be 1');
-
-        // equip an amulet and verify result doesn't change
-        adventurer.neck = ItemPrimitive { id: ItemId::Amulet, xp: 400, metadata: 1 };
-        let gold_discovery = ExploreUtils::get_gold_discovery(adventurer, entropy);
-        assert(gold_discovery == 1, 'gold_discovery should be 1');
-
-        // equip a pendant and verify we get 2x gold
-        adventurer.neck = ItemPrimitive { id: ItemId::Pendant, xp: 400, metadata: 2 };
-        let gold_discovery = ExploreUtils::get_gold_discovery(adventurer, entropy);
-        assert(gold_discovery == 2, 'gold_discovery should be 2');
     }
 
     #[test]
-    #[available_gas(61690)]
+    #[available_gas(55560)]
     fn test_get_health_discovery_gas() {
         let adventurer = ImplAdventurer::new(
             12,
@@ -140,7 +120,7 @@ mod tests {
     }
 
     #[test]
-    #[available_gas(509690)]
+    #[available_gas(56060)]
     fn test_get_health_discovery() {
         let mut adventurer = ImplAdventurer::new(
             12,
@@ -154,21 +134,6 @@ mod tests {
         let entropy = 0;
         let discovery_amount = ExploreUtils::get_health_discovery(adventurer, entropy);
         assert(discovery_amount == 1, 'health discovery should be 1');
-
-        // equip a pendant and verify result doesn't change
-        adventurer.neck = ItemPrimitive { id: ItemId::Pendant, xp: 400, metadata: 1 };
-        let discovery_amount = ExploreUtils::get_health_discovery(adventurer, entropy);
-        assert(discovery_amount == 1, 'health discovery should be 1');
-
-        // last we equip a necklace and verify result is doubled
-        adventurer.neck = ItemPrimitive { id: ItemId::Necklace, xp: 400, metadata: 1 };
-        let discovery_amount = ExploreUtils::get_health_discovery(adventurer, entropy);
-        assert(discovery_amount == 1, 'health discovery should be 1');
-
-        // equip an amulet and verify result doesn't change
-        adventurer.neck = ItemPrimitive { id: ItemId::Amulet, xp: 400, metadata: 1 };
-        let discovery_amount = ExploreUtils::get_health_discovery(adventurer, entropy);
-        assert(discovery_amount == 2, 'double discovery fail');
     }
 
     #[test]

--- a/contracts/adventurer/src/item_meta.cairo
+++ b/contracts/adventurer/src/item_meta.cairo
@@ -1,16 +1,9 @@
-use core::serde::Serde;
-use traits::{TryInto, Into};
-use option::OptionTrait;
-use integer::{U256TryIntoU32, U256TryIntoU16, U256TryIntoU8};
-use pack::pack::{Packing, rshift_split};
-use pack::constants::pow;
+use pack::{pack::{Packing, rshift_split}, constants::pow};
 use lootitems::constants::{ItemId, ItemSuffix};
-
 use super::{
     adventurer::{Adventurer, IAdventurer, ImplAdventurer}, item_primitive::ItemPrimitive,
-    adventurer_stats::Stats
+    adventurer_stats::Stats, bag::{Bag, IBag}
 };
-use super::bag::{Bag, IBag};
 
 mod STORAGE {
     // First 10 indexes are stored in storage 1
@@ -475,595 +468,621 @@ impl ImplItemSpecials of IItemSpecials {
     }
 }
 
-#[test]
-#[available_gas(3000000)]
-fn test_item_meta_packing() {
-    // initailize ItemSpecialsStorage with strategic test values
-    let storage = ItemSpecialsStorage {
-        item_1: ItemSpecials { special1: 0, special2: 0, special3: 0 // zero case
-         },
-        item_2: ItemSpecials { special1: 1, special2: 2, special3: 3 // uniqueness
-         },
-        item_3: ItemSpecials { special1: 4, special2: 4, special3: 4 // all same
-         },
-        item_4: ItemSpecials { special1: 15, special2: 127, special3: 31 // max packable values
-         },
-        item_5: ItemSpecials { special1: 255, special2: 255, special3: 255 // max u8 values
-         },
-        item_6: ItemSpecials { special1: 5, special2: 5, special3: 5 // dnc
-         },
-        item_7: ItemSpecials { special1: 6, special2: 6, special3: 6 // dnc
-         },
-        item_8: ItemSpecials { special1: 7, special2: 7, special3: 7 // dnc
-         },
-        item_9: ItemSpecials { special1: 8, special2: 8, special3: 8 // dnc
-         },
-        item_10: ItemSpecials { special1: 9, special2: 9, special3: 9 // dnc
-         },
-        mutated: false,
+// ---------------------------
+// ---------- Tests ----------
+// ---------------------------
+#[cfg(test)]
+mod tests {
+    use pack::pack::{Packing};
+    use lootitems::constants::{ItemId};
+    use survivor::{
+        adventurer::{ImplAdventurer}, item_primitive::ItemPrimitive,
+        adventurer_stats::Stats, bag::{Bag, IBag},
+        item_meta::{
+            ImplItemSpecials, ItemSpecialsStorage, ItemSpecials, MAX_SPECIAL1, MAX_SPECIAL2,
+            MAX_SPECIAL3, STORAGE
+        },
     };
 
-    // pack and then unpack the specials
-    let unpacked: ItemSpecialsStorage = Packing::unpack(storage.pack());
-
-    // assert the values were not altered using PartialEq
-    assert(unpacked.item_1 == storage.item_1, 'item 1 packing error');
-    assert(unpacked.item_2 == storage.item_2, 'item 2 packing error');
-    assert(unpacked.item_3 == storage.item_3, 'item 3 packing error');
-    assert(unpacked.item_4 == storage.item_4, 'item 4 packing error');
-    assert(unpacked.item_6 == storage.item_6, 'item 6 packing error');
-    assert(unpacked.item_7 == storage.item_7, 'item 7 packing error');
-    assert(unpacked.item_8 == storage.item_8, 'item 8 packing error');
-    assert(unpacked.item_9 == storage.item_9, 'item 9 packing error');
-    assert(unpacked.item_10 == storage.item_10, 'item 10 packing error');
-
-    // item 5 is special in that it attempts to overflow the packing
-    // assert the packing overflow protection works and instead of
-    // overflowing, sets these values to max
-    assert(unpacked.item_5.special1 == MAX_SPECIAL1, 'special1 max u8 check');
-    assert(unpacked.item_5.special2 == MAX_SPECIAL2, 'special2 max u8 check');
-    assert(unpacked.item_5.special3 == MAX_SPECIAL3, 'special3 max u8 check');
-}
-
-#[test]
-#[available_gas(4000000)]
-fn test_set_metadata_id() {
-    // start test with a new adventurer wielding a wand
-    let mut adventurer = ImplAdventurer::new(
-        12,
-        1,
-        Stats { strength: 1, dexterity: 1, vitality: 1, intelligence: 1, wisdom: 1, charisma: 1, }
-    );
-
-    // assert adventurer starter weapon has meta data id 1
-    assert(adventurer.weapon.metadata == 1, 'advntr wpn meta data shld be 1');
-
-    // generate starter wand
-    let mut starter_wand = ItemPrimitive { id: ItemId::Wand, xp: 1, metadata: 1 };
-
-    // and an empty bag
-    let mut bag = Bag {
-        item_1: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
-        item_2: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
-        item_3: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
-        item_4: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
-        item_5: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
-        item_6: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
-        item_7: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
-        item_8: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
-        item_9: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
-        item_10: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
-        item_11: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
-        mutated: false
-    };
-
-    // stage a bunch of gear
-    let mut katana = ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 0 };
-    let mut demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 1, metadata: 0 };
-    let mut silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 1, metadata: 0 };
-    let mut silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 1, metadata: 0 };
-    let mut ghost_wand = ItemPrimitive { id: ItemId::GhostWand, xp: 1, metadata: 0 };
-    let mut leather_gloves = ItemPrimitive { id: ItemId::LeatherGloves, xp: 1, metadata: 0 };
-    let mut silk_gloves = ItemPrimitive { id: ItemId::SilkGloves, xp: 1, metadata: 0 };
-    let mut linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 1, metadata: 0 };
-    let mut crown = ItemPrimitive { id: ItemId::Crown, xp: 1, metadata: 0 };
-    let mut divine_slippers = ItemPrimitive { id: ItemId::DivineSlippers, xp: 1, metadata: 0 };
-    let mut warhammer = ItemPrimitive { id: ItemId::Warhammer, xp: 1, metadata: 0 };
-    let mut ancient_helm = ItemPrimitive { id: ItemId::AncientHelm, xp: 1, metadata: 0 };
-    let mut divine_robe = ItemPrimitive { id: ItemId::DivineRobe, xp: 1, metadata: 0 };
-    let mut holy_chestplate = ItemPrimitive { id: ItemId::HolyChestplate, xp: 1, metadata: 0 };
-    let mut holy_greaves = ItemPrimitive { id: ItemId::HolyGreaves, xp: 1, metadata: 0 };
-    let mut demonhide_boots = ItemPrimitive { id: ItemId::DemonhideBoots, xp: 1, metadata: 0 };
-    let mut holy_gauntlets = ItemPrimitive { id: ItemId::HolyGauntlets, xp: 1, metadata: 0 };
-    let mut demonhide_belt = ItemPrimitive { id: ItemId::DemonhideBelt, xp: 1, metadata: 0 };
-
-    // get next available specials storage slot
-    // this should result is the meta data is incrementing for each item
-    katana.set_metadata_id(adventurer, bag);
-    adventurer.equip_item(katana);
-    assert(katana.metadata == 2, 'wrong katana metadata');
-
-    demon_crown.set_metadata_id(adventurer, bag);
-    adventurer.equip_item(demon_crown);
-    assert(demon_crown.metadata == 3, 'wrong demon crown metadata');
-
-    silk_robe.set_metadata_id(adventurer, bag);
-    adventurer.equip_item(silk_robe);
-    assert(silk_robe.metadata == 4, 'wrong silk robe metadata');
-
-    silver_ring.set_metadata_id(adventurer, bag);
-    adventurer.equip_item(silver_ring);
-    assert(silver_ring.metadata == 5, 'wrong silver ring metadata');
-
-    ghost_wand.set_metadata_id(adventurer, bag);
-    bag.add_item(katana);
-    adventurer.equip_item(ghost_wand);
-    assert(ghost_wand.metadata == 6, 'wrong ghost wand metadata');
-
-    leather_gloves.set_metadata_id(adventurer, bag);
-    adventurer.equip_item(leather_gloves);
-    assert(leather_gloves.metadata == 7, 'wrong leather gloves metadata');
-
-    silk_gloves.set_metadata_id(adventurer, bag);
-    bag.add_item(leather_gloves);
-    adventurer.equip_item(silk_gloves);
-    assert(silk_gloves.metadata == 8, 'wrong silk gloves metadata');
-
-    linen_gloves.set_metadata_id(adventurer, bag);
-    bag.add_item(silk_gloves);
-    adventurer.equip_item(linen_gloves);
-    assert(linen_gloves.metadata == 9, 'wrong linen gloves metadata');
-
-    crown.set_metadata_id(adventurer, bag);
-    bag.add_item(demon_crown);
-    adventurer.equip_item(crown);
-    assert(crown.metadata == 10, 'wrong crown metadata');
-
-    divine_slippers.set_metadata_id(adventurer, bag);
-    adventurer.equip_item(divine_slippers);
-    assert(divine_slippers.metadata == 11, 'wrong divine slippers metadata');
-
-    warhammer.set_metadata_id(adventurer, bag);
-    bag.add_item(ghost_wand);
-    adventurer.equip_item(warhammer);
-    assert(warhammer.metadata == 12, 'wrong warhammer metadata');
-
-    ancient_helm.set_metadata_id(adventurer, bag);
-    bag.add_item(crown);
-    adventurer.equip_item(ancient_helm);
-    assert(ancient_helm.metadata == 13, 'wrong ancient helm metadata');
-
-    divine_robe.set_metadata_id(adventurer, bag);
-    bag.add_item(silk_robe);
-    adventurer.equip_item(divine_robe);
-    assert(divine_robe.metadata == 14, 'wrong divine robe metadata');
-
-    holy_chestplate.set_metadata_id(adventurer, bag);
-    bag.add_item(divine_robe);
-    adventurer.equip_item(holy_chestplate);
-    assert(holy_chestplate.metadata == 15, 'wrong holy chestplate metadata');
-
-    holy_greaves.set_metadata_id(adventurer, bag);
-    bag.add_item(divine_slippers);
-    adventurer.equip_item(holy_greaves);
-    assert(holy_greaves.metadata == 16, 'wrong holy greaves metadata');
-
-    demonhide_boots.set_metadata_id(adventurer, bag);
-    bag.add_item(holy_greaves);
-    adventurer.equip_item(demonhide_boots);
-    assert(demonhide_boots.metadata == 17, 'wrong demonhide boots metadata');
-
-    holy_gauntlets.set_metadata_id(adventurer, bag);
-    bag.add_item(linen_gloves);
-    adventurer.equip_item(holy_gauntlets);
-    assert(holy_gauntlets.metadata == 18, 'wrong holy gauntlets metadata');
-
-    demonhide_belt.set_metadata_id(adventurer, bag);
-    adventurer.equip_item(demonhide_belt);
-    assert(demonhide_belt.metadata == 19, 'wrong demonhide belts metadata');
-
-    // do one final pass to make sure none of the meta data got
-    // altered during equipment swap operations
-    assert(katana.metadata == 2, 'wrong katana metadata');
-    assert(demon_crown.metadata == 3, 'wrong demon crown metadata');
-    assert(silk_robe.metadata == 4, 'wrong silk robe metadata');
-    assert(silver_ring.metadata == 5, 'wrong silver ring metadata');
-    assert(ghost_wand.metadata == 6, 'wrong ghost wand metadata');
-    assert(leather_gloves.metadata == 7, 'wrong leather gloves metadata');
-    assert(silk_gloves.metadata == 8, 'wrong silk gloves metadata');
-    assert(linen_gloves.metadata == 9, 'wrong linen gloves metadata');
-    assert(crown.metadata == 10, 'wrong crown metadata');
-    assert(divine_slippers.metadata == 11, 'wrong divine slippers metadata');
-    assert(warhammer.metadata == 12, 'wrong warhammer metadata');
-    assert(ancient_helm.metadata == 13, 'wrong ancient helm metadata');
-    assert(divine_robe.metadata == 14, 'wrong divine robe metadata');
-    assert(holy_chestplate.metadata == 15, 'wrong holy chestplate metadata');
-    assert(holy_greaves.metadata == 16, 'wrong holy greaves metadata');
-    assert(demonhide_boots.metadata == 17, 'wrong demonhide boots metadata');
-    assert(holy_gauntlets.metadata == 18, 'wrong holy gauntlets metadata');
-}
-
-#[test]
-#[available_gas(500000)]
-fn test_get_specials() {
-    // create 19 items to be used for the test
-    let wand = ItemPrimitive { id: ItemId::Wand, xp: 1, metadata: 1 };
-    let katana = ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 2 };
-    let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 1, metadata: 3 };
-    let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 1, metadata: 4 };
-    let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 1, metadata: 5 };
-    let ghost_wand = ItemPrimitive { id: ItemId::GhostWand, xp: 1, metadata: 6 };
-    let leather_gloves = ItemPrimitive { id: ItemId::LeatherGloves, xp: 1, metadata: 7 };
-    let silk_gloves = ItemPrimitive { id: ItemId::SilkGloves, xp: 1, metadata: 8 };
-    let linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 1, metadata: 9 };
-    let crown = ItemPrimitive { id: ItemId::Crown, xp: 1, metadata: 10 };
-    let divine_slippers = ItemPrimitive { id: ItemId::DivineSlippers, xp: 1, metadata: 11 };
-    let warhammer = ItemPrimitive { id: ItemId::Warhammer, xp: 1, metadata: 12 };
-    let ancient_helm = ItemPrimitive { id: ItemId::AncientHelm, xp: 1, metadata: 13 };
-    let divine_robe = ItemPrimitive { id: ItemId::DivineRobe, xp: 1, metadata: 14 };
-    let holy_chestplate = ItemPrimitive { id: ItemId::HolyChestplate, xp: 1, metadata: 15 };
-    let holy_greaves = ItemPrimitive { id: ItemId::HolyGreaves, xp: 1, metadata: 16 };
-    let demonhide_boots = ItemPrimitive { id: ItemId::DemonhideBoots, xp: 1, metadata: 17 };
-    let holy_gauntlets = ItemPrimitive { id: ItemId::HolyGauntlets, xp: 1, metadata: 18 };
-    let demonhide_boots = ItemPrimitive { id: ItemId::DemonhideBoots, xp: 1, metadata: 19 };
-
-    // generate unique specials for each item
-    let wand_specials = ItemSpecials { special1: 1, special2: 1, special3: 1 };
-    let katana_specials = ItemSpecials { special1: 2, special2: 2, special3: 2 };
-    let demon_crown_specials = ItemSpecials { special1: 3, special2: 3, special3: 3 };
-    let silk_robe_specials = ItemSpecials { special1: 4, special2: 4, special3: 4 };
-    let silver_ring_specials = ItemSpecials { special1: 5, special2: 5, special3: 5 };
-    let ghost_wand_specials = ItemSpecials { special1: 6, special2: 6, special3: 6 };
-    let leather_gloves_specials = ItemSpecials { special1: 7, special2: 7, special3: 7 };
-    let silk_gloves_specials = ItemSpecials { special1: 8, special2: 8, special3: 8 };
-    let linen_gloves_specials = ItemSpecials { special1: 9, special2: 9, special3: 9 };
-    let crown_specials = ItemSpecials { special1: 10, special2: 10, special3: 10 };
-    let divine_slippers_specials = ItemSpecials { special1: 11, special2: 11, special3: 11 };
-    let warhammer_specials = ItemSpecials { special1: 12, special2: 12, special3: 12 };
-    let ancient_helm_specials = ItemSpecials { special1: 13, special2: 13, special3: 13 };
-    let divine_robe_specials = ItemSpecials { special1: 14, special2: 14, special3: 14 };
-    let holy_chestplate_specials = ItemSpecials { special1: 15, special2: 15, special3: 15 };
-    let holy_greaves_specials = ItemSpecials { special1: 1, special2: 16, special3: 16 };
-    let demonhide_boots_specials = ItemSpecials { special1: 2, special2: 17, special3: 17 };
-    let holy_gauntlets_specials = ItemSpecials { special1: 3, special2: 18, special3: 18 };
-    let demonhide_boots_specials = ItemSpecials { special1: 4, special2: 19, special3: 19 };
-
-    // initialize special storage 1 with first 10 items
-    let storage1 = ItemSpecialsStorage {
-        item_1: wand_specials,
-        item_2: katana_specials,
-        item_3: demon_crown_specials,
-        item_4: silk_robe_specials,
-        item_5: silver_ring_specials,
-        item_6: ghost_wand_specials,
-        item_7: leather_gloves_specials,
-        item_8: silk_gloves_specials,
-        item_9: linen_gloves_specials,
-        item_10: crown_specials,
-        mutated: false
-    };
-
-    // initialize special storage 2 with remaining 9 items
-    let storage2 = ItemSpecialsStorage {
-        item_1: divine_slippers_specials,
-        item_2: warhammer_specials,
-        item_3: ancient_helm_specials,
-        item_4: divine_robe_specials,
-        item_5: holy_chestplate_specials,
-        item_6: holy_greaves_specials,
-        item_7: demonhide_boots_specials,
-        item_8: holy_gauntlets_specials,
-        item_9: demonhide_boots_specials,
-        item_10: ItemSpecials { // no item 10 in storage2
-         special1: 0, special2: 0, special3: 0 },
-        mutated: false
-    };
-
-    // assert calling get_special for each item returns the expected specials
-    // we use PartialEq for comparision so if any of the attributes of ItemSpecials are
-    // different the assert will fail
-    assert(storage1.get_specials(wand) == wand_specials, 'wrong wand specials');
-    assert(storage1.get_specials(katana) == katana_specials, 'wrong katana specials');
-    assert(
-        storage1.get_specials(demon_crown) == demon_crown_specials, 'wrong demon crown specials'
-    );
-    assert(storage1.get_specials(silk_robe) == silk_robe_specials, 'wrong silk robe specials');
-    assert(
-        storage1.get_specials(silver_ring) == silver_ring_specials, 'wrong silver ring specials'
-    );
-    assert(storage1.get_specials(ghost_wand) == ghost_wand_specials, 'wrong ghost wand specials');
-    assert(
-        storage1.get_specials(leather_gloves) == leather_gloves_specials,
-        'wrong leather gloves specials'
-    );
-    assert(
-        storage1.get_specials(silk_gloves) == silk_gloves_specials, 'wrong silk gloves specials'
-    );
-    assert(
-        storage1.get_specials(linen_gloves) == linen_gloves_specials, 'wrong linen gloves specials'
-    );
-    assert(storage1.get_specials(crown) == crown_specials, 'wrong crown specials');
-    assert(
-        storage2.get_specials(divine_slippers) == divine_slippers_specials,
-        'wrong divine slippers specials'
-    );
-    assert(storage2.get_specials(warhammer) == warhammer_specials, 'wrong warhammer specials');
-    assert(
-        storage2.get_specials(ancient_helm) == ancient_helm_specials, 'wrong ancient helm specials'
-    );
-    assert(
-        storage2.get_specials(divine_robe) == divine_robe_specials, 'wrong divine robe specials'
-    );
-    assert(
-        storage2.get_specials(holy_chestplate) == holy_chestplate_specials,
-        'wrong holy chestplate specials'
-    );
-    assert(
-        storage2.get_specials(holy_greaves) == holy_greaves_specials, 'wrong holy greaves specials'
-    );
-    assert(
-        storage2.get_specials(demonhide_boots) == demonhide_boots_specials,
-        'wrong demonhide boots specials'
-    );
-    assert(
-        storage2.get_specials(holy_gauntlets) == holy_gauntlets_specials,
-        'wrong holy gauntlets specials'
-    );
-    assert(
-        storage2.get_specials(demonhide_boots) == demonhide_boots_specials,
-        'wrong demonhide boots specials'
-    );
-}
-
-#[test]
-#[should_panic(expected: ('item specials not in storage',))]
-#[available_gas(30000)]
-fn test_get_specials_overflow_fail() {
-    // initialize ItemSpecialsStorage with all empty ItemSpecials
-    // as we don't need them for this test
-    let name_storage1 = ItemSpecialsStorage {
-        item_1: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_2: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_3: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_4: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_5: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_6: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_7: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_8: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_9: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_10: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        mutated: false
-    };
-
-    // initialze an item whose meta data exceeds the max storage slot for the special storage
-    let meta_data_id = STORAGE::MAX_TOTAL_STORAGE_SPECIALS + 1;
-    let item_11 = ItemPrimitive { id: 10, xp: 1, metadata: meta_data_id };
-
-    // attempt to get specials for this item
-    // this should throw a panic with the error 'metadata id out of bounds'
-    // this test is annotated to expect this error and will fail
-    // if it is not thrown
-    let meta_data = name_storage1.get_specials(item_11);
-}
-
-#[test]
-#[should_panic(expected: ('item specials not in storage',))]
-#[available_gas(30000)]
-fn test_get_specials_zero_fail() {
-    // initialize ItemSpecialsStorage with all empty ItemSpecials
-    // as we don't need them for this test
-    let name_storage1 = ItemSpecialsStorage {
-        item_1: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_2: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_3: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_4: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_5: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_6: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_7: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_8: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_9: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_10: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        mutated: false
-    };
-
-    // initialze an item whose meta data exceeds the max storage slot for the special storage
-    let meta_data_id_zero = 0;
-    let item_11 = ItemPrimitive { id: 10, xp: 1, metadata: meta_data_id_zero };
-
-    // attempt to get specials for this item which has meta data id 0
-    // this should throw a panic with the error 'metadata id out of bounds'
-    // this test is annotated to expect this error
-    let meta_data = name_storage1.get_specials(item_11);
-}
-
-#[test]
-#[available_gas(600000)]
-fn test_set_specials() {
-    let mut storage1 = ItemSpecialsStorage {
-        item_1: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_2: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_3: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_4: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_5: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_6: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_7: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_8: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_9: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_10: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        mutated: false
-    };
-
-    let mut storage2 = ItemSpecialsStorage {
-        item_1: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_2: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_3: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_4: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_5: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_6: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_7: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_8: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_9: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        item_10: ItemSpecials { special2: 0, special3: 0, special1: 0, },
-        mutated: false
-    };
-
-    // Storage 1 Tests
-    let wand = ItemPrimitive { id: ItemId::Wand, xp: 0, metadata: 1 };
-    let wand_specials = ItemSpecials { special2: 12, special3: 2, special1: 5 };
-    storage1.set_specials(wand, wand_specials);
-    assert(storage1.item_1 == wand_specials, 'wand set specials error');
-
-    let katana = ItemPrimitive { id: ItemId::Wand, xp: 0, metadata: 2 };
-    let katana_specials = ItemSpecials { special2: 1, special3: 2, special1: 3 };
-    storage1.set_specials(katana, katana_specials);
-    assert(storage1.item_2 == katana_specials, 'katana set specials error');
-
-    let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 0, metadata: 3 };
-    let demon_crown_specials = ItemSpecials { special2: 2, special3: 3, special1: 4 };
-    storage1.set_specials(demon_crown, demon_crown_specials);
-    assert(storage1.item_3 == demon_crown_specials, 'demon crown set specials error');
-
-    let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 0, metadata: 4 };
-    let silk_robe_specials = ItemSpecials { special2: 3, special3: 4, special1: 5 };
-    storage1.set_specials(silk_robe, silk_robe_specials);
-    assert(storage1.item_4 == silk_robe_specials, 'silk robe set specials error');
-
-    let brightsilk_sash = ItemPrimitive { id: ItemId::BrightsilkSash, xp: 0, metadata: 5 };
-    let brightsilk_sash_specials = ItemSpecials { special2: 4, special3: 5, special1: 6 };
-    storage1.set_specials(brightsilk_sash, brightsilk_sash_specials);
-    assert(storage1.item_5 == brightsilk_sash_specials, 'sash set specials error');
-
-    let divine_gloves = ItemPrimitive { id: ItemId::DivineGloves, xp: 0, metadata: 6 };
-    let divine_gloves_specials = ItemSpecials { special2: 5, special3: 6, special1: 7 };
-    storage1.set_specials(divine_gloves, divine_gloves_specials);
-    assert(storage1.item_6 == divine_gloves_specials, 'divine gloves set specials err');
-
-    let shoes = ItemPrimitive { id: ItemId::Shoes, xp: 0, metadata: 7 };
-    let shoes_specials = ItemSpecials { special2: 6, special3: 7, special1: 8 };
-    storage1.set_specials(shoes, shoes_specials);
-    assert(storage1.item_7 == shoes_specials, 'shoes set specials error');
-
-    let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 0, metadata: 8 };
-    let silver_ring_specials = ItemSpecials { special2: 4, special3: 5, special1: 6 };
-    storage1.set_specials(silver_ring, silver_ring_specials);
-    assert(storage1.item_5 == silver_ring_specials, 'silver ring set specials error');
-
-    let necklace = ItemPrimitive { id: ItemId::Necklace, xp: 0, metadata: 9 };
-    let necklace_specials = ItemSpecials { special2: 8, special3: 9, special1: 10 };
-    storage1.set_specials(necklace, necklace_specials);
-    assert(storage1.item_9 == necklace_specials, 'necklace set specials error');
-
-    let linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 0, metadata: 10 };
-    let linen_gloves_specials = ItemSpecials { special2: 9, special3: 10, special1: 11 };
-    storage1.set_specials(linen_gloves, linen_gloves_specials);
-    assert(storage1.item_10 == linen_gloves_specials, 'linen gloves set specials error');
-
-    // Repeat for Storage 2 with meta data ids in the 11-19 range
-    let wand = ItemPrimitive { id: ItemId::Wand, xp: 0, metadata: 11 };
-    let wand_specials = ItemSpecials { special2: 12, special3: 2, special1: 5 };
-    storage2.set_specials(wand, wand_specials);
-    assert(storage2.item_1 == wand_specials, 'wand set specials error');
-
-    let katana = ItemPrimitive { id: ItemId::Wand, xp: 0, metadata: 12 };
-    let katana_specials = ItemSpecials { special2: 1, special3: 2, special1: 3 };
-    storage2.set_specials(katana, katana_specials);
-    assert(storage2.item_2 == katana_specials, 'katana set specials error');
-
-    let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 0, metadata: 13 };
-    let demon_crown_specials = ItemSpecials { special2: 2, special3: 3, special1: 4 };
-    storage2.set_specials(demon_crown, demon_crown_specials);
-    assert(storage2.item_3 == demon_crown_specials, 'demon crown set specials error');
-
-    let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 0, metadata: 14 };
-    let silk_robe_specials = ItemSpecials { special2: 3, special3: 4, special1: 5 };
-    storage2.set_specials(silk_robe, silk_robe_specials);
-    assert(storage2.item_4 == silk_robe_specials, 'silk robe set specials error');
-
-    let brightsilk_sash = ItemPrimitive { id: ItemId::BrightsilkSash, xp: 0, metadata: 15 };
-    let brightsilk_sash_specials = ItemSpecials { special2: 4, special3: 5, special1: 6 };
-    storage2.set_specials(brightsilk_sash, brightsilk_sash_specials);
-    assert(storage2.item_5 == brightsilk_sash_specials, 'sash set specials error');
-
-    let divine_gloves = ItemPrimitive { id: ItemId::DivineGloves, xp: 0, metadata: 16 };
-    let divine_gloves_specials = ItemSpecials { special2: 5, special3: 6, special1: 7 };
-    storage2.set_specials(divine_gloves, divine_gloves_specials);
-    assert(storage2.item_6 == divine_gloves_specials, 'divine gloves set specials err');
-
-    let shoes = ItemPrimitive { id: ItemId::Shoes, xp: 0, metadata: 17 };
-    let shoes_specials = ItemSpecials { special2: 6, special3: 7, special1: 8 };
-    storage2.set_specials(shoes, shoes_specials);
-    assert(storage2.item_7 == shoes_specials, 'shoes set specials error');
-
-    let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 0, metadata: 18 };
-    let silver_ring_specials = ItemSpecials { special2: 4, special3: 5, special1: 6 };
-    storage2.set_specials(silver_ring, silver_ring_specials);
-    assert(storage2.item_5 == silver_ring_specials, 'silver ring set specials error');
-
-    let necklace = ItemPrimitive { id: ItemId::Necklace, xp: 0, metadata: 19 };
-    let necklace_specials = ItemSpecials { special2: 8, special3: 9, special1: 10 };
-    storage2.set_specials(necklace, necklace_specials);
-    assert(storage2.item_9 == necklace_specials, 'necklace set specials error');
-}
-
-#[test]
-#[should_panic(expected: ('meta data id not in storage',))]
-#[available_gas(40000)]
-fn test_set_specials_storage_zero_fail() {
-    // initialize ItemSpecialsStorage with all empty ItemSpecials
-    // as we don't need them for this test
-    let mut name_storage1 = ItemSpecialsStorage {
-        item_1: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_2: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_3: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_4: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_5: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_6: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_7: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_8: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_9: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_10: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        mutated: false
-    };
-
-    // initialze an item with meta data id zero
-    let meta_data_zero = 0;
-    let item_11 = ItemPrimitive { id: 10, xp: 1, metadata: meta_data_zero };
-    let item_11_specials = ItemSpecials { special2: 1, special3: 1, special1: 1 };
-
-    // attempt to set specials for an item with meta data id zero
-    // since this is not possible, we expect set_specials to panic
-    // with 'metadata id out of bounds'
-    let meta_data = name_storage1.set_specials(item_11, item_11_specials);
-}
-
-#[test]
-#[should_panic(expected: ('meta data id not in storage',))]
-#[available_gas(40000)]
-fn test_set_specials_storage_overflow_fail() {
-    // initialize ItemSpecialsStorage with all empty ItemSpecials
-    // as we don't need them for this test
-    let mut name_storage1 = ItemSpecialsStorage {
-        item_1: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_2: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_3: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_4: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_5: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_6: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_7: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_8: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_9: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        item_10: ItemSpecials { special2: 0, special3: 0, special1: 0 },
-        mutated: false
-    };
-
-    // initialze an item whose meta data exceeds the max storage slot for the special storage
-    let meta_data_id = STORAGE::MAX_TOTAL_STORAGE_SPECIALS + 1;
-    let item_11 = ItemPrimitive { id: 10, xp: 1, metadata: meta_data_id };
-    let item_11_specials = ItemSpecials { special2: 1, special3: 1, special1: 1 };
-
-    // attempt to set specials for this item which is not possible because
-    // it's meta data exceeds the max storage slot for the special storage system
-    // this should throw a panic with the error 'metadata id out of bounds'
-    // this test is annotated to expect this error
-    let meta_data = name_storage1.set_specials(item_11, item_11_specials);
+    #[test]
+    #[available_gas(3000000)]
+    fn test_item_meta_packing() {
+        // initailize ItemSpecialsStorage with strategic test values
+        let storage = ItemSpecialsStorage {
+            item_1: ItemSpecials { special1: 0, special2: 0, special3: 0 // zero case
+             },
+            item_2: ItemSpecials { special1: 1, special2: 2, special3: 3 // uniqueness
+             },
+            item_3: ItemSpecials { special1: 4, special2: 4, special3: 4 // all same
+             },
+            item_4: ItemSpecials {
+                special1: 15, special2: 127, special3: 31 // max packable values
+            },
+            item_5: ItemSpecials { special1: 255, special2: 255, special3: 255 // max u8 values
+             },
+            item_6: ItemSpecials { special1: 5, special2: 5, special3: 5 // dnc
+             },
+            item_7: ItemSpecials { special1: 6, special2: 6, special3: 6 // dnc
+             },
+            item_8: ItemSpecials { special1: 7, special2: 7, special3: 7 // dnc
+             },
+            item_9: ItemSpecials { special1: 8, special2: 8, special3: 8 // dnc
+             },
+            item_10: ItemSpecials { special1: 9, special2: 9, special3: 9 // dnc
+             },
+            mutated: false,
+        };
+
+        // pack and then unpack the specials
+        let unpacked: ItemSpecialsStorage = Packing::unpack(storage.pack());
+
+        // assert the values were not altered using PartialEq
+        assert(unpacked.item_1 == storage.item_1, 'item 1 packing error');
+        assert(unpacked.item_2 == storage.item_2, 'item 2 packing error');
+        assert(unpacked.item_3 == storage.item_3, 'item 3 packing error');
+        assert(unpacked.item_4 == storage.item_4, 'item 4 packing error');
+        assert(unpacked.item_6 == storage.item_6, 'item 6 packing error');
+        assert(unpacked.item_7 == storage.item_7, 'item 7 packing error');
+        assert(unpacked.item_8 == storage.item_8, 'item 8 packing error');
+        assert(unpacked.item_9 == storage.item_9, 'item 9 packing error');
+        assert(unpacked.item_10 == storage.item_10, 'item 10 packing error');
+
+        // item 5 is special in that it attempts to overflow the packing
+        // assert the packing overflow protection works and instead of
+        // overflowing, sets these values to max
+        assert(unpacked.item_5.special1 == MAX_SPECIAL1, 'special1 max u8 check');
+        assert(unpacked.item_5.special2 == MAX_SPECIAL2, 'special2 max u8 check');
+        assert(unpacked.item_5.special3 == MAX_SPECIAL3, 'special3 max u8 check');
+    }
+
+    #[test]
+    #[available_gas(4000000)]
+    fn test_set_metadata_id() {
+        // start test with a new adventurer wielding a wand
+        let mut adventurer = ImplAdventurer::new(
+            12,
+            1,
+            Stats {
+                strength: 1, dexterity: 1, vitality: 1, intelligence: 1, wisdom: 1, charisma: 1,
+            }
+        );
+
+        // assert adventurer starter weapon has meta data id 1
+        assert(adventurer.weapon.metadata == 1, 'advntr wpn meta data shld be 1');
+
+        // generate starter wand
+        let mut starter_wand = ItemPrimitive { id: ItemId::Wand, xp: 1, metadata: 1 };
+
+        // and an empty bag
+        let mut bag = Bag {
+            item_1: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
+            item_2: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
+            item_3: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
+            item_4: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
+            item_5: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
+            item_6: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
+            item_7: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
+            item_8: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
+            item_9: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
+            item_10: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
+            item_11: ItemPrimitive { id: 0, xp: 0, metadata: 0, },
+            mutated: false
+        };
+
+        // stage a bunch of gear
+        let mut katana = ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 0 };
+        let mut demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 1, metadata: 0 };
+        let mut silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 1, metadata: 0 };
+        let mut silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 1, metadata: 0 };
+        let mut ghost_wand = ItemPrimitive { id: ItemId::GhostWand, xp: 1, metadata: 0 };
+        let mut leather_gloves = ItemPrimitive { id: ItemId::LeatherGloves, xp: 1, metadata: 0 };
+        let mut silk_gloves = ItemPrimitive { id: ItemId::SilkGloves, xp: 1, metadata: 0 };
+        let mut linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 1, metadata: 0 };
+        let mut crown = ItemPrimitive { id: ItemId::Crown, xp: 1, metadata: 0 };
+        let mut divine_slippers = ItemPrimitive { id: ItemId::DivineSlippers, xp: 1, metadata: 0 };
+        let mut warhammer = ItemPrimitive { id: ItemId::Warhammer, xp: 1, metadata: 0 };
+        let mut ancient_helm = ItemPrimitive { id: ItemId::AncientHelm, xp: 1, metadata: 0 };
+        let mut divine_robe = ItemPrimitive { id: ItemId::DivineRobe, xp: 1, metadata: 0 };
+        let mut holy_chestplate = ItemPrimitive { id: ItemId::HolyChestplate, xp: 1, metadata: 0 };
+        let mut holy_greaves = ItemPrimitive { id: ItemId::HolyGreaves, xp: 1, metadata: 0 };
+        let mut demonhide_boots = ItemPrimitive { id: ItemId::DemonhideBoots, xp: 1, metadata: 0 };
+        let mut holy_gauntlets = ItemPrimitive { id: ItemId::HolyGauntlets, xp: 1, metadata: 0 };
+        let mut demonhide_belt = ItemPrimitive { id: ItemId::DemonhideBelt, xp: 1, metadata: 0 };
+
+        // get next available specials storage slot
+        // this should result is the meta data is incrementing for each item
+        katana.set_metadata_id(adventurer, bag);
+        adventurer.equip_item(katana);
+        assert(katana.metadata == 2, 'wrong katana metadata');
+
+        demon_crown.set_metadata_id(adventurer, bag);
+        adventurer.equip_item(demon_crown);
+        assert(demon_crown.metadata == 3, 'wrong demon crown metadata');
+
+        silk_robe.set_metadata_id(adventurer, bag);
+        adventurer.equip_item(silk_robe);
+        assert(silk_robe.metadata == 4, 'wrong silk robe metadata');
+
+        silver_ring.set_metadata_id(adventurer, bag);
+        adventurer.equip_item(silver_ring);
+        assert(silver_ring.metadata == 5, 'wrong silver ring metadata');
+
+        ghost_wand.set_metadata_id(adventurer, bag);
+        bag.add_item(katana);
+        adventurer.equip_item(ghost_wand);
+        assert(ghost_wand.metadata == 6, 'wrong ghost wand metadata');
+
+        leather_gloves.set_metadata_id(adventurer, bag);
+        adventurer.equip_item(leather_gloves);
+        assert(leather_gloves.metadata == 7, 'wrong leather gloves metadata');
+
+        silk_gloves.set_metadata_id(adventurer, bag);
+        bag.add_item(leather_gloves);
+        adventurer.equip_item(silk_gloves);
+        assert(silk_gloves.metadata == 8, 'wrong silk gloves metadata');
+
+        linen_gloves.set_metadata_id(adventurer, bag);
+        bag.add_item(silk_gloves);
+        adventurer.equip_item(linen_gloves);
+        assert(linen_gloves.metadata == 9, 'wrong linen gloves metadata');
+
+        crown.set_metadata_id(adventurer, bag);
+        bag.add_item(demon_crown);
+        adventurer.equip_item(crown);
+        assert(crown.metadata == 10, 'wrong crown metadata');
+
+        divine_slippers.set_metadata_id(adventurer, bag);
+        adventurer.equip_item(divine_slippers);
+        assert(divine_slippers.metadata == 11, 'wrong divine slippers metadata');
+
+        warhammer.set_metadata_id(adventurer, bag);
+        bag.add_item(ghost_wand);
+        adventurer.equip_item(warhammer);
+        assert(warhammer.metadata == 12, 'wrong warhammer metadata');
+
+        ancient_helm.set_metadata_id(adventurer, bag);
+        bag.add_item(crown);
+        adventurer.equip_item(ancient_helm);
+        assert(ancient_helm.metadata == 13, 'wrong ancient helm metadata');
+
+        divine_robe.set_metadata_id(adventurer, bag);
+        bag.add_item(silk_robe);
+        adventurer.equip_item(divine_robe);
+        assert(divine_robe.metadata == 14, 'wrong divine robe metadata');
+
+        holy_chestplate.set_metadata_id(adventurer, bag);
+        bag.add_item(divine_robe);
+        adventurer.equip_item(holy_chestplate);
+        assert(holy_chestplate.metadata == 15, 'wrong holy chestplate metadata');
+
+        holy_greaves.set_metadata_id(adventurer, bag);
+        bag.add_item(divine_slippers);
+        adventurer.equip_item(holy_greaves);
+        assert(holy_greaves.metadata == 16, 'wrong holy greaves metadata');
+
+        demonhide_boots.set_metadata_id(adventurer, bag);
+        bag.add_item(holy_greaves);
+        adventurer.equip_item(demonhide_boots);
+        assert(demonhide_boots.metadata == 17, 'wrong demonhide boots metadata');
+
+        holy_gauntlets.set_metadata_id(adventurer, bag);
+        bag.add_item(linen_gloves);
+        adventurer.equip_item(holy_gauntlets);
+        assert(holy_gauntlets.metadata == 18, 'wrong holy gauntlets metadata');
+
+        demonhide_belt.set_metadata_id(adventurer, bag);
+        adventurer.equip_item(demonhide_belt);
+        assert(demonhide_belt.metadata == 19, 'wrong demonhide belts metadata');
+
+        // do one final pass to make sure none of the meta data got
+        // altered during equipment swap operations
+        assert(katana.metadata == 2, 'wrong katana metadata');
+        assert(demon_crown.metadata == 3, 'wrong demon crown metadata');
+        assert(silk_robe.metadata == 4, 'wrong silk robe metadata');
+        assert(silver_ring.metadata == 5, 'wrong silver ring metadata');
+        assert(ghost_wand.metadata == 6, 'wrong ghost wand metadata');
+        assert(leather_gloves.metadata == 7, 'wrong leather gloves metadata');
+        assert(silk_gloves.metadata == 8, 'wrong silk gloves metadata');
+        assert(linen_gloves.metadata == 9, 'wrong linen gloves metadata');
+        assert(crown.metadata == 10, 'wrong crown metadata');
+        assert(divine_slippers.metadata == 11, 'wrong divine slippers metadata');
+        assert(warhammer.metadata == 12, 'wrong warhammer metadata');
+        assert(ancient_helm.metadata == 13, 'wrong ancient helm metadata');
+        assert(divine_robe.metadata == 14, 'wrong divine robe metadata');
+        assert(holy_chestplate.metadata == 15, 'wrong holy chestplate metadata');
+        assert(holy_greaves.metadata == 16, 'wrong holy greaves metadata');
+        assert(demonhide_boots.metadata == 17, 'wrong demonhide boots metadata');
+        assert(holy_gauntlets.metadata == 18, 'wrong holy gauntlets metadata');
+    }
+
+    #[test]
+    #[available_gas(500000)]
+    fn test_get_specials() {
+        // create 19 items to be used for the test
+        let wand = ItemPrimitive { id: ItemId::Wand, xp: 1, metadata: 1 };
+        let katana = ItemPrimitive { id: ItemId::Katana, xp: 1, metadata: 2 };
+        let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 1, metadata: 3 };
+        let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 1, metadata: 4 };
+        let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 1, metadata: 5 };
+        let ghost_wand = ItemPrimitive { id: ItemId::GhostWand, xp: 1, metadata: 6 };
+        let leather_gloves = ItemPrimitive { id: ItemId::LeatherGloves, xp: 1, metadata: 7 };
+        let silk_gloves = ItemPrimitive { id: ItemId::SilkGloves, xp: 1, metadata: 8 };
+        let linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 1, metadata: 9 };
+        let crown = ItemPrimitive { id: ItemId::Crown, xp: 1, metadata: 10 };
+        let divine_slippers = ItemPrimitive { id: ItemId::DivineSlippers, xp: 1, metadata: 11 };
+        let warhammer = ItemPrimitive { id: ItemId::Warhammer, xp: 1, metadata: 12 };
+        let ancient_helm = ItemPrimitive { id: ItemId::AncientHelm, xp: 1, metadata: 13 };
+        let divine_robe = ItemPrimitive { id: ItemId::DivineRobe, xp: 1, metadata: 14 };
+        let holy_chestplate = ItemPrimitive { id: ItemId::HolyChestplate, xp: 1, metadata: 15 };
+        let holy_greaves = ItemPrimitive { id: ItemId::HolyGreaves, xp: 1, metadata: 16 };
+        let demonhide_boots = ItemPrimitive { id: ItemId::DemonhideBoots, xp: 1, metadata: 17 };
+        let holy_gauntlets = ItemPrimitive { id: ItemId::HolyGauntlets, xp: 1, metadata: 18 };
+        let demonhide_boots = ItemPrimitive { id: ItemId::DemonhideBoots, xp: 1, metadata: 19 };
+
+        // generate unique specials for each item
+        let wand_specials = ItemSpecials { special1: 1, special2: 1, special3: 1 };
+        let katana_specials = ItemSpecials { special1: 2, special2: 2, special3: 2 };
+        let demon_crown_specials = ItemSpecials { special1: 3, special2: 3, special3: 3 };
+        let silk_robe_specials = ItemSpecials { special1: 4, special2: 4, special3: 4 };
+        let silver_ring_specials = ItemSpecials { special1: 5, special2: 5, special3: 5 };
+        let ghost_wand_specials = ItemSpecials { special1: 6, special2: 6, special3: 6 };
+        let leather_gloves_specials = ItemSpecials { special1: 7, special2: 7, special3: 7 };
+        let silk_gloves_specials = ItemSpecials { special1: 8, special2: 8, special3: 8 };
+        let linen_gloves_specials = ItemSpecials { special1: 9, special2: 9, special3: 9 };
+        let crown_specials = ItemSpecials { special1: 10, special2: 10, special3: 10 };
+        let divine_slippers_specials = ItemSpecials { special1: 11, special2: 11, special3: 11 };
+        let warhammer_specials = ItemSpecials { special1: 12, special2: 12, special3: 12 };
+        let ancient_helm_specials = ItemSpecials { special1: 13, special2: 13, special3: 13 };
+        let divine_robe_specials = ItemSpecials { special1: 14, special2: 14, special3: 14 };
+        let holy_chestplate_specials = ItemSpecials { special1: 15, special2: 15, special3: 15 };
+        let holy_greaves_specials = ItemSpecials { special1: 1, special2: 16, special3: 16 };
+        let demonhide_boots_specials = ItemSpecials { special1: 2, special2: 17, special3: 17 };
+        let holy_gauntlets_specials = ItemSpecials { special1: 3, special2: 18, special3: 18 };
+        let demonhide_boots_specials = ItemSpecials { special1: 4, special2: 19, special3: 19 };
+
+        // initialize special storage 1 with first 10 items
+        let storage1 = ItemSpecialsStorage {
+            item_1: wand_specials,
+            item_2: katana_specials,
+            item_3: demon_crown_specials,
+            item_4: silk_robe_specials,
+            item_5: silver_ring_specials,
+            item_6: ghost_wand_specials,
+            item_7: leather_gloves_specials,
+            item_8: silk_gloves_specials,
+            item_9: linen_gloves_specials,
+            item_10: crown_specials,
+            mutated: false
+        };
+
+        // initialize special storage 2 with remaining 9 items
+        let storage2 = ItemSpecialsStorage {
+            item_1: divine_slippers_specials,
+            item_2: warhammer_specials,
+            item_3: ancient_helm_specials,
+            item_4: divine_robe_specials,
+            item_5: holy_chestplate_specials,
+            item_6: holy_greaves_specials,
+            item_7: demonhide_boots_specials,
+            item_8: holy_gauntlets_specials,
+            item_9: demonhide_boots_specials,
+            item_10: ItemSpecials { // no item 10 in storage2
+                special1: 0, special2: 0, special3: 0
+            },
+            mutated: false
+        };
+
+        // assert calling get_special for each item returns the expected specials
+        // we use PartialEq for comparision so if any of the attributes of ItemSpecials are
+        // different the assert will fail
+        assert(storage1.get_specials(wand) == wand_specials, 'wrong wand specials');
+        assert(storage1.get_specials(katana) == katana_specials, 'wrong katana specials');
+        assert(
+            storage1.get_specials(demon_crown) == demon_crown_specials, 'wrong demon crown specials'
+        );
+        assert(storage1.get_specials(silk_robe) == silk_robe_specials, 'wrong silk robe specials');
+        assert(
+            storage1.get_specials(silver_ring) == silver_ring_specials, 'wrong silver ring specials'
+        );
+        assert(
+            storage1.get_specials(ghost_wand) == ghost_wand_specials, 'wrong ghost wand specials'
+        );
+        assert(
+            storage1.get_specials(leather_gloves) == leather_gloves_specials,
+            'wrong leather gloves specials'
+        );
+        assert(
+            storage1.get_specials(silk_gloves) == silk_gloves_specials, 'wrong silk gloves specials'
+        );
+        assert(
+            storage1.get_specials(linen_gloves) == linen_gloves_specials,
+            'wrong linen gloves specials'
+        );
+        assert(storage1.get_specials(crown) == crown_specials, 'wrong crown specials');
+        assert(
+            storage2.get_specials(divine_slippers) == divine_slippers_specials,
+            'wrong divine slippers specials'
+        );
+        assert(storage2.get_specials(warhammer) == warhammer_specials, 'wrong warhammer specials');
+        assert(
+            storage2.get_specials(ancient_helm) == ancient_helm_specials,
+            'wrong ancient helm specials'
+        );
+        assert(
+            storage2.get_specials(divine_robe) == divine_robe_specials, 'wrong divine robe specials'
+        );
+        assert(
+            storage2.get_specials(holy_chestplate) == holy_chestplate_specials,
+            'wrong holy chestplate specials'
+        );
+        assert(
+            storage2.get_specials(holy_greaves) == holy_greaves_specials,
+            'wrong holy greaves specials'
+        );
+        assert(
+            storage2.get_specials(demonhide_boots) == demonhide_boots_specials,
+            'wrong demonhide boots specials'
+        );
+        assert(
+            storage2.get_specials(holy_gauntlets) == holy_gauntlets_specials,
+            'wrong holy gauntlets specials'
+        );
+        assert(
+            storage2.get_specials(demonhide_boots) == demonhide_boots_specials,
+            'wrong demonhide boots specials'
+        );
+    }
+
+    #[test]
+    #[should_panic(expected: ('item specials not in storage',))]
+    #[available_gas(30000)]
+    fn test_get_specials_overflow_fail() {
+        // initialize ItemSpecialsStorage with all empty ItemSpecials
+        // as we don't need them for this test
+        let name_storage1 = ItemSpecialsStorage {
+            item_1: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_2: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_3: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_4: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_5: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_6: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_7: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_8: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_9: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_10: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            mutated: false
+        };
+
+        // initialze an item whose meta data exceeds the max storage slot for the special storage
+        let meta_data_id = STORAGE::MAX_TOTAL_STORAGE_SPECIALS + 1;
+        let item_11 = ItemPrimitive { id: 10, xp: 1, metadata: meta_data_id };
+
+        // attempt to get specials for this item
+        // this should throw a panic with the error 'metadata id out of bounds'
+        // this test is annotated to expect this error and will fail
+        // if it is not thrown
+        let meta_data = name_storage1.get_specials(item_11);
+    }
+
+    #[test]
+    #[should_panic(expected: ('item specials not in storage',))]
+    #[available_gas(30000)]
+    fn test_get_specials_zero_fail() {
+        // initialize ItemSpecialsStorage with all empty ItemSpecials
+        // as we don't need them for this test
+        let name_storage1 = ItemSpecialsStorage {
+            item_1: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_2: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_3: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_4: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_5: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_6: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_7: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_8: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_9: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_10: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            mutated: false
+        };
+
+        // initialze an item whose meta data exceeds the max storage slot for the special storage
+        let meta_data_id_zero = 0;
+        let item_11 = ItemPrimitive { id: 10, xp: 1, metadata: meta_data_id_zero };
+
+        // attempt to get specials for this item which has meta data id 0
+        // this should throw a panic with the error 'metadata id out of bounds'
+        // this test is annotated to expect this error
+        let meta_data = name_storage1.get_specials(item_11);
+    }
+
+    #[test]
+    #[available_gas(600000)]
+    fn test_set_specials() {
+        let mut storage1 = ItemSpecialsStorage {
+            item_1: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_2: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_3: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_4: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_5: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_6: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_7: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_8: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_9: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_10: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            mutated: false
+        };
+
+        let mut storage2 = ItemSpecialsStorage {
+            item_1: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_2: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_3: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_4: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_5: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_6: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_7: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_8: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_9: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            item_10: ItemSpecials { special2: 0, special3: 0, special1: 0, },
+            mutated: false
+        };
+
+        // Storage 1 Tests
+        let wand = ItemPrimitive { id: ItemId::Wand, xp: 0, metadata: 1 };
+        let wand_specials = ItemSpecials { special2: 12, special3: 2, special1: 5 };
+        storage1.set_specials(wand, wand_specials);
+        assert(storage1.item_1 == wand_specials, 'wand set specials error');
+
+        let katana = ItemPrimitive { id: ItemId::Wand, xp: 0, metadata: 2 };
+        let katana_specials = ItemSpecials { special2: 1, special3: 2, special1: 3 };
+        storage1.set_specials(katana, katana_specials);
+        assert(storage1.item_2 == katana_specials, 'katana set specials error');
+
+        let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 0, metadata: 3 };
+        let demon_crown_specials = ItemSpecials { special2: 2, special3: 3, special1: 4 };
+        storage1.set_specials(demon_crown, demon_crown_specials);
+        assert(storage1.item_3 == demon_crown_specials, 'demon crown set specials error');
+
+        let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 0, metadata: 4 };
+        let silk_robe_specials = ItemSpecials { special2: 3, special3: 4, special1: 5 };
+        storage1.set_specials(silk_robe, silk_robe_specials);
+        assert(storage1.item_4 == silk_robe_specials, 'silk robe set specials error');
+
+        let brightsilk_sash = ItemPrimitive { id: ItemId::BrightsilkSash, xp: 0, metadata: 5 };
+        let brightsilk_sash_specials = ItemSpecials { special2: 4, special3: 5, special1: 6 };
+        storage1.set_specials(brightsilk_sash, brightsilk_sash_specials);
+        assert(storage1.item_5 == brightsilk_sash_specials, 'sash set specials error');
+
+        let divine_gloves = ItemPrimitive { id: ItemId::DivineGloves, xp: 0, metadata: 6 };
+        let divine_gloves_specials = ItemSpecials { special2: 5, special3: 6, special1: 7 };
+        storage1.set_specials(divine_gloves, divine_gloves_specials);
+        assert(storage1.item_6 == divine_gloves_specials, 'divine gloves set specials err');
+
+        let shoes = ItemPrimitive { id: ItemId::Shoes, xp: 0, metadata: 7 };
+        let shoes_specials = ItemSpecials { special2: 6, special3: 7, special1: 8 };
+        storage1.set_specials(shoes, shoes_specials);
+        assert(storage1.item_7 == shoes_specials, 'shoes set specials error');
+
+        let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 0, metadata: 8 };
+        let silver_ring_specials = ItemSpecials { special2: 4, special3: 5, special1: 6 };
+        storage1.set_specials(silver_ring, silver_ring_specials);
+        assert(storage1.item_5 == silver_ring_specials, 'silver ring set specials error');
+
+        let necklace = ItemPrimitive { id: ItemId::Necklace, xp: 0, metadata: 9 };
+        let necklace_specials = ItemSpecials { special2: 8, special3: 9, special1: 10 };
+        storage1.set_specials(necklace, necklace_specials);
+        assert(storage1.item_9 == necklace_specials, 'necklace set specials error');
+
+        let linen_gloves = ItemPrimitive { id: ItemId::LinenGloves, xp: 0, metadata: 10 };
+        let linen_gloves_specials = ItemSpecials { special2: 9, special3: 10, special1: 11 };
+        storage1.set_specials(linen_gloves, linen_gloves_specials);
+        assert(storage1.item_10 == linen_gloves_specials, 'linen gloves set specials error');
+
+        // Repeat for Storage 2 with meta data ids in the 11-19 range
+        let wand = ItemPrimitive { id: ItemId::Wand, xp: 0, metadata: 11 };
+        let wand_specials = ItemSpecials { special2: 12, special3: 2, special1: 5 };
+        storage2.set_specials(wand, wand_specials);
+        assert(storage2.item_1 == wand_specials, 'wand set specials error');
+
+        let katana = ItemPrimitive { id: ItemId::Wand, xp: 0, metadata: 12 };
+        let katana_specials = ItemSpecials { special2: 1, special3: 2, special1: 3 };
+        storage2.set_specials(katana, katana_specials);
+        assert(storage2.item_2 == katana_specials, 'katana set specials error');
+
+        let demon_crown = ItemPrimitive { id: ItemId::DemonCrown, xp: 0, metadata: 13 };
+        let demon_crown_specials = ItemSpecials { special2: 2, special3: 3, special1: 4 };
+        storage2.set_specials(demon_crown, demon_crown_specials);
+        assert(storage2.item_3 == demon_crown_specials, 'demon crown set specials error');
+
+        let silk_robe = ItemPrimitive { id: ItemId::SilkRobe, xp: 0, metadata: 14 };
+        let silk_robe_specials = ItemSpecials { special2: 3, special3: 4, special1: 5 };
+        storage2.set_specials(silk_robe, silk_robe_specials);
+        assert(storage2.item_4 == silk_robe_specials, 'silk robe set specials error');
+
+        let brightsilk_sash = ItemPrimitive { id: ItemId::BrightsilkSash, xp: 0, metadata: 15 };
+        let brightsilk_sash_specials = ItemSpecials { special2: 4, special3: 5, special1: 6 };
+        storage2.set_specials(brightsilk_sash, brightsilk_sash_specials);
+        assert(storage2.item_5 == brightsilk_sash_specials, 'sash set specials error');
+
+        let divine_gloves = ItemPrimitive { id: ItemId::DivineGloves, xp: 0, metadata: 16 };
+        let divine_gloves_specials = ItemSpecials { special2: 5, special3: 6, special1: 7 };
+        storage2.set_specials(divine_gloves, divine_gloves_specials);
+        assert(storage2.item_6 == divine_gloves_specials, 'divine gloves set specials err');
+
+        let shoes = ItemPrimitive { id: ItemId::Shoes, xp: 0, metadata: 17 };
+        let shoes_specials = ItemSpecials { special2: 6, special3: 7, special1: 8 };
+        storage2.set_specials(shoes, shoes_specials);
+        assert(storage2.item_7 == shoes_specials, 'shoes set specials error');
+
+        let silver_ring = ItemPrimitive { id: ItemId::SilverRing, xp: 0, metadata: 18 };
+        let silver_ring_specials = ItemSpecials { special2: 4, special3: 5, special1: 6 };
+        storage2.set_specials(silver_ring, silver_ring_specials);
+        assert(storage2.item_5 == silver_ring_specials, 'silver ring set specials error');
+
+        let necklace = ItemPrimitive { id: ItemId::Necklace, xp: 0, metadata: 19 };
+        let necklace_specials = ItemSpecials { special2: 8, special3: 9, special1: 10 };
+        storage2.set_specials(necklace, necklace_specials);
+        assert(storage2.item_9 == necklace_specials, 'necklace set specials error');
+    }
+
+    #[test]
+    #[should_panic(expected: ('meta data id not in storage',))]
+    #[available_gas(40000)]
+    fn test_set_specials_storage_zero_fail() {
+        // initialize ItemSpecialsStorage with all empty ItemSpecials
+        // as we don't need them for this test
+        let mut name_storage1 = ItemSpecialsStorage {
+            item_1: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_2: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_3: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_4: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_5: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_6: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_7: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_8: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_9: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_10: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            mutated: false
+        };
+
+        // initialze an item with meta data id zero
+        let meta_data_zero = 0;
+        let item_11 = ItemPrimitive { id: 10, xp: 1, metadata: meta_data_zero };
+        let item_11_specials = ItemSpecials { special2: 1, special3: 1, special1: 1 };
+
+        // attempt to set specials for an item with meta data id zero
+        // since this is not possible, we expect set_specials to panic
+        // with 'metadata id out of bounds'
+        let meta_data = name_storage1.set_specials(item_11, item_11_specials);
+    }
+
+    #[test]
+    #[should_panic(expected: ('meta data id not in storage',))]
+    #[available_gas(40000)]
+    fn test_set_specials_storage_overflow_fail() {
+        // initialize ItemSpecialsStorage with all empty ItemSpecials
+        // as we don't need them for this test
+        let mut name_storage1 = ItemSpecialsStorage {
+            item_1: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_2: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_3: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_4: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_5: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_6: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_7: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_8: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_9: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            item_10: ItemSpecials { special2: 0, special3: 0, special1: 0 },
+            mutated: false
+        };
+
+        // initialze an item whose meta data exceeds the max storage slot for the special storage
+        let meta_data_id = STORAGE::MAX_TOTAL_STORAGE_SPECIALS + 1;
+        let item_11 = ItemPrimitive { id: 10, xp: 1, metadata: meta_data_id };
+        let item_11_specials = ItemSpecials { special2: 1, special3: 1, special1: 1 };
+
+        // attempt to set specials for this item which is not possible because
+        // it's meta data exceeds the max storage slot for the special storage system
+        // this should throw a panic with the error 'metadata id out of bounds'
+        // this test is annotated to expect this error
+        let meta_data = name_storage1.set_specials(item_11, item_11_specials);
+    }
 }

--- a/contracts/adventurer/src/item_primitive.cairo
+++ b/contracts/adventurer/src/item_primitive.cairo
@@ -1,6 +1,7 @@
 use option::OptionTrait;
 use traits::{TryInto, Into};
 use pack::{pack::{Packing, rshift_split}, constants::pow};
+use lootitems::loot::{ItemId};
 
 #[derive(Drop, Copy, PartialEq, Serde)] // 21 bits
 struct ItemPrimitive {
@@ -40,59 +41,125 @@ impl ImplItemPrimitive of IItemPrimitive {
     // @notice creates a new ItemPrimitive with the given id
     // @param item_id the id of the item
     // @return the new ItemPrimitive
-    fn new(item_id: u8) -> ItemPrimitive { 
+    fn new(item_id: u8) -> ItemPrimitive {
         ItemPrimitive { id: item_id, xp: 0, metadata: 0 }
+    }
+
+    #[inline(always)]
+    fn is_jewlery(self: ItemPrimitive) -> bool {
+        if (self.id == ItemId::BronzeRing) {
+            return true;
+        } else if (self.id == ItemId::SilverRing) {
+            return true;
+        } else if (self.id == ItemId::GoldRing) {
+            return true;
+        } else if (self.id == ItemId::PlatinumRing) {
+            return true;
+        } else if (self.id == ItemId::TitaniumRing) {
+            return true;
+        } else if (self.id == ItemId::Necklace) {
+            return true;
+        } else if (self.id == ItemId::Amulet) {
+            return true;
+        } else if (self.id == ItemId::Pendant) {
+            return true;
+        } else {
+            return false;
+        }
     }
 }
 
-#[test]
-#[available_gas(9000)]
-fn test_new_item() {
-    // zero case
-    let item = IItemPrimitive::new(0);
-    assert(item.id == 0, 'id should be 0');
-    assert(item.xp == 0, 'xp should be 0');
-    assert(item.metadata == 0, 'metadata should be 0');
+// ---------------------------
+// ---------- Tests ----------
+// ---------------------------
+#[cfg(test)]
+mod tests {
+    use survivor::item_primitive::{
+        ItemPrimitive, ImplItemPrimitive, ItemPrimitivePacking, IItemPrimitive
+    };
+    use lootitems::constants::{ItemId};
 
-    // base case
-    let item = IItemPrimitive::new(1);
-    assert(item.id == 1, 'id should be 1');
-    assert(item.xp == 0, 'xp should be 0');
-    assert(item.metadata == 0, 'metadata should be 0');
+    #[test]
+    #[available_gas(1893950)]
+    fn test_is_jewlery_gas() {
+        assert(!ImplItemPrimitive::new(101).is_jewlery(), 'should not be jewlery');
+    }
 
-    // max u8 case
-    let item = IItemPrimitive::new(255);
-    assert(item.id == 255, 'id should be 255');
-    assert(item.xp == 0, 'xp should be 0');
-    assert(item.metadata == 0, 'metadata should be 0');
-}
+    #[test]
+    #[available_gas(1893950)]
+    fn test_is_jewlery() {
+        let mut item_index = 1;
+        loop {
+            if item_index == 102 {
+                break;
+            }
 
-#[test]
-#[available_gas(500000)]
-fn test_item_primitive_packing() {
-    let item = ItemPrimitive { id: 1, xp: 2, metadata: 3 };
+            if (item_index == ItemId::BronzeRing
+                || item_index == ItemId::SilverRing
+                || item_index == ItemId::GoldRing
+                || item_index == ItemId::PlatinumRing
+                || item_index == ItemId::TitaniumRing
+                || item_index == ItemId::Necklace
+                || item_index == ItemId::Amulet
+                || item_index == ItemId::Pendant) {
+                assert(ImplItemPrimitive::new(item_index).is_jewlery(), 'should be jewlery')
+            } else {
+                assert(!ImplItemPrimitive::new(item_index).is_jewlery(), 'should not be jewlery');
+            }
 
-    let packed = item.pack();
-    let unpacked = ItemPrimitivePacking::unpack(packed);
+            item_index += 1;
+        };
+    }
 
-    assert(item.id == unpacked.id, 'id should be the same');
-    assert(item.xp == unpacked.xp, 'xp should be the same');
-    assert(item.metadata == unpacked.metadata, 'metadata should be the same');
+    #[test]
+    #[available_gas(9000)]
+    fn test_new_item() {
+        // zero case
+        let item = IItemPrimitive::new(0);
+        assert(item.id == 0, 'id should be 0');
+        assert(item.xp == 0, 'xp should be 0');
+        assert(item.metadata == 0, 'metadata should be 0');
 
-    // max value case
-    let item = ItemPrimitive { id: 127, xp: 511, metadata: 31 };
+        // base case
+        let item = IItemPrimitive::new(1);
+        assert(item.id == 1, 'id should be 1');
+        assert(item.xp == 0, 'xp should be 0');
+        assert(item.metadata == 0, 'metadata should be 0');
 
-    let packed = item.pack();
-    let unpacked = ItemPrimitivePacking::unpack(packed);
-    assert(item.id == unpacked.id, 'id should be the same');
-    assert(item.xp == unpacked.xp, 'xp should be the same');
-    assert(item.metadata == unpacked.metadata, 'metadata should be the same');
+        // max u8 case
+        let item = IItemPrimitive::new(255);
+        assert(item.id == 255, 'id should be 255');
+        assert(item.xp == 0, 'xp should be 0');
+        assert(item.metadata == 0, 'metadata should be 0');
+    }
 
-    // overflow case
-    let item = ItemPrimitive { id: 128, xp: 512, metadata: 32 };
-    let packed = item.pack();
-    let unpacked = ItemPrimitivePacking::unpack(packed);
-    assert(unpacked.id == 0, 'id should overflow to 0');
-    assert(unpacked.xp == 1, 'xp should overflow to 1');
-    assert(unpacked.metadata == 1, 'metadata should overflow to 1');
+    #[test]
+    #[available_gas(500000)]
+    fn test_item_primitive_packing() {
+        let item = ItemPrimitive { id: 1, xp: 2, metadata: 3 };
+
+        let packed = item.pack();
+        let unpacked = ItemPrimitivePacking::unpack(packed);
+
+        assert(item.id == unpacked.id, 'id should be the same');
+        assert(item.xp == unpacked.xp, 'xp should be the same');
+        assert(item.metadata == unpacked.metadata, 'metadata should be the same');
+
+        // max value case
+        let item = ItemPrimitive { id: 127, xp: 511, metadata: 31 };
+
+        let packed = item.pack();
+        let unpacked = ItemPrimitivePacking::unpack(packed);
+        assert(item.id == unpacked.id, 'id should be the same');
+        assert(item.xp == unpacked.xp, 'xp should be the same');
+        assert(item.metadata == unpacked.metadata, 'metadata should be the same');
+
+        // overflow case
+        let item = ItemPrimitive { id: 128, xp: 512, metadata: 32 };
+        let packed = item.pack();
+        let unpacked = ItemPrimitivePacking::unpack(packed);
+        assert(unpacked.id == 0, 'id should overflow to 0');
+        assert(unpacked.xp == 1, 'xp should overflow to 1');
+        assert(unpacked.metadata == 1, 'metadata should overflow to 1');
+    }
 }

--- a/contracts/beasts/src/beast.cairo
+++ b/contracts/beasts/src/beast.cairo
@@ -147,8 +147,9 @@ impl ImplBeast of IBeast {
         weapon: CombatSpec,
         adventurer_luck: u8,
         adventurer_strength: u8,
-        double_critical_hit: bool,
-        double_name_bonus_damage: bool,
+        critical_hit_damage_multiplier: u8,
+        name_bonus_damage_multplier: u8,
+        armor_defense_multiplier: u8,
         entropy: u128
     ) -> (u16, bool) {
         // check if the attack is a critical hit
@@ -162,8 +163,9 @@ impl ImplBeast of IBeast {
                 MINIMUM_DAMAGE,
                 adventurer_strength.into(),
                 is_critical_hit,
-                double_critical_hit,
-                double_name_bonus_damage,
+                critical_hit_damage_multiplier,
+                name_bonus_damage_multplier,
+                armor_defense_multiplier,
                 entropy
             ),
             is_critical_hit
@@ -178,8 +180,9 @@ impl ImplBeast of IBeast {
     fn counter_attack(self: Beast, armor: CombatSpec, entropy: u128) -> (u16, bool) {
         // beast have a fixed 1/6 chance of critical hit
         let is_critical_hit = (entropy % 6) == 0;
-        let double_critical_hit_damage = false;
-        let double_name_bonus_damage = false;
+        let critical_hit_damage_multplier = 1;
+        let name_bonus_damage_multplier = 1;
+        let armor_defense_multplier = 1;
 
         // delegate damage calculation to combat system
         (
@@ -189,8 +192,9 @@ impl ImplBeast of IBeast {
                 MINIMUM_DAMAGE,
                 STRENGTH_BONUS,
                 is_critical_hit,
-                double_critical_hit_damage,
-                double_name_bonus_damage,
+                critical_hit_damage_multplier,
+                name_bonus_damage_multplier,
+                armor_defense_multplier,
                 entropy
             ),
             is_critical_hit
@@ -227,11 +231,10 @@ impl ImplBeast of IBeast {
             base_reward = GOLD_REWARD_BASE_MINIMUM;
         }
 
-        // gold bonus will be based on 10% increments
+        // gold bonus will be based on 25% increments
         let bonus_base = base_reward / GOLD_REWARD_BONUS_DIVISOR;
 
-        // multiplier will be 0-10 inclusive, providing
-        // a maximum gold bonus of 100%
+        // multiplier will be 0-4 inclusive, providing a bonus range of (25%, 50%, 75%, 100%)
         let bonus_multiplier = (entropy % (1 + GOLD_REWARD_BONUS_MAX_MULTPLIER))
             .try_into()
             .unwrap();
@@ -442,7 +445,7 @@ mod tests {
     }
 
     #[test]
-    #[available_gas(500000)]
+    #[available_gas(505770)]
     fn test_attack() {
         let mut adventurer_strength = 0;
         let mut adventurer_luck = 0;
@@ -470,25 +473,25 @@ mod tests {
         };
 
         let (damage, critical_hit) = beast
-            .attack(weapon, adventurer_luck, adventurer_strength, false, false, entropy);
+            .attack(weapon, adventurer_luck, adventurer_strength, 1, 1, 1, entropy);
         assert(damage == 140, 'g20 katana ruins lvl5 goblin');
 
         // bump adventurer strength by 1 which gives a +20% on base attack damage
         // T1 G20 is 100 base HP so they gain an extra 20HP for their strength stat
         adventurer_strength = 1;
         let (damage, critical_hit) = beast
-            .attack(weapon, adventurer_luck, adventurer_strength, false, false, entropy);
+            .attack(weapon, adventurer_luck, adventurer_strength, 1, 1, 1, entropy);
         assert(damage == 160, 'strength gives extra damage');
 
         // boost luck to generate a critical hit (sorry gobblin)
         adventurer_luck = 40;
         let (damage, critical_hit) = beast
-            .attack(weapon, adventurer_luck, adventurer_strength, false, false, entropy);
+            .attack(weapon, adventurer_luck, adventurer_strength, 1, 1, 1, entropy);
         assert(damage == 235, 'critical hit gives extra damage');
 
         // rerun same attack with double critical hit enabled
         let (damage, critical_hit) = beast
-            .attack(weapon, adventurer_luck, adventurer_strength, true, false, entropy);
+            .attack(weapon, adventurer_luck, adventurer_strength, 2, 1, 1, entropy);
         assert(damage == 310, 'double critical hit damage');
     }
 

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -795,7 +795,8 @@ mod tests {
                 buy_and_equip_tested = true;
             } else {
                 // if equip was false, verify item is in bag
-                assert(bag.contains(item_purchase.item_id), 'item not in bag');
+                let (contains, _) = bag.contains(item_purchase.item_id);
+                assert(contains, 'item not in bag');
                 buy_and_bagged_tested = true;
             }
             i += 1;
@@ -951,7 +952,8 @@ mod tests {
                 break ();
             }
             // verify they are all in our bag
-            assert(bag.contains(*purchased_items_span.at(i)), 'item should be in bag');
+            let (contains, _) = bag.contains(*purchased_items_span.at(i));
+            assert(contains, 'item should be in bag');
             items_to_equip.append(*purchased_items_span.at(i));
             i += 1;
         };
@@ -971,8 +973,9 @@ mod tests {
             if i == items_to_equip.len() {
                 break ();
             }
+            let (contains, _) = bag.contains(*purchased_items_span.at(i));
             // verify they are no longer in bag
-            assert(!bag.contains(*items_to_equip.at(i)), 'item should not be in bag');
+            assert(!contains, 'item should not be in bag');
             // and equipped on the adventurer
             assert(adventurer.is_equipped(*purchased_items_span.at(i)), 'item should be equipped');
             i += 1;
@@ -1219,7 +1222,7 @@ mod tests {
     }
 
     #[test]
-    #[available_gas(128236310)]
+    #[available_gas(137119130)]
     fn test_multi_slay_adventurers() {
         let STARTING_BLOCK_NUMBER = 512;
 
@@ -1594,7 +1597,8 @@ mod tests {
         // assert adventurer has starting weapon equipped
         assert(adventurer.weapon.id != 0, 'adventurer should have weapon');
         // assert bag has the purchased item
-        assert(bag.contains(purchased_item_id), 'item should be in bag');
+        let (contains, _) = bag.contains(purchased_item_id);
+        assert(contains, 'item should be in bag');
 
         // create drop list consisting of adventurers equipped weapon and purchased item that is in bag
         let mut drop_list = ArrayTrait::<u8>::new();
@@ -1614,7 +1618,8 @@ mod tests {
         assert(adventurer.weapon.xp == 0, 'weapon should have no xp');
 
         // assert bag does not have the purchased item
-        assert(!bag.contains(purchased_item_id), 'item should not be in bag');
+        let (contains, _) = bag.contains(purchased_item_id);
+        assert(!contains, 'item should not be in bag');
     }
 
     #[test]

--- a/contracts/obstacles/src/obstacle.cairo
+++ b/contracts/obstacles/src/obstacle.cairo
@@ -114,24 +114,26 @@ impl ImplObstacle of IObstacle {
     // @param obstacle The obstacle whose damage is being calculated.
     // @param armor_combat_spec The combat specifications of the armor.
     // @param entropy A value used to introduce randomness in the damage calculation.
-    // @return The calculated damage as a 16-bit unsigned integer.
+    // @return The calculated damage as a 16-bit unsigned integer and boolean indicating if the damage was a critical hit.
     // @dev Note that critical hits are not considered for obstacles in this calculation.
-    fn get_damage(obstacle: Obstacle, armor_combat_spec: CombatSpec, entropy: u128) -> u16 {
+    fn get_damage(obstacle: Obstacle, armor_combat_spec: CombatSpec, armor_defense_bonus: u8, entropy: u128) -> (u16, bool) {
         // obstacle critical hit is always 1/6
         let is_critical_hit = (entropy % 6) == 0;
-        let double_critical_hit_damage = false;
-        let double_name_damage = false;
+        let critical_hit_damage_multplier = 1;
+        let name_bonus_damage_multplier = 1;
+        let armor_defense_multplier = 1;
 
-        ImplCombat::calculate_damage(
+        (ImplCombat::calculate_damage(
             obstacle.combat_specs,
             armor_combat_spec,
             ObstacleSettings::MINIMUM_DAMAGE,
             ObstacleSettings::DAMAGE_BOOST,
             is_critical_hit,
-            double_critical_hit_damage,
-            double_name_damage,
+            critical_hit_damage_multplier,
+            name_bonus_damage_multplier,
+            armor_defense_multplier,
             entropy
-        )
+        ), is_critical_hit)
     }
 
     // @notice get_xp_reward returns the xp reward from encountering the obstacle


### PR DESCRIPTION
* Jewlery items contribute to luck even when in bag
* Provides smaller ability for select Jewlery items prior to g20
* Bronze ring stays the same but gains from being able to contribute luck even when bagged 
** This makes it more reasonable as a starter ring that can still provide after it is upgraded and bagged
* Silver ring stays the same, providing a +20 Luck boost when equipped at G20
* Equipped Gold Ring provides 2x gold reward when defeating beasts and then 4x at g20
* Platinum Ring provides 2x discovery rewards and then 4x at g20 
** This applies to all discovery types {health, gold, xp}
* Titanium Ring provides gold equal to XP when encountering obstacles and then 2x at g20 
** By default, Adventurers do not gain Gold from Obstacles
* G20 Necklace now provides the 2x name bonus damage bonus when equipped
* G20 Pendent now provides 2x critical hit damage bonus when equipped
* G20 Amulet now provides 2x armor bonus when equipped