### PR TITLE
minor adjustment to rate limit

### DIFF
--- a/contracts/adventurer/src/adventurer.cairo
+++ b/contracts/adventurer/src/adventurer.cairo
@@ -1708,7 +1708,7 @@ impl ImplAdventurer of IAdventurer {
 
     #[inline(always)]
     fn reset_actions_per_block(ref self: Adventurer) {
-        self.actions_per_block = 1;
+        self.actions_per_block = 0;
     }
 
     #[inline(always)]

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -2473,7 +2473,7 @@ mod Game {
     }
 
     fn _assert_rate_limit(actions_per_block: u8, rate_limit: u64) {
-        assert(actions_per_block.into() <= rate_limit, messages::RATE_LIMIT_EXCEEDED);
+        assert(actions_per_block.into() < rate_limit, messages::RATE_LIMIT_EXCEEDED);
     }
 
     fn _assert_is_idle(self: @ContractState, adventurer: Adventurer) {


### PR DESCRIPTION
* reset actions per block to 0 on block rotation
* use < instead of <= to block player action when it hits the limit vs allowing it to go one over.
* this makes the view functions more intuitive