### PR TITLE
Add vitality boost removal check

### DIFF
--- a/ui/src/app/components/marketplace/MarketplaceTable.tsx
+++ b/ui/src/app/components/marketplace/MarketplaceTable.tsx
@@ -17,6 +17,7 @@ export interface MarketplaceTableProps {
   ) => void;
   totalCharisma: number;
   calculatedNewGold: number;
+  adventurerItems: Item[];
 }
 
 const MarketplaceTable = ({
@@ -25,6 +26,7 @@ const MarketplaceTable = ({
   upgradeHandler,
   totalCharisma,
   calculatedNewGold,
+  adventurerItems,
 }: MarketplaceTableProps) => {
   const [sortField, setSortField] = useState<string | null>(null);
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
@@ -36,9 +38,6 @@ const MarketplaceTable = ({
 
   const marketLatestItems = useQueriesStore(
     (state) => state.data.latestMarketItemsQuery?.items || []
-  );
-  const adventurerItems = useQueriesStore(
-    (state) => state.data.itemsByAdventurerQuery?.items || []
   );
 
   const headings = ["Item", "Tier", "Slot", "Type", "Cost", "Actions"];

--- a/ui/src/app/components/navigation/TransactionCart.tsx
+++ b/ui/src/app/components/navigation/TransactionCart.tsx
@@ -456,16 +456,23 @@ const TransactionCart = ({
                 resetNotification();
                 // Handle for vitBoostRemoval
                 if (potionAmount > 0) {
+                  // Check whether health + pots is within vitBoostRemoved of the maxHealth
                   const vitBoostRemoved = calculateVitBoostRemoved(
                     purchaseItems,
                     adventurer!,
                     data.itemsByAdventurerQuery?.items ?? []
                   );
-                  handleAddUpgradeTx(
-                    undefined,
-                    potionAmount - vitBoostRemoved,
-                    undefined
-                  );
+                  const maxHealth = 100 + (adventurer?.vitality ?? 0) * 10;
+                  const healthPlusPots = 100 + potionAmount * 10;
+                  const checkInRange =
+                    maxHealth - healthPlusPots < vitBoostRemoved * 10;
+                  if (checkInRange) {
+                    handleAddUpgradeTx(
+                      undefined,
+                      Math.max(potionAmount - vitBoostRemoved, 0),
+                      undefined
+                    );
+                  }
                 }
                 await multicall(loadingMessage, notification);
                 handleResetCalls();

--- a/ui/src/app/components/navigation/TransactionCart.tsx
+++ b/ui/src/app/components/navigation/TransactionCart.tsx
@@ -26,6 +26,7 @@ import useOnClickOutside from "@/app/hooks/useOnClickOutside";
 import useLoadingStore from "@/app/hooks/useLoadingStore";
 import { chunkArray } from "@/app/lib/utils";
 import { UpgradeStats } from "@/app/types";
+import { calculateVitBoostRemoved } from "@/app/lib/utils";
 
 export interface TransactionCartProps {
   buttonRef: RefObject<HTMLElement>;
@@ -453,6 +454,19 @@ const TransactionCart = ({
               disabled={!callExists}
               onClick={async () => {
                 resetNotification();
+                // Handle for vitBoostRemoval
+                if (potionAmount > 0) {
+                  const vitBoostRemoved = calculateVitBoostRemoved(
+                    purchaseItems,
+                    adventurer!,
+                    data.itemsByAdventurerQuery?.items ?? []
+                  );
+                  handleAddUpgradeTx(
+                    undefined,
+                    potionAmount - vitBoostRemoved,
+                    undefined
+                  );
+                }
                 await multicall(loadingMessage, notification);
                 handleResetCalls();
               }}

--- a/ui/src/app/components/start/Spawn.tsx
+++ b/ui/src/app/components/start/Spawn.tsx
@@ -61,7 +61,7 @@ export const Spawn = ({
 
   const checkEnoughLords = lordsBalance! >= BigInt(25000000000000000000);
 
-  const goldenTokenExists = true;
+  // const goldenTokenExists = true;
 
   return (
     <div className="flex flex-col w-full h-full justify-center">

--- a/ui/src/app/containers/MarketplaceScreen.tsx
+++ b/ui/src/app/containers/MarketplaceScreen.tsx
@@ -1,7 +1,7 @@
 import useAdventurerStore from "@/app/hooks/useAdventurerStore";
 import LootIconLoader from "@/app/components/icons/Loader";
 import { useQueriesStore } from "@/app/hooks/useQueryStore";
-import { ItemPurchase, UpgradeStats } from "@/app/types";
+import { Item, ItemPurchase, UpgradeStats } from "@/app/types";
 import MarketplaceTable from "@/app/components/marketplace/MarketplaceTable";
 
 export interface MarketplaceScreenProps {
@@ -14,6 +14,7 @@ export interface MarketplaceScreenProps {
     purchases?: any[]
   ) => void;
   totalCharisma: number;
+  adventurerItems: Item[];
 }
 /**
  * @container
@@ -26,13 +27,10 @@ export default function MarketplaceScreen({
   setPurchaseItems,
   upgradeHandler,
   totalCharisma,
+  adventurerItems,
 }: MarketplaceScreenProps) {
   const adventurer = useAdventurerStore((state) => state.adventurer);
   const { isLoading } = useQueriesStore();
-
-  const adventurerItems = useQueriesStore(
-    (state) => state.data.itemsByAdventurerQuery?.items || []
-  );
 
   const calculatedNewGold = adventurer?.gold
     ? adventurer?.gold - upgradeTotalCost
@@ -55,6 +53,7 @@ export default function MarketplaceScreen({
             upgradeHandler={upgradeHandler}
             totalCharisma={totalCharisma}
             calculatedNewGold={calculatedNewGold}
+            adventurerItems={adventurerItems}
           />
         </div>
       ) : (

--- a/ui/src/app/containers/UpgradeScreen.tsx
+++ b/ui/src/app/containers/UpgradeScreen.tsx
@@ -31,6 +31,8 @@ import useUIStore from "@/app/hooks/useUIStore";
 import { UpgradeStats, ZeroUpgrade, UpgradeSummary } from "@/app/types";
 import Summary from "@/app/components/upgrade/Summary";
 import { HealthCountDown } from "@/app/components/CountDown";
+import { calculateVitBoostRemoved } from "@/app/lib/utils";
+import { useQueriesStore } from "@/app/hooks/useQueryStore";
 
 interface UpgradeScreenProps {
   upgrade: (...args: any[]) => any;
@@ -268,8 +270,14 @@ export default function UpgradeScreen({
   const handleSubmitUpgradeTx = async () => {
     renderSummary();
     resetNotification();
+    const vitBoostRemoved = calculateVitBoostRemoved(
+      purchaseItems,
+      adventurer!,
+      adventurerItems
+    );
+    handleAddUpgradeTx(undefined, potionAmount - vitBoostRemoved, undefined)
     try {
-      await upgrade(upgrades, purchaseItems, potionAmount);
+      await upgrade(upgrades, purchaseItems, potionAmount - vitBoostRemoved);
       setPotionAmount(0);
       setPurchaseItems([]);
       setUpgrades({ ...ZeroUpgrade });
@@ -325,6 +333,10 @@ export default function UpgradeScreen({
   useEffect(() => {
     getNoBoostedStats();
   }, []);
+
+  const adventurerItems = useQueriesStore(
+    (state) => state.data.itemsByAdventurerQuery?.items || []
+  );
 
   return (
     <>
@@ -501,6 +513,7 @@ export default function UpgradeScreen({
                         setPurchaseItems={setPurchaseItems}
                         upgradeHandler={handleAddUpgradeTx}
                         totalCharisma={totalCharisma}
+                        adventurerItems={adventurerItems}
                       />
                     </div>
                   )}
@@ -512,6 +525,7 @@ export default function UpgradeScreen({
                         setPurchaseItems={setPurchaseItems}
                         upgradeHandler={handleAddUpgradeTx}
                         totalCharisma={totalCharisma}
+                        adventurerItems={adventurerItems}
                       />
                     </div>
                   )}

--- a/ui/src/app/containers/UpgradeScreen.tsx
+++ b/ui/src/app/containers/UpgradeScreen.tsx
@@ -270,14 +270,31 @@ export default function UpgradeScreen({
   const handleSubmitUpgradeTx = async () => {
     renderSummary();
     resetNotification();
+    // Handle for vitBoostRemoval
     const vitBoostRemoved = calculateVitBoostRemoved(
       purchaseItems,
       adventurer!,
       adventurerItems
     );
-    handleAddUpgradeTx(undefined, potionAmount - vitBoostRemoved, undefined)
+    if (potionAmount > 0) {
+      // Check whether health + pots is within vitBoostRemoved of the maxHealth
+      const maxHealth = 100 + (adventurer?.vitality ?? 0) * 10;
+      const healthPlusPots = 100 + potionAmount * 10;
+      const checkInRange = maxHealth - healthPlusPots < vitBoostRemoved * 10;
+      if (checkInRange) {
+        handleAddUpgradeTx(
+          undefined,
+          Math.max(potionAmount - vitBoostRemoved, 0),
+          undefined
+        );
+      }
+    }
     try {
-      await upgrade(upgrades, purchaseItems, potionAmount - vitBoostRemoved);
+      await upgrade(
+        upgrades,
+        purchaseItems,
+        Math.max(potionAmount - vitBoostRemoved, 0)
+      );
       setPotionAmount(0);
       setPurchaseItems([]);
       setUpgrades({ ...ZeroUpgrade });

--- a/ui/src/app/lib/utils/index.ts
+++ b/ui/src/app/lib/utils/index.ts
@@ -3,7 +3,7 @@ import { twMerge } from "tailwind-merge";
 import BN from "bn.js";
 import { z } from "zod";
 import { Call, AccountInterface } from "starknet";
-import { Adventurer, Item } from "@/app/types";
+import { Adventurer, Item, ItemPurchase } from "@/app/types";
 import { GameData } from "@/app/lib/data/GameData";
 import {
   itemCharismaDiscount,
@@ -434,4 +434,48 @@ export const fetchBlockTime = async (currentBlock: number) => {
   } catch (error) {
     console.error("Error:", error);
   }
+};
+
+export const checkVitBoostRemoved = (
+  purchases: ItemPurchase[],
+  adventurer: Adventurer
+) => {
+  const gameData = new GameData();
+  const equippedItems = purchases.filter((purchase) => purchase.equip === "1");
+  const itemStrings = equippedItems.map(
+    (purchase) => gameData.ITEMS[parseInt(purchase?.item) ?? 0]
+  );
+  const slotStrings = itemStrings.map(
+    (itemString) => gameData.ITEM_SLOTS[itemString.split(" ").join("")]
+  );
+
+  // loop through slots and check what item is equipped
+  const unequippedItems = [];
+  for (const slot of slotStrings) {
+    if (slot === "Weapon") {
+      unequippedItems.push(adventurer.weapon);
+    }
+    if (slot === "Chest") {
+      unequippedItems.push(adventurer.chest);
+    }
+    if (slot === "Head") {
+      unequippedItems.push(adventurer.head);
+    }
+    if (slot === "Waist") {
+      unequippedItems.push(adventurer.waist);
+    }
+    if (slot === "Foot") {
+      unequippedItems.push(adventurer.foot);
+    }
+    if (slot === "Hand") {
+      unequippedItems.push(adventurer.hand);
+    }
+    if (slot === "Neck") {
+      unequippedItems.push(adventurer.neck);
+    }
+    if (slot === "Ring") {
+      unequippedItems.push(adventurer.ring);
+    }
+  }
+  return unequippedItems;
 };

--- a/ui/src/app/lib/utils/index.ts
+++ b/ui/src/app/lib/utils/index.ts
@@ -436,9 +436,10 @@ export const fetchBlockTime = async (currentBlock: number) => {
   }
 };
 
-export const checkVitBoostRemoved = (
+export const calculateVitBoostRemoved = (
   purchases: ItemPurchase[],
-  adventurer: Adventurer
+  adventurer: Adventurer,
+  items: any[]
 ) => {
   const gameData = new GameData();
   const equippedItems = purchases.filter((purchase) => purchase.equip === "1");
@@ -450,32 +451,125 @@ export const checkVitBoostRemoved = (
   );
 
   // loop through slots and check what item is equipped
-  const unequippedItems = [];
+  const unequippedSuffixBoosts = [];
   for (const slot of slotStrings) {
     if (slot === "Weapon") {
-      unequippedItems.push(adventurer.weapon);
+      unequippedSuffixBoosts.push(
+        gameData.ITEM_SUFFIX_BOOST[
+          parseInt(
+            getKeyFromValue(
+              gameData.ITEM_SUFFIXES,
+              items.find((item) => item.item === adventurer.weapon)?.special1
+            ) ?? "0"
+          )
+        ]
+      );
     }
     if (slot === "Chest") {
-      unequippedItems.push(adventurer.chest);
+      unequippedSuffixBoosts.push(
+        gameData.ITEM_SUFFIX_BOOST[
+          parseInt(
+            getKeyFromValue(
+              gameData.ITEM_SUFFIXES,
+              items.find((item) => item.item === adventurer.chest)?.special1
+            ) ?? "0"
+          )
+        ]
+      );
     }
     if (slot === "Head") {
-      unequippedItems.push(adventurer.head);
+      unequippedSuffixBoosts.push(
+        gameData.ITEM_SUFFIX_BOOST[
+          parseInt(
+            getKeyFromValue(
+              gameData.ITEM_SUFFIXES,
+              items.find((item) => item.item === adventurer.head)?.special1
+            ) ?? "0"
+          )
+        ]
+      );
     }
     if (slot === "Waist") {
-      unequippedItems.push(adventurer.waist);
+      unequippedSuffixBoosts.push(
+        gameData.ITEM_SUFFIX_BOOST[
+          parseInt(
+            getKeyFromValue(
+              gameData.ITEM_SUFFIXES,
+              items.find((item) => item.item === adventurer.waist)?.special1
+            ) ?? "0"
+          )
+        ]
+      );
     }
     if (slot === "Foot") {
-      unequippedItems.push(adventurer.foot);
+      unequippedSuffixBoosts.push(
+        gameData.ITEM_SUFFIX_BOOST[
+          parseInt(
+            getKeyFromValue(
+              gameData.ITEM_SUFFIXES,
+              items.find((item) => item.item === adventurer.foot)?.special1
+            ) ?? "0"
+          )
+        ]
+      );
     }
     if (slot === "Hand") {
-      unequippedItems.push(adventurer.hand);
+      console.log(adventurer.hand);
+      unequippedSuffixBoosts.push(
+        gameData.ITEM_SUFFIX_BOOST[
+          parseInt(
+            getKeyFromValue(
+              gameData.ITEM_SUFFIXES,
+              items.find((item) => item.item === adventurer.hand)?.special1
+            ) ?? "0"
+          )
+        ]
+      );
     }
     if (slot === "Neck") {
-      unequippedItems.push(adventurer.neck);
+      unequippedSuffixBoosts.push(
+        gameData.ITEM_SUFFIX_BOOST[
+          parseInt(
+            getKeyFromValue(
+              gameData.ITEM_SUFFIXES,
+              items.find((item) => item.item === adventurer.neck)?.special1
+            ) ?? "0"
+          )
+        ]
+      );
     }
     if (slot === "Ring") {
-      unequippedItems.push(adventurer.ring);
+      unequippedSuffixBoosts.push(
+        gameData.ITEM_SUFFIX_BOOST[
+          parseInt(
+            getKeyFromValue(
+              gameData.ITEM_SUFFIXES,
+              items.find((item) => item.item === adventurer.ring)?.special1
+            ) ?? "0"
+          )
+        ]
+      );
     }
   }
-  return unequippedItems;
+  const vitTotal = findAndSumVitValues(unequippedSuffixBoosts);
+  return vitTotal;
 };
+
+function findAndSumVitValues(arr: string[]): number {
+  let total = 0;
+
+  arr.forEach((str) => {
+    const matches = str.match(/VIT \+\d+/g);
+    console.log(matches);
+
+    if (matches) {
+      matches.forEach((match) => {
+        const value = parseInt(match.split("+")[1]);
+        console.log(value);
+        total += value;
+      });
+    }
+  });
+
+  return total;
+}

--- a/ui/src/app/lib/utils/index.ts
+++ b/ui/src/app/lib/utils/index.ts
@@ -551,7 +551,10 @@ export const calculateVitBoostRemoved = (
       );
     }
   }
-  const vitTotal = findAndSumVitValues(unequippedSuffixBoosts);
+  const filteredSuffixBoosts = unequippedSuffixBoosts.filter(
+    (suffix) => suffix !== undefined
+  );
+  const vitTotal = findAndSumVitValues(filteredSuffixBoosts);
   return vitTotal;
 };
 


### PR DESCRIPTION
We now calculate the VIT that is removed from an item purchase & equip and remove potions if it will take the health below max