### PR TITLE
Slay Idle Adventurers

### DIFF
--- a/ui/src/app/abi/Game.json
+++ b/ui/src/app/abi/Game.json
@@ -857,6 +857,22 @@
       },
       {
         "type": "function",
+        "name": "is_idle",
+        "inputs": [
+          {
+            "name": "adventurer_id",
+            "type": "core::felt252"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "(core::bool, core::integer::u16)"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
         "name": "get_stats",
         "inputs": [
           {
@@ -1947,6 +1963,17 @@
         "outputs": [
           {
             "type": "game_entropy::game_entropy::GameEntropy"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "get_idle_penalty_blocks",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u64"
           }
         ],
         "state_mutability": "view"

--- a/ui/src/app/components/leaderboard/LiveTable.tsx
+++ b/ui/src/app/components/leaderboard/LiveTable.tsx
@@ -12,6 +12,7 @@ export interface LiveLeaderboardTableProps {
   gameContract: Contract;
   gameEntropyUpdateTime: number;
   currentBlock: number;
+  idleAdventurers?: string[];
 }
 
 const LiveLeaderboardTable = ({
@@ -21,6 +22,7 @@ const LiveLeaderboardTable = ({
   gameContract,
   gameEntropyUpdateTime,
   currentBlock,
+  idleAdventurers,
 }: LiveLeaderboardTableProps) => {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const setScreen = useUIStore((state) => state.setScreen);
@@ -72,6 +74,7 @@ const LiveLeaderboardTable = ({
                   gameContract={gameContract}
                   gameEntropyUpdateTime={gameEntropyUpdateTime}
                   currentBlock={currentBlock}
+                  idleAdventurers={idleAdventurers}
                 />
               )
             )}

--- a/ui/src/app/components/navigation/TransactionCart.tsx
+++ b/ui/src/app/components/navigation/TransactionCart.tsx
@@ -138,6 +138,7 @@ const TransactionCart = ({
       } Adventurers`,
     ]);
     setLoadingMessage((messages) => [...messages, "Slaying Adventurer"]);
+    console.log("here");
   }, []);
 
   const handleLoadData = useCallback(() => {

--- a/ui/src/app/components/navigation/TransactionCart.tsx
+++ b/ui/src/app/components/navigation/TransactionCart.tsx
@@ -138,7 +138,6 @@ const TransactionCart = ({
       } Adventurers`,
     ]);
     setLoadingMessage((messages) => [...messages, "Slaying Adventurer"]);
-    console.log("here");
   }, []);
 
   const handleLoadData = useCallback(() => {

--- a/ui/src/app/containers/LeaderboardScreen.tsx
+++ b/ui/src/app/containers/LeaderboardScreen.tsx
@@ -19,7 +19,7 @@ import { ProfileIcon, SkullIcon } from "@/app/components/icons/Icons";
 import { IsIdleResult } from "@/app/types";
 
 interface LeaderboardScreenProps {
-  slayAllIdles: (slayAdventurers: string[]) => Promise<void>;
+  slayIdles: (slayAdventurers: string[]) => Promise<void>;
   gameContract: Contract;
 }
 
@@ -28,7 +28,7 @@ interface LeaderboardScreenProps {
  * @description Provides the leaderboard screen for the adventurer.
  */
 export default function LeaderboardScreen({
-  slayAllIdles,
+  slayIdles,
   gameContract,
 }: LeaderboardScreenProps) {
   const itemsPerPage = 10;
@@ -126,7 +126,6 @@ export default function LeaderboardScreen({
         adventurer?.id ?? "0",
       ]);
       const isIdle = (isIdleResult as IsIdleResult)["0"];
-      console.log(isIdle);
       if (isIdle) {
         idleAdventurers.push(adventurer?.id?.toString() ?? "0");
       }
@@ -160,10 +159,16 @@ export default function LeaderboardScreen({
               <p className="sm:text-2xl">{aliveAdventurers.length}</p>
             </div>
             <Button
-              onClick={async () => await slayAllIdles(idleAdventurers!)}
-              disabled={loadingIdles}
+              onClick={async () => await slayIdles(idleAdventurers!)}
+              disabled={loadingIdles || idleAdventurers?.length === 0}
             >
-              Slay Idle Adventurers
+              {loadingIdles ? (
+                <p className="loading-ellipsis">Loading Idles</p>
+              ) : idleAdventurers?.length === 0 ? (
+                "No Idle Adventurers"
+              ) : (
+                "Slay Idle Adventurers"
+              )}
             </Button>
             <Button
               onClick={async () => {
@@ -195,6 +200,7 @@ export default function LeaderboardScreen({
                 gameContract={gameContract}
                 gameEntropyUpdateTime={gameEntropyUpdateTime!}
                 currentBlock={currentBlock!}
+                idleAdventurers={idleAdventurers}
               />
             </div>
             <div

--- a/ui/src/app/lib/utils/syscalls.ts
+++ b/ui/src/app/lib/utils/syscalls.ts
@@ -1321,7 +1321,7 @@ export function syscalls({
     }
   };
 
-  const slayAllIdles = async (slayAdventurers: number[]) => {
+  const slayAllIdles = async (slayAdventurers: string[]) => {
     const slayIdleAdventurersTx = {
       contractAddress: gameContract?.address ?? "",
       entrypoint: "slay_idle_adventurers",

--- a/ui/src/app/lib/utils/syscalls.ts
+++ b/ui/src/app/lib/utils/syscalls.ts
@@ -1407,7 +1407,6 @@ export function syscalls({
     upgradeTx?: any
   ) => {
     const isArcade = checkArcadeConnector(connector!);
-    console.log(loadingMessage);
     startLoading("Multicall", loadingMessage, undefined, adventurer?.id);
     try {
       let upgradeCalls = [];

--- a/ui/src/app/lib/utils/syscalls.ts
+++ b/ui/src/app/lib/utils/syscalls.ts
@@ -1321,7 +1321,7 @@ export function syscalls({
     }
   };
 
-  const slayAllIdles = async (slayAdventurers: string[]) => {
+  const slayIdles = async (slayAdventurers: string[]) => {
     const slayIdleAdventurersTx = {
       contractAddress: gameContract?.address ?? "",
       entrypoint: "slay_idle_adventurers",
@@ -1407,7 +1407,7 @@ export function syscalls({
     upgradeTx?: any
   ) => {
     const isArcade = checkArcadeConnector(connector!);
-
+    console.log(loadingMessage);
     startLoading("Multicall", loadingMessage, undefined, adventurer?.id);
     try {
       let upgradeCalls = [];
@@ -1709,7 +1709,7 @@ export function syscalls({
     attack,
     flee,
     upgrade,
-    slayAllIdles,
+    slayIdles,
     multicall,
     mintLords,
   };

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -223,7 +223,7 @@ function Home({ updateConnectors }: HomeProps) {
     attack,
     flee,
     upgrade,
-    slayAllIdles,
+    slayIdles,
     multicall,
     mintLords,
   } = syscalls({
@@ -587,7 +587,7 @@ function Home({ updateConnectors }: HomeProps) {
                   )}
                   {screen === "leaderboard" && (
                     <LeaderboardScreen
-                      slayAllIdles={slayAllIdles}
+                      slayIdles={slayIdles}
                       gameContract={gameContract!}
                     />
                   )}

--- a/ui/src/app/types/index.ts
+++ b/ui/src/app/types/index.ts
@@ -502,3 +502,8 @@ export type BlockData = {
   status: string;
   timestamp: number;
 };
+
+export type IsIdleResult = {
+  0: boolean;
+  1: bigint;
+};


### PR DESCRIPTION
Implemented the slay Idle adventurers method.

- Fetches all of the `is_idle` results of all adventurers when leaderboard is rendered
- Implements Slay Idle Adventurers button
- Implements slay each of the adventurers in live leaderboard row