### PR TITLE
fixes vitality max health not adjusted during item swaps involving items with VIT boosts 

### DIFF
--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -588,11 +588,6 @@ mod Game {
             // upgrade adventurer's stats
             _upgrade_stats(@self, ref adventurer, stat_upgrades);
 
-            // if the player is buying potions as part of the upgrade
-            if potions != 0 {
-                _buy_potions(ref self, ref adventurer, adventurer_id, potions);
-            }
-
             // if the player is buying items, process purchases
             if (items.len() != 0) {
                 let (purchases, equipped_items, unequipped_items) = _buy_items(
@@ -614,6 +609,12 @@ mod Game {
                         ref self, adventurer, adventurer_id, bag, equipped_items, unequipped_items,
                     );
                 }
+            }
+
+            // if the player is buying potions as part of the upgrade, process purchase
+            // @dev process potion purchase after items in case item purchases changes item stat boosts
+            if potions != 0 {
+                _buy_potions(ref self, ref adventurer, adventurer_id, potions);
             }
 
             // emit adventurer upgraded event
@@ -2378,6 +2379,13 @@ mod Game {
         let (name_storage1, name_storage2) = _get_special_storages(self, adventurer_id);
         let item_specials = ImplItemSpecials::get_specials_full(name_storage1, name_storage2, item);
         adventurer.stats.remove_suffix_boost(item_specials.special1);
+
+        // if the adventurer's health is now above the max health due to a change in Vitality
+        let max_health = AdventurerUtils::get_max_health(adventurer.stats.vitality);
+        if adventurer.health > max_health {
+            // lower adventurer's health to max health 
+            adventurer.health = max_health;
+        }
     }
 
     fn _apply_equipment_stat_boosts(


### PR DESCRIPTION
* the bug allows players to equip VIT boosting items during upgrade, buy potions, then swap those items without losing that health
* to prevent players from wasting gold, this PR processes item purchases before potion purchases. If player swaps a VIT boosting item as part of their potion, the contract will have the updated VIT and use that to enforce potion limit.
* if a player buys potions up to max health with a VIT boosting item and then swaps out that item after upgrade, contract will lower their health to max health with updated VIT.