### PR TITLE
use primary account for rewards and beast collectibles

### DIFF
--- a/contracts/adventurer/src/adventurer_meta.cairo
+++ b/contracts/adventurer/src/adventurer_meta.cairo
@@ -4,16 +4,24 @@ use super::stats::{Stats, StatsPacking, StatUtils};
 
 #[derive(Drop, Copy, Serde)]
 struct AdventurerMetadata {
-    start_block: u64, // 64 bits
-    starting_stats: Stats, // 24 bits
-    name: u128, // 128 bits
+    start_block: u64, // 64 bits in storage
+    starting_stats: Stats, // 24 bits in storage
+    name: u128, // 128 bits in storage
+    interface_camel: bool, // 1 bit bool in storage
 }
 
 impl PackingAdventurerMetadata of StorePacking<AdventurerMetadata, felt252> {
     fn pack(value: AdventurerMetadata) -> felt252 {
+        let interface_camel_u256: u256 = if value.interface_camel {
+            1
+        } else {
+            0
+        };
+
         (value.start_block.into()
             + StatsPacking::pack(value.starting_stats).into() * TWO_POW_64
-            + value.name.into() * TWO_POW_88)
+            + interface_camel_u256 * TWO_POW_88
+            + value.name.into() * TWO_POW_89)
             .try_into()
             .unwrap()
     }
@@ -25,11 +33,18 @@ impl PackingAdventurerMetadata of StorePacking<AdventurerMetadata, felt252> {
         let (packed, starting_stats) = integer::U256DivRem::div_rem(
             packed, TWO_POW_24.try_into().unwrap()
         );
+        let (packed, interface_camel_u256) = integer::U256DivRem::div_rem(
+            packed, TWO_POW_1.try_into().unwrap()
+        );
         let (_, name) = integer::U256DivRem::div_rem(packed, TWO_POW_128.try_into().unwrap());
+
+        let interface_camel = interface_camel_u256 == 1;
+
         AdventurerMetadata {
             start_block: start_block.try_into().unwrap(),
             starting_stats: StatsPacking::unpack(starting_stats.try_into().unwrap()),
-            name: name.try_into().unwrap()
+            name: name.try_into().unwrap(),
+            interface_camel
         }
     }
 }
@@ -40,15 +55,18 @@ impl ImplAdventurerMetadata of IAdventurerMetadata {
     // @dev: AdventurerMetadata is initialized without any starting stats
     // @param name: The name of the adventurer
     // @param start_block: The block number at which the adventurer was created
+    // @param interface_camel: Whether the players account is using a camelcase interface
     // @return: The newly created AdventurerMetadata struct
-    fn new(name: u128, start_block: u64) -> AdventurerMetadata {
-        AdventurerMetadata { name, start_block, starting_stats: StatUtils::new() }
+    fn new(name: u128, start_block: u64, interface_camel: bool) -> AdventurerMetadata {
+        AdventurerMetadata { name, start_block, starting_stats: StatUtils::new(), interface_camel }
     }
 }
 
+const TWO_POW_1: u256 = 0x2;
 const TWO_POW_24: u256 = 0x1000000;
 const TWO_POW_64: u256 = 0x10000000000000000;
 const TWO_POW_88: u256 = 0x10000000000000000000000;
+const TWO_POW_89: u256 = 0x20000000000000000000000;
 const TWO_POW_128: u256 = 0x100000000000000000000000000000000;
 
 #[cfg(test)]
@@ -65,25 +83,69 @@ fn test_adventurer_metadata_packing() {
         intelligence: 15,
         wisdom: 15,
         charisma: 15,
-        luck: 15
+        luck: 0
     };
+    let interface_camel = true;
 
     let meta = AdventurerMetadata {
-        start_block: max_u64, starting_stats: max_starting_stats, name: max_name_length
+        start_block: max_u64,
+        starting_stats: max_starting_stats,
+        name: max_name_length,
+        interface_camel
     };
 
     let packed = PackingAdventurerMetadata::pack(meta);
     let unpacked: AdventurerMetadata = PackingAdventurerMetadata::unpack(packed);
     assert(meta.name == unpacked.name, 'name should be max');
     assert(meta.start_block == unpacked.start_block, 'sblock should be max u64');
+    assert(
+        meta.starting_stats.strength == unpacked.starting_stats.strength, 'strength should be max'
+    );
+    assert(
+        meta.starting_stats.dexterity == unpacked.starting_stats.dexterity,
+        'dexterity should be max'
+    );
+    assert(
+        meta.starting_stats.vitality == unpacked.starting_stats.vitality, 'vitality should be max'
+    );
+    assert(
+        meta.starting_stats.intelligence == unpacked.starting_stats.intelligence,
+        'intelligence should be max'
+    );
+    assert(meta.starting_stats.wisdom == unpacked.starting_stats.wisdom, 'wisdom should be max');
+    assert(
+        meta.starting_stats.charisma == unpacked.starting_stats.charisma, 'charisma should be max'
+    );
+    assert(meta.interface_camel == unpacked.interface_camel, 'interface_camel should be true');
 
     // zero case
     let zero_starting_stats = Stats {
         strength: 0, dexterity: 0, vitality: 0, intelligence: 0, wisdom: 0, charisma: 0, luck: 0
     };
-    let meta = AdventurerMetadata { start_block: 0, starting_stats: zero_starting_stats, name: 0 };
+    let interface_camel = false;
+    let meta = AdventurerMetadata {
+        start_block: 0, starting_stats: zero_starting_stats, name: 0, interface_camel
+    };
     let packed = PackingAdventurerMetadata::pack(meta);
     let unpacked: AdventurerMetadata = PackingAdventurerMetadata::unpack(packed);
     assert(unpacked.name == 0, 'name should be 0');
     assert(unpacked.start_block == 0, 'entropy should be 0');
+    assert(
+        meta.starting_stats.strength == unpacked.starting_stats.strength, 'strength should be 0'
+    );
+    assert(
+        meta.starting_stats.dexterity == unpacked.starting_stats.dexterity, 'dexterity should be 0'
+    );
+    assert(
+        meta.starting_stats.vitality == unpacked.starting_stats.vitality, 'vitality should be 0'
+    );
+    assert(
+        meta.starting_stats.intelligence == unpacked.starting_stats.intelligence,
+        'intelligence should be 0'
+    );
+    assert(meta.starting_stats.wisdom == unpacked.starting_stats.wisdom, 'wisdom should be 0');
+    assert(
+        meta.starting_stats.charisma == unpacked.starting_stats.charisma, 'charisma should be 0'
+    );
+    assert(unpacked.interface_camel == interface_camel, 'interface_camel should be false');
 }

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -59,7 +59,7 @@ mod tests {
 
     const ADVENTURER_ID: felt252 = 1;
 
-    const MAX_LORDS: u256 = 10000000000000000000000000000;
+    const MAX_LORDS: u256 = 10000000000000000000000000000000000;
     const APPROVE: u256 = 100000000000000000000000000000;
     const NAME: felt252 = 111;
     const SYMBOL: felt252 = 222;
@@ -84,6 +84,69 @@ mod tests {
         lords0
     }
 
+    use arcade_account::{Account, TRANSACTION_VERSION};
+    use arcade_account::tests::utils::helper_contracts::{
+        ISimpleTestContractDispatcher, ISimpleTestContractDispatcherTrait, simple_test_contract,
+    };
+    use arcade_account::account::interface::{
+        IMasterControl, IMasterControlDispatcher, IMasterControlDispatcherTrait,
+        ArcadeAccountABIDispatcher, ArcadeAccountABIDispatcherTrait,
+        ArcadeAccountCamelABIDispatcher, ArcadeAccountCamelABIDispatcherTrait,
+    };
+    const PUBLIC_KEY: felt252 = 0x333333;
+    const NEW_PUBKEY: felt252 = 0x789789;
+    const SALT: felt252 = 123;
+    #[derive(Drop)]
+    struct SignedTransactionData {
+        private_key: felt252,
+        public_key: felt252,
+        transaction_hash: felt252,
+        r: felt252,
+        s: felt252
+    }
+
+    fn AA_CLASS_HASH() -> felt252 {
+        Account::TEST_CLASS_HASH
+    }
+
+    fn SIGNED_TX_DATA() -> SignedTransactionData {
+        SignedTransactionData {
+            private_key: 1234,
+            public_key: 883045738439352841478194533192765345509759306772397516907181243450667673002,
+            transaction_hash: 2717105892474786771566982177444710571376803476229898722748888396642649184538,
+            r: 3068558690657879390136740086327753007413919701043650133111397282816679110801,
+            s: 3355728545224320878895493649495491771252432631648740019139167265522817576501
+        }
+    }
+
+    fn deploy_arcade_account(data: Option<@SignedTransactionData>) -> ContractAddress {
+        // Set the transaction version
+        testing::set_version(TRANSACTION_VERSION);
+
+        let mut calldata = array![];
+        let mut public_key = PUBLIC_KEY;
+
+        if data.is_some() {
+            // set public key
+            let _data = data.unwrap();
+            public_key = *_data.public_key;
+
+            // Set the signature and transaction hash
+            let mut signature = array![];
+            signature.append(*_data.r);
+            signature.append(*_data.s);
+            testing::set_signature(signature.span());
+            testing::set_transaction_hash(*_data.transaction_hash);
+        }
+
+        // add constructor parameters to calldata
+        Serde::serialize(@public_key, ref calldata);
+        Serde::serialize(@starknet::get_contract_address(), ref calldata);
+
+        // Deploy the account contract
+        utils::deploy(AA_CLASS_HASH(), calldata)
+    }
+
     fn setup(
         starting_block: u64, starting_timestamp: u64, terminal_block: u64
     ) -> (IGameDispatcher, IERC20CamelDispatcher) {
@@ -106,10 +169,21 @@ mod tests {
 
         testing::set_contract_address(OWNER());
 
+        let arcade_account = ArcadeAccountABIDispatcher {
+            contract_address: deploy_arcade_account(Option::None(()))
+        };
+        let master_control_dispatcher = IMasterControlDispatcher {
+            contract_address: arcade_account.contract_address
+        };
+
+        master_control_dispatcher.update_whitelisted_contracts(array![(address0, true)]);
+
         let lords_contract = IERC20CamelDispatcher { contract_address: lords };
 
-        lords_contract.approve(address0, APPROVE.into());
+        lords_contract.transfer(arcade_account.contract_address, 1000000000000000000000000000);
 
+        testing::set_contract_address(arcade_account.contract_address);
+        lords_contract.approve(address0, APPROVE.into());
         (IGameDispatcher { contract_address: address0 }, lords_contract)
     }
 


### PR DESCRIPTION
* previously rewards would be distributed to arcade account
* now rewards will be distributed to the primary account
* previously the collectible beasts would be minted to the arcade account
* now collectible beasts will be minted to the primary account