### PR TITLE
Show estimate wait time on spawn page

### DIFF
--- a/ui/src/app/containers/BeastScreen.tsx
+++ b/ui/src/app/containers/BeastScreen.tsx
@@ -31,6 +31,7 @@ export default function BeastScreen({
   const adventurer = useAdventurerStore((state) => state.adventurer);
   const loading = useLoadingStore((state) => state.loading);
   const estimatingFee = useUIStore((state) => state.estimatingFee);
+  const averageBlockTime = useUIStore((state) => state.averageBlockTime);
   const resetNotification = useLoadingStore((state) => state.resetNotification);
   const [showBattleLog, setShowBattleLog] = useState(false);
   const hasBeast = useAdventurerStore((state) => state.computed.hasBeast);
@@ -178,7 +179,10 @@ export default function BeastScreen({
   return (
     <div className="sm:w-2/3 flex flex-col sm:flex-row h-full">
       {!revealBlockReached && mainnetBotProtection && (
-        <InterludeScreen currentBlockNumber={currentBlockNumber} />
+        <InterludeScreen
+          currentBlockNumber={currentBlockNumber}
+          averageBlockTime={averageBlockTime}
+        />
       )}
       <div className="sm:w-1/2 order-1 sm:order-2 h-3/4 sm:h-full">
         {hasBeast ? (

--- a/ui/src/app/containers/InterludeScreen.tsx
+++ b/ui/src/app/containers/InterludeScreen.tsx
@@ -1,33 +1,26 @@
 import { useState, useEffect } from "react";
 import { EntropyCountDown } from "@/app/components/CountDown";
 import Hints from "@/app/components/interlude/Hints";
-import { fetchAverageBlockTime } from "@/app/lib/utils";
 import useAdventurerStore from "@/app/hooks/useAdventurerStore";
 
 interface InterludeScreenProps {
   currentBlockNumber: number;
+  averageBlockTime: number;
 }
 
 export default function InterludeScreen({
   currentBlockNumber,
+  averageBlockTime,
 }: InterludeScreenProps) {
   const { adventurer } = useAdventurerStore();
-  const [fetchedAverageBlockTime, setFetchedAverageBlockTime] = useState(false);
-  const [averageBlockTime, setAverageBlockTime] = useState(0);
   const [nextEntropyTime, setNextEntropyTime] = useState<number | null>(null);
   const [countDownExpired, setCountDownExpired] = useState(false);
-
-  const fetchData = async () => {
-    const result = await fetchAverageBlockTime(currentBlockNumber, 20);
-    setAverageBlockTime(result!);
-    setFetchedAverageBlockTime(true);
-  };
 
   const getNextEntropyTime = () => {
     const nextBlockHashBlock = adventurer?.revealBlock!;
     const adventurerStartBlock = adventurer?.startBlock!;
     const blockDifference = nextBlockHashBlock - adventurerStartBlock;
-    const secondsUntilNextEntropy = blockDifference * averageBlockTime;
+    const secondsUntilNextEntropy = (blockDifference + 1) * averageBlockTime; // add one for closer estimate
     const adventurerCreatedTime = new Date(adventurer?.createdTime!).getTime();
     const nextEntropyTime =
       adventurerCreatedTime + secondsUntilNextEntropy * 1000;
@@ -35,12 +28,8 @@ export default function InterludeScreen({
   };
 
   useEffect(() => {
-    if (fetchedAverageBlockTime) {
-      getNextEntropyTime();
-    } else if (currentBlockNumber > 0) {
-      fetchData();
-    }
-  }, [fetchedAverageBlockTime, currentBlockNumber]);
+    getNextEntropyTime();
+  }, []);
 
   return (
     <>

--- a/ui/src/app/hooks/useUIStore.ts
+++ b/ui/src/app/hooks/useUIStore.ts
@@ -84,6 +84,8 @@ type State = {
   setSpecialBeast: (value: SpecialBeast | null) => void;
   isMintingLords: boolean;
   setIsMintingLords: (value: boolean) => void;
+  averageBlockTime: number;
+  setAverageBlockTime: (value: number) => void;
 };
 
 const useUIStore = create<State>((set) => ({
@@ -149,6 +151,8 @@ const useUIStore = create<State>((set) => ({
   setSpecialBeast: (value) => set({ specialBeast: value }),
   isMintingLords: false,
   setIsMintingLords: (value) => set({ isMintingLords: value }),
+  averageBlockTime: 0,
+  setAverageBlockTime: (value) => set({ averageBlockTime: value }),
 }));
 
 export default useUIStore;

--- a/ui/src/app/lib/utils/index.ts
+++ b/ui/src/app/lib/utils/index.ts
@@ -135,6 +135,15 @@ export const formatTime = (date: Date) => {
   );
 };
 
+export const formatTimeSeconds = (totalSeconds: number) => {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds - hours * 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes.toString().padStart(2, "0")}:${seconds
+    .toString()
+    .padStart(2, "0")}`;
+};
+
 export function shortenHex(hexString: string, numDigits = 6) {
   if (hexString?.length <= numDigits) {
     return hexString;

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -463,14 +463,14 @@ function Home({ updateConnectors }: HomeProps) {
     setUpgrades({ ...ZeroUpgrade });
   }, [adventurer]);
 
-  if (!isConnected && introComplete && disconnected) {
-    return <WalletSelect />;
-  }
-
   const spawnLoader =
     pendingMessage &&
     (pendingMessage === "Spawning Adventurer" ||
       pendingMessage.includes("Spawning Adventurer"));
+
+  if (!isConnected && introComplete && disconnected) {
+    return <WalletSelect />;
+  }
 
   return (
     <main


### PR DESCRIPTION
- move average block time getter to spawn page
- set the time as a global zustand variable
- only activate if on mainnet
- show the estimate wait time in spawn page
- increase the wait estimate by 1 block

Closes #473 + #457 