### PR TITLE
adds helpful view functions related to idle penalty

### DIFF
--- a/contracts/game/src/game/interfaces.cairo
+++ b/contracts/game/src/game/interfaces.cairo
@@ -47,6 +47,7 @@ trait IGame<TContractState> {
     fn get_last_action_block(self: @TContractState, adventurer_id: felt252) -> u16;
     fn get_actions_per_block(self: @TContractState, adventurer_id: felt252) -> u8;
     fn get_reveal_block(self: @TContractState, adventurer_id: felt252) -> u64;
+    fn is_idle(self: @TContractState, adventurer_id: felt252) -> (bool, u16);
 
     // adventurer stats (includes boost)
     fn get_stats(self: @TContractState, adventurer_id: felt252) -> Stats;
@@ -148,6 +149,7 @@ trait IGame<TContractState> {
     fn get_dao_address(self: @TContractState) -> ContractAddress;
     fn get_lords_address(self: @TContractState) -> ContractAddress;
     fn get_game_entropy(self: @TContractState) -> GameEntropy;
+    fn get_idle_penalty_blocks(self: @TContractState) -> u64;
     fn get_leaderboard(self: @TContractState) -> Leaderboard;
     fn get_cost_to_play(self: @TContractState) -> u128;
     fn get_games_played_snapshot(self: @TContractState) -> GamesPlayedSnapshot;

--- a/contracts/game/src/lib.cairo
+++ b/contracts/game/src/lib.cairo
@@ -61,7 +61,8 @@ mod Game {
             messages, Rewards, REWARD_DISTRIBUTIONS_PHASE1_BP, REWARD_DISTRIBUTIONS_PHASE2_BP,
             REWARD_DISTRIBUTIONS_PHASE3_BP, BLOCKS_IN_A_WEEK, COST_TO_PLAY, U64_MAX, U128_MAX,
             STARTER_BEAST_ATTACK_DAMAGE, NUM_STARTING_STATS,
-            STARTING_GAME_ENTROPY_ROTATION_INTERVAL, MINIMUM_DAMAGE_FROM_BEASTS, MAINNET_REVEAL_DELAY_BLOCKS
+            STARTING_GAME_ENTROPY_ROTATION_INTERVAL, MINIMUM_DAMAGE_FROM_BEASTS,
+            MAINNET_REVEAL_DELAY_BLOCKS
         }
     };
     use lootitems::{
@@ -843,6 +844,11 @@ mod Game {
         fn get_reveal_block(self: @ContractState, adventurer_id: felt252) -> u64 {
             _get_reveal_block(self, adventurer_id)
         }
+        fn is_idle(self: @ContractState, adventurer_id: felt252) -> (bool, u16) {
+            let adventurer = _load_adventurer(self, adventurer_id);
+            let game_entropy = _load_game_entropy(self);
+            _is_idle(self, adventurer, adventurer_id, game_entropy)
+        }
         fn get_equipped_items(
             self: @ContractState, adventurer_id: felt252
         ) -> Array<ItemPrimitive> {
@@ -967,6 +973,9 @@ mod Game {
         }
         fn get_game_entropy(self: @ContractState) -> GameEntropy {
             _load_game_entropy(self)
+        }
+        fn get_idle_penalty_blocks(self: @ContractState) -> u64 {
+            _load_game_entropy(self).get_idle_penalty_blocks()
         }
         fn get_leaderboard(self: @ContractState) -> Leaderboard {
             self._leaderboard.read()

--- a/contracts/game/src/tests/test_game.cairo
+++ b/contracts/game/src/tests/test_game.cairo
@@ -2299,4 +2299,29 @@ mod tests {
         // try to play again with golden token which should cause panic
         add_adventurer_to_game(ref game, golden_token_id);
     }
+
+    #[test]
+    #[available_gas(60000000)]
+    fn test_is_idle_view_function() {
+        let STARTING_BLOCK_NUMBER = 510;
+        let mut game = new_adventurer(STARTING_BLOCK_NUMBER);
+        game.attack(ADVENTURER_ID, false);
+
+        // verify adventurer is not idle
+        let (is_idle, _) = game.is_idle(ADVENTURER_ID);
+        assert(!is_idle, 'should not be idle');
+
+        // roll forward blockchain to make adventurer idle
+        let game_entropy = game.get_game_entropy();
+        testing::set_block_number(
+            STARTING_BLOCK_NUMBER
+                + MAINNET_REVEAL_DELAY_BLOCKS.into()
+                + game_entropy.get_idle_penalty_blocks()
+                + 1
+        );
+
+        // verify adventurer is now idle
+        let (is_idle, _) = game.is_idle(ADVENTURER_ID);
+        assert(is_idle, 'should be idle');
+    }
 }


### PR DESCRIPTION
* is_idle(adventurer_id) -> (bool, u16) where the u16 is number of blocks they have been idle
* get_idle_penalty_blocks() -> u64 the current idle penalty threshold in blocks
* these view functions should simplify clients providing a reliable idle penalty block timer for players