### PR TITLE
Gas optimizations and general code cleanup

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -956,18 +956,15 @@ impl ImplAdventurer of IAdventurer {
         specials
     }
 
-    // @notice get_beast_seed provides an entropy source that is fixed during battle
-    // it intentionally does not use global_entropy as that could change during battle and this
-    // entropy allows us to simulate a persistent battle without having to store beast
-    // details on-chain.
-    // @param self A reference to the Adventurer object which represents the adventurer.
-    // @param adventurer_entropy A number used for randomization.
+    // @notice provides a a beast seed that is fixed during battle. This function does not use 
+    // game entropy as that could change during battle resulting in the beast changing
+    // @param self A reference to the Adventurer to get the beast seed for.
+    // @param adventurer_entropy A u128 used to randomize the beast seed
     // @return Returns a number used for generated a random beast.
     fn get_beast_seed(self: Adventurer, adventurer_entropy: u128) -> u128 {
         if self.get_level() > 1 {
             let mut hash_span = ArrayTrait::new();
             hash_span.append(self.xp.into());
-            hash_span.append(self.gold.into());
             hash_span.append(adventurer_entropy.into());
             let poseidon = poseidon_hash_span(hash_span.span());
             let (d, r) = rshift_split(poseidon.into(), 340282366920938463463374607431768211455);
@@ -1409,12 +1406,12 @@ impl ImplAdventurer of IAdventurer {
     }
 
     fn get_randomness(
-        self: Adventurer, adventurer_entropy: u128, global_entropy: u128
+        self: Adventurer, adventurer_entropy: u128, game_entropy: u128
     ) -> (u128, u128) {
         let mut hash_span = ArrayTrait::<felt252>::new();
         hash_span.append(self.xp.into());
         hash_span.append(adventurer_entropy.into());
-        hash_span.append(global_entropy.into());
+        hash_span.append(game_entropy.into());
 
         let poseidon = poseidon_hash_span(hash_span.span());
         let (d, r) = rshift_split(poseidon.into(), U128_MAX.into());

--- a/contracts/adventurer/src/adventurer_meta.cairo
+++ b/contracts/adventurer/src/adventurer_meta.cairo
@@ -1,36 +1,26 @@
-use option::OptionTrait;
 use traits::{TryInto, Into};
-
 use pack::constants::pow;
 use pack::pack::{Packing, rshift_split};
 
 #[derive(Drop, Copy, Serde)]
 struct AdventurerMetadata {
     name: u128,
-    home_realm: u16,
-    class: u8,
     entropy: u128,
 }
 
 impl PackingAdventurerMetadata of Packing<AdventurerMetadata> {
     fn pack(self: AdventurerMetadata) -> felt252 {
         (self.entropy.into()
-            + self.home_realm.into() * pow::TWO_POW_128
-            + self.class.into() * pow::TWO_POW_141
-            + self.name.into() * pow::TWO_POW_145)
+            + self.name.into() * pow::TWO_POW_128)
             .try_into()
             .expect('pack AdventurerMetadata')
     }
     fn unpack(packed: felt252) -> AdventurerMetadata {
         let packed = packed.into();
         let (packed, entropy) = rshift_split(packed, pow::TWO_POW_128);
-        let (packed, home_realm) = rshift_split(packed, pow::TWO_POW_13);
-        let (packed, class) = rshift_split(packed, pow::TWO_POW_4);
-        let (_, name) = rshift_split(packed, pow::TWO_POW_107);
+        let (_, name) = rshift_split(packed, pow::TWO_POW_128);
         AdventurerMetadata {
             name: name.try_into().expect('unpack AdvMetadata name'),
-            home_realm: home_realm.try_into().expect('unpack AdvMetadata home_realm'),
-            class: class.try_into().expect('unpack AdvMetadata class'),
             entropy: entropy.try_into().expect('unpack AdvMetadata entropy')
         }
     }
@@ -43,19 +33,15 @@ impl PackingAdventurerMetadata of Packing<AdventurerMetadata> {
 
 #[cfg(test)]
 #[test]
-#[available_gas(50000000)]
-fn test_meta() {
+#[available_gas(96380)]
+fn test_pack_unpack_adventurer_meta() {
     let meta = AdventurerMetadata {
-        name: 'abcdefghijklm',
-        home_realm: 8000,
-        class: 1,
+        name: 'abcdefghijklmno',
         entropy: 340282366920938463463374607431768211455
     };
 
     let packed = meta.pack();
     let unpacked: AdventurerMetadata = Packing::unpack(packed);
     assert(meta.name == unpacked.name, 'name');
-    assert(meta.home_realm == unpacked.home_realm, 'home_realm');
-    assert(meta.class == unpacked.class, 'class');
     assert(meta.entropy == unpacked.entropy, 'entropy');
 }

--- a/contracts/adventurer/src/adventurer_utils.cairo
+++ b/contracts/adventurer/src/adventurer_utils.cairo
@@ -86,10 +86,13 @@ impl AdventurerUtils of IAdventurerUtils {
     // @param block_number The block number used in generating the entropy
     // @param adventurer_id The ID of the adventurer used in generating the entropy
     // @return A u128 type entropy unique to the block number and adventurer ID
-    fn generate_adventurer_entropy(block_number: u64, adventurer_id: u256) -> u128 {
+    fn generate_adventurer_entropy(
+        adventurer_id: u256, block_number: u64, block_timestamp: u64
+    ) -> u128 {
         let mut hash_span = ArrayTrait::<felt252>::new();
-        hash_span.append(block_number.into());
         hash_span.append(adventurer_id.try_into().unwrap());
+        hash_span.append(block_number.into());
+        hash_span.append(block_timestamp.into());
         let poseidon: felt252 = poseidon_hash_span(hash_span.span()).into();
         let (d, r) = rshift_split(poseidon.into(), U128_MAX.into());
         r.try_into().unwrap()
@@ -181,15 +184,15 @@ impl AdventurerUtils of IAdventurerUtils {
     // @notice gets randomness for adventurer
     // @param adventurer_xp: adventurer xp
     // @param adventurer_entropy: adventurer entropy
-    // @param global_entropy: global entropy
+    // @param game_entropy: game entropy
     // @return (u128, u128): tuple of randomness
     fn get_randomness(
-        adventurer_xp: u16, adventurer_entropy: u128, global_entropy: u128
+        adventurer_xp: u16, adventurer_entropy: u128, game_entropy: u128
     ) -> (u128, u128) {
         let mut hash_span = ArrayTrait::<felt252>::new();
         hash_span.append(adventurer_xp.into());
         hash_span.append(adventurer_entropy.into());
-        hash_span.append(global_entropy.into());
+        hash_span.append(game_entropy.into());
         let poseidon = poseidon_hash_span(hash_span.span());
         AdventurerUtils::split_hash(poseidon)
     }
@@ -198,16 +201,16 @@ impl AdventurerUtils of IAdventurerUtils {
     // @param adventurer_xp: adventurer xp
     // @param adventurer_entropy: adventurer entropy
     // @param adventurer_health: adventurer health
-    // @param global_entropy: global entropy
+    // @param game_entropy: game entropy
     // @return (u128, u128): tuple of randomness
     fn get_randomness_with_health(
-        adventurer_xp: u16, adventurer_health: u16, adventurer_entropy: u128, global_entropy: u128
+        adventurer_xp: u16, adventurer_health: u16, adventurer_entropy: u128, game_entropy: u128
     ) -> (u128, u128) {
         let mut hash_span = ArrayTrait::<felt252>::new();
         hash_span.append(adventurer_xp.into());
         hash_span.append(adventurer_health.into());
         hash_span.append(adventurer_entropy.into());
-        hash_span.append(global_entropy.into());
+        hash_span.append(game_entropy.into());
         let poseidon = poseidon_hash_span(hash_span.span());
         AdventurerUtils::split_hash(poseidon)
     }
@@ -305,7 +308,7 @@ mod tests {
         adventurer_utils::AdventurerUtils
     };
     use combat::constants::CombatEnums::{Type, Tier, Slot};
-        #[test]
+    #[test]
     #[available_gas(166544)]
     fn test_generate_starting_stats_gas() {
         AdventurerUtils::generate_starting_stats(0, 1);
@@ -535,8 +538,9 @@ mod tests {
             }
             let adventurer_id: u256 = i;
             let block_number = 839152;
+            let block_timestamp = 53289712;
             let adventurer_entropy = AdventurerUtils::generate_adventurer_entropy(
-                block_number, adventurer_id
+                adventurer_id, block_number, block_timestamp
             );
             i += 1;
         };

--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -1,27 +1,24 @@
 use starknet::ContractAddress;
+use market::market::{ItemPurchase};
+use beasts::beast::Beast;
 use survivor::{
     bag::Bag, adventurer::{Adventurer, Stats}, adventurer_meta::AdventurerMetadata,
     item_meta::{ItemSpecials, ItemSpecialsStorage}
 };
-use lootitems::loot::{Loot};
-use market::market::{ItemPurchase};
-use beasts::beast::Beast;
+
 
 #[starknet::interface]
 trait IGame<TContractState> {
-    // actions ---------------------------------------------------
-    fn start(
-        ref self: TContractState,
-        client_reward_address: ContractAddress,
-        starting_weapon: u8,
-        adventurer_meta: AdventurerMetadata
+    // ------ Game Actions ------
+    fn new_game(
+        ref self: TContractState, client_reward_address: ContractAddress, weapon: u8, name: u128
     );
     fn explore(ref self: TContractState, adventurer_id: u256, till_beast: bool);
     fn attack(ref self: TContractState, adventurer_id: u256, to_the_death: bool);
     fn flee(ref self: TContractState, adventurer_id: u256, to_the_death: bool);
     fn equip(ref self: TContractState, adventurer_id: u256, items: Array<u8>);
-    fn drop_items(ref self: TContractState, adventurer_id: u256, items: Array<u8>);
-    fn upgrade_adventurer(
+    fn drop(ref self: TContractState, adventurer_id: u256, items: Array<u8>);
+    fn upgrade(
         ref self: TContractState,
         adventurer_id: u256,
         potions: u8,
@@ -29,9 +26,9 @@ trait IGame<TContractState> {
         items: Array<ItemPurchase>,
     );
     fn slay_idle_adventurers(ref self: TContractState, adventurer_ids: Array<u256>);
-    fn rotate_global_entropy(ref self: TContractState);
+    fn rotate_game_entropy(ref self: TContractState);
 
-    // --------- view functions ---------
+    // ------ View Functions ------
 
     // adventurer details
     fn get_adventurer(self: @TContractState, adventurer_id: u256) -> Adventurer;
@@ -54,7 +51,6 @@ trait IGame<TContractState> {
     fn get_charisma(self: @TContractState, adventurer_id: u256) -> u8;
 
     // item stats
-    // TODO: get_equipped_items(self: @TContractState, adventurer_id: u256) -> Array<u8>;
     fn get_weapon_greatness(self: @TContractState, adventurer_id: u256) -> u8;
     fn get_chest_greatness(self: @TContractState, adventurer_id: u256) -> u8;
     fn get_head_greatness(self: @TContractState, adventurer_id: u256) -> u8;
@@ -106,14 +102,12 @@ trait IGame<TContractState> {
     fn get_beast_type(self: @TContractState, beast_id: u8) -> u8;
     fn get_beast_tier(self: @TContractState, beast_id: u8) -> u8;
 
-    // TODO: Game settings
-    fn next_global_entropy_rotation(self: @TContractState) -> felt252;
+    // game settings
+    fn next_game_entropy_rotation(self: @TContractState) -> felt252;
 
     // contract details
+    fn owner_of(self: @TContractState, adventurer_id: u256) -> ContractAddress;
     fn get_dao_address(self: @TContractState) -> ContractAddress;
     fn get_lords_address(self: @TContractState) -> ContractAddress;
     fn get_entropy(self: @TContractState) -> u64;
-
-    // checks ----------------------------------------------------
-    fn owner_of(self: @TContractState, adventurer_id: u256) -> ContractAddress;
 }

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -147,7 +147,7 @@ mod Game {
         /// @dev The function asserts the provided weapon's validity, starts the game, and distributes rewards.
         ///
         /// @param client_reward_address Address where client rewards should be sent.
-        /// @param weapon A u8 representing the weapon to start the game with. Valid options are: {wand: 12, book: 17,  short sword: 46, club: 76}
+        /// @param weapon A u8 representing the weapon to start the game with. Valid options are: {wand: 12, book: 17, short sword: 46, club: 76}
         /// @param name A u128 value representing the player's name.
         fn new_game(
             ref self: ContractState, client_reward_address: ContractAddress, weapon: u8, name: u128,

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -98,11 +98,7 @@ mod tests {
     }
 
     fn add_adventurer_to_game(ref game: IGameDispatcher) {
-        let adventurer_meta = AdventurerMetadata {
-            name: 'loothero'.try_into().unwrap(), home_realm: 1, class: 1, entropy: 1
-        };
-
-        game.start(INTERFACE_ID(), ItemId::Wand, adventurer_meta);
+        game.new_game(INTERFACE_ID(), ItemId::Wand, 'loothero');
 
         let original_adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(original_adventurer.xp == 0, 'wrong starting xp');
@@ -116,11 +112,7 @@ mod tests {
     fn new_adventurer(starting_block: u64) -> IGameDispatcher {
         let mut game = setup(starting_block);
 
-        let adventurer_meta = AdventurerMetadata {
-            name: 'Loaf'.try_into().unwrap(), home_realm: 1, class: 1, entropy: 1
-        };
-
-        game.start(INTERFACE_ID(), ItemId::Wand, adventurer_meta);
+        game.new_game(INTERFACE_ID(), ItemId::Wand, 'loothero');
 
         let original_adventurer = game.get_adventurer(ADVENTURER_ID);
         assert(original_adventurer.xp == 0, 'wrong starting xp');
@@ -136,14 +128,7 @@ mod tests {
     fn new_adventurer_max_charisma() -> IGameDispatcher {
         let mut game = setup(1000);
 
-        game
-            .start(
-                INTERFACE_ID(),
-                ItemId::Wand,
-                AdventurerMetadata {
-                    name: 'loothero'.try_into().unwrap(), home_realm: 1, class: 1, entropy: 1
-                }
-            );
+        game.new_game(INTERFACE_ID(), ItemId::Wand, 'loothero');
 
         game
     }
@@ -210,9 +195,15 @@ mod tests {
 
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
-            strength: stat, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+            strength: stat,
+            dexterity: 0,
+            vitality: 0,
+            intelligence: 0,
+            wisdom: 0,
+            charisma: 1,
+            luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
 
         // go explore
         game.explore(ADVENTURER_ID, true);
@@ -237,9 +228,15 @@ mod tests {
         // upgrade charisma
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
-            strength: stat, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+            strength: stat,
+            dexterity: 0,
+            vitality: 0,
+            intelligence: 0,
+            wisdom: 0,
+            charisma: 1,
+            luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
 
         // go explore
         game.explore(ADVENTURER_ID, true);
@@ -260,9 +257,15 @@ mod tests {
         // upgrade charisma
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
-            strength: stat, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+            strength: stat,
+            dexterity: 0,
+            vitality: 0,
+            intelligence: 0,
+            wisdom: 0,
+            charisma: 1,
+            luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
 
         // go explore
         game.explore(ADVENTURER_ID, true);
@@ -321,9 +324,15 @@ mod tests {
         // upgrade stats
 
         let stat_upgrades = Stats {
-            strength: stat, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+            strength: stat,
+            dexterity: 0,
+            vitality: 0,
+            intelligence: 0,
+            wisdom: 0,
+            charisma: 1,
+            luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
 
         // go explore
         game.explore(ADVENTURER_ID, true);
@@ -340,9 +349,15 @@ mod tests {
         let STRENGTH: u8 = 0;
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
-            strength: stat, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+            strength: stat,
+            dexterity: 0,
+            vitality: 0,
+            intelligence: 0,
+            wisdom: 0,
+            charisma: 1,
+            luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
 
         // go explore
         game.explore(ADVENTURER_ID, true);
@@ -358,9 +373,15 @@ mod tests {
         let STRENGTH: u8 = 0;
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
-            strength: stat, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+            strength: stat,
+            dexterity: 0,
+            vitality: 0,
+            intelligence: 0,
+            wisdom: 0,
+            charisma: 1,
+            luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
 
         // go explore
         game.explore(ADVENTURER_ID, true);
@@ -376,9 +397,15 @@ mod tests {
         let STRENGTH: u8 = 0;
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
-            strength: stat, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+            strength: stat,
+            dexterity: 0,
+            vitality: 0,
+            intelligence: 0,
+            wisdom: 0,
+            charisma: 1,
+            luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
 
         // go explore
         game.explore(ADVENTURER_ID, true);
@@ -394,9 +421,15 @@ mod tests {
         let STRENGTH: u8 = 0;
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
-            strength: stat, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+            strength: stat,
+            dexterity: 0,
+            vitality: 0,
+            intelligence: 0,
+            wisdom: 0,
+            charisma: 1,
+            luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
 
         // go explore
         game.explore(ADVENTURER_ID, true);
@@ -415,9 +448,15 @@ mod tests {
         let STRENGTH: u8 = 0;
         let shopping_cart = ArrayTrait::<ItemPurchase>::new();
         let stat_upgrades = Stats {
-            strength: stat, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
+            strength: stat,
+            dexterity: 0,
+            vitality: 0,
+            intelligence: 0,
+            wisdom: 0,
+            charisma: 1,
+            luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
 
         // go explore
         game.explore(ADVENTURER_ID, true);
@@ -451,8 +490,6 @@ mod tests {
 
         // check meta
         assert(adventurer_meta_1.name == 'Loaf', 'name');
-        assert(adventurer_meta_1.home_realm == 1, 'home_realm');
-        assert(adventurer_meta_1.class == 1, 'class');
 
         adventurer_meta_1.entropy;
     }
@@ -570,16 +607,16 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
 
         testing::set_block_number(1006);
         game.explore(ADVENTURER_ID, true);
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
         testing::set_block_number(1007);
         game.explore(ADVENTURER_ID, true);
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
         game.explore(ADVENTURER_ID, true);
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
         game.explore(ADVENTURER_ID, true);
 
         // verify we found a beast
@@ -634,7 +671,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
     }
 
     #[test]
@@ -656,11 +693,11 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, empty_shoppping_cart.clone());
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, empty_shoppping_cart.clone());
 
         // after upgrade try to buy item
         // should panic with message 'Market is closed'
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shoppping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shoppping_cart);
     }
 
     #[test]
@@ -684,7 +721,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
     }
 
     #[test]
@@ -707,7 +744,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
     }
 
     #[test]
@@ -720,7 +757,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
     }
 
     #[test]
@@ -734,7 +771,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
         let bag = game.get_bag(ADVENTURER_ID);
         assert(bag.item_1.id == *market_items.at(0), 'item should be in bag');
     }
@@ -808,7 +845,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
 
         // get updated adventurer and bag state
         let bag = game.get_bag(ADVENTURER_ID);
@@ -980,7 +1017,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
 
         // get bag from storage
         let bag = game.get_bag(ADVENTURER_ID);
@@ -1041,7 +1078,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 1, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 0, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, number_of_potions, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, number_of_potions, stat_upgrades, shopping_cart);
 
         // get updated adventurer stat
         let adventurer = game.get_adventurer(ADVENTURER_ID);
@@ -1083,7 +1120,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, potions, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, potions, stat_upgrades, shopping_cart);
     }
 
     #[test]
@@ -1098,11 +1135,11 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
 
         // then try to buy potions (should panic with 'Market is closed')
         let potions = 1;
-        game.upgrade_adventurer(ADVENTURER_ID, potions, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, potions, stat_upgrades, shopping_cart);
     }
 
     #[test]
@@ -1120,7 +1157,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, potions, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, potions, stat_upgrades, shopping_cart);
     }
 
     #[test]
@@ -1643,7 +1680,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
 
         // get adventurer state
         let adventurer = game.get_adventurer(ADVENTURER_ID);
@@ -1662,7 +1699,7 @@ mod tests {
         drop_list.append(purchased_item_id);
 
         // call contract drop
-        game.drop_items(ADVENTURER_ID, drop_list);
+        game.drop(ADVENTURER_ID, drop_list);
 
         // get adventurer state
         let adventurer = game.get_adventurer(ADVENTURER_ID);
@@ -1692,7 +1729,7 @@ mod tests {
         // try to drop an item the adventurer doesn't own
         // this should result in a panic 'Item not owned by adventurer'
         // this test is annotated to expect that panic
-        game.drop_items(ADVENTURER_ID, drop_list);
+        game.drop(ADVENTURER_ID, drop_list);
     }
 
     #[test]
@@ -1713,7 +1750,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
 
         // get update adventurer state
         let adventurer = game.get_adventurer(ADVENTURER_ID);
@@ -1740,7 +1777,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 2, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart);
     }
 
     #[test]
@@ -1776,7 +1813,7 @@ mod tests {
         let stat_upgrades = Stats {
             strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 1, luck: 0
         };
-        game.upgrade_adventurer(ADVENTURER_ID, potions, stat_upgrades, items_to_purchase);
+        game.upgrade(ADVENTURER_ID, potions, stat_upgrades, items_to_purchase);
 
         // get updated adventurer state
         let adventurer = game.get_adventurer(ADVENTURER_ID);

--- a/contracts/pack/src/pack.cairo
+++ b/contracts/pack/src/pack.cairo
@@ -7,13 +7,9 @@ trait Packing<T> {
     fn unpack(packed: felt252) -> T;
 }
 
-//#[inline(always)]
+#[inline(always)]
 fn rshift_split(value: u256, bits: u256) -> (u256, u256) {
-    // temporary commented out until 0.12.1 when u256_safe_divmod is an allowed libfunc
-    // integer::U256DivRem::div_rem(value, bits.try_into().expect('0 bits'))
-    let value = integer::u512 { limb0: value.low, limb1: value.high, limb2: 0, limb3: 0 };
-    let (q, r) = integer::u512_safe_div_rem_by_u256(value, bits.try_into().expect('0 bits'));
-    (u256 { low: q.limb0, high: q.limb1 }, r)
+    integer::U256DivRem::div_rem(value, bits.try_into().expect('0 bits'))
 }
 
 #[cfg(test)]
@@ -22,7 +18,7 @@ mod tests {
     use pack::constants::pow;
 
     #[test]
-    #[available_gas(10000000)]
+    #[available_gas(81450)]
     fn test_rshift_split_pass() {
         let v = 0b11010101;
 
@@ -48,7 +44,7 @@ mod tests {
     }
 
     #[test]
-    #[available_gas(10000000)]
+    #[available_gas(11750)]
     #[should_panic]
     fn test_rshift_split_0() {
         rshift_split(0b1101, 0);


### PR DESCRIPTION
* Changes public interface `start` to `new_game` to be more description
* Inputs to `new_game` have been greatly simplified, now requiring only: {Client Address, Weapon, Name}
* Removes unused variables {Home Realm, Class} from AdventurerMeta and expands storage space for Name
* Reduces gas for Packing/Unpacking by taking advantage of U256DivRem added in V0.12.1
* Changes external function `drop_items` to `drop`
* Changes external function `upgrade_adventurer` to `upgrade`
* Changes external function `rotate_global_entropy` to `rotate_game_entropy`
* Removes Gold from Beast Seed hash to reduce manipulation
* Adds block timestamp to Adventurer Seed hash to increase randomness