### PR TITLE
fixes only 10hp health for multi VIT increase

### DIFF
--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -1906,7 +1906,7 @@ mod Game {
         }
         if stat_upgrades.vitality != 0 {
             adventurer.stats.increase_vitality(stat_upgrades.vitality);
-            adventurer.increase_health(VITALITY_INSTANT_HEALTH_BONUS);
+            adventurer.increase_health(VITALITY_INSTANT_HEALTH_BONUS * stat_upgrades.vitality.into());
         }
         if stat_upgrades.intelligence != 0 {
             adventurer.stats.increase_intelligence(stat_upgrades.intelligence);


### PR DESCRIPTION
* Adventurers upgraded VIT multiple times would only receive a single 10HP health potion instead of 30HP