### PR TITLE
Reduces storage slots for game entropy from 2 to 1

### DIFF
--- a/contracts/adventurer/src/bag.cairo
+++ b/contracts/adventurer/src/bag.cairo
@@ -73,7 +73,7 @@ impl BagPacking of Packing<Bag> {
         }
     }
 
-    // TODO: add overflow pack protection
+    // Not used for bag
     fn overflow_pack_protection(self: Bag) -> Bag {
         self
     }

--- a/contracts/game/Scarb.toml
+++ b/contracts/game/Scarb.toml
@@ -8,7 +8,7 @@ lootitems = { path = "../loot" }
 survivor = { path = "../adventurer" }
 market = { path = "../market" }
 obstacles = { path = "../obstacles" }
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", rev = "05429e4" }
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.7.0" }
 
 [[target.starknet-contract]]
 allowed-libfuncs-list.name = "experimental"

--- a/contracts/game/src/TODO:
+++ b/contracts/game/src/TODO:
@@ -1,4 +1,0 @@
-1. Include Equipped Item Specials in AdventurerState for DD
-2. Handle mid-flight stat boost/item changes
-3. Limit transactions per block
-4. Commit and wait starting scheme

--- a/contracts/game/src/TODO:
+++ b/contracts/game/src/TODO:
@@ -1,0 +1,4 @@
+1. Include Equipped Item Specials in AdventurerState for DD
+2. Handle mid-flight stat boost/item changes
+3. Limit transactions per block
+4. Commit and wait starting scheme

--- a/contracts/game/src/game/game_entropy.cairo
+++ b/contracts/game/src/game/game_entropy.cairo
@@ -1,0 +1,55 @@
+use pack::{constants::pow, pack::{Packing, rshift_split}};
+
+#[derive(Drop, Copy, Serde)]
+struct GameEntropy {
+    entropy: u128,
+    last_updated: u64,
+}
+
+impl GameEntropyPacking of Packing<GameEntropy> {
+    fn pack(self: GameEntropy) -> felt252 {
+        (self.entropy.into()
+            + self.last_updated.into() * pow::TWO_POW_128)
+            .try_into()
+            .expect('pack GameEntropy')
+    }
+
+    fn unpack(packed: felt252) -> GameEntropy {
+        let packed = packed.into();
+        let (packed, entropy) = rshift_split(packed, pow::TWO_POW_128);
+        let (_, last_updated) = rshift_split(packed, pow::TWO_POW_128);
+
+        GameEntropy {
+            entropy: entropy.try_into().unwrap(), last_updated: last_updated.try_into().unwrap(),
+        }
+    }
+    // Not used for game entropy
+    fn overflow_pack_protection(self: GameEntropy) -> GameEntropy {
+        self
+    }
+}
+
+// ---------------------------
+// ---------- Tests ----------
+// ---------------------------
+#[cfg(test)]
+mod tests {
+    use game::game::game_entropy::{GameEntropy, GameEntropyPacking};
+    use pack::{pack::{Packing}};
+
+    #[test]
+    #[available_gas(3000000)]
+    fn test_packing_and_unpacking_game_entropy() {
+        let game_entropy = GameEntropy { entropy: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, last_updated: 0xFFFFFFFFFFFFFFFF };
+        let unpacked: GameEntropy = Packing::unpack(game_entropy.pack());
+
+        assert(unpacked.entropy == game_entropy.entropy, 'wrong entropy max value');
+        assert(unpacked.last_updated == game_entropy.last_updated, 'wrong last_updated max value');
+
+        let game_entropy = GameEntropy { entropy: 0, last_updated: 0 };
+        let unpacked: GameEntropy = Packing::unpack(game_entropy.pack());
+
+        assert(unpacked.entropy == game_entropy.entropy, 'wrong entropy zero');
+        assert(unpacked.last_updated == game_entropy.last_updated, 'wrong last_updated zero');
+    }
+}

--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -5,6 +5,7 @@ use survivor::{
     bag::Bag, adventurer::{Adventurer, Stats}, adventurer_meta::AdventurerMetadata,
     item_meta::{ItemSpecials, ItemSpecialsStorage}
 };
+use game::game::game_entropy::{GameEntropy};
 
 
 #[starknet::interface]
@@ -109,5 +110,5 @@ trait IGame<TContractState> {
     fn owner_of(self: @TContractState, adventurer_id: u256) -> ContractAddress;
     fn get_dao_address(self: @TContractState) -> ContractAddress;
     fn get_lords_address(self: @TContractState) -> ContractAddress;
-    fn get_entropy(self: @TContractState) -> u64;
+    fn get_game_entropy(self: @TContractState) -> GameEntropy;
 }

--- a/contracts/game/src/game/lib.cairo
+++ b/contracts/game/src/game/lib.cairo
@@ -1,3 +1,4 @@
 mod game;
 mod constants;
 mod interfaces;
+mod game_entropy;

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -608,7 +608,9 @@ mod tests {
         game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
 
         // go exploring
-        testing::set_block_number(1006);
+        testing::set_block_number(1008);
+        game.explore(ADVENTURER_ID, true);
+        game.upgrade(ADVENTURER_ID, 0, stat_upgrades, shopping_cart.clone());
         game.explore(ADVENTURER_ID, true);
 
         // verify we found a beast
@@ -1360,10 +1362,11 @@ mod tests {
 
     #[test]
     #[available_gas(20000000)]
-    fn test_entropy() {
+    fn test_get_game_entropy() {
         let mut game = new_adventurer(1000);
-
-        game.get_entropy();
+        let game_entropy = game.get_game_entropy();
+        assert(game_entropy.entropy == 0x612220ba39bfbf46a1851365c9bd0a8a, 'wrong game entropy');
+        assert(game_entropy.last_updated == 0x3e8, 'wrong game entropy last update');
     }
 
     #[test]


### PR DESCRIPTION
* previously the entropy and last updated block were stored in two storage slots
* now entropy and last updated block are packed into single storage slot
* this reduces cost of rotating game entropy by ~50% which will be a common call